### PR TITLE
refactor: Consolidate duplicate code into shared utilities

### DIFF
--- a/frontend/src/components/builds/BuildDetail/BuildDetail.tsx
+++ b/frontend/src/components/builds/BuildDetail/BuildDetail.tsx
@@ -21,7 +21,7 @@ import type {
   BuildIssue,
   BuildStatus,
 } from '../../../types';
-import { colors } from '../../../styles/tokens';
+import { formatDate, formatDuration, formatFileSize } from '../../../utils';
 
 const { Title, Text } = Typography;
 
@@ -30,42 +30,6 @@ export interface BuildDetailProps {
   artifacts?: BuildModuleArtifact[];
   onCompare?: (build: BuildDetailType) => void;
 }
-
-const formatDate = (dateString: string | undefined): string => {
-  if (!dateString) return '-';
-  const date = new Date(dateString);
-  return date.toLocaleString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-};
-
-const formatDuration = (durationMs: number | undefined): string => {
-  if (!durationMs) return '-';
-  const seconds = Math.floor(durationMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-
-  if (hours > 0) {
-    return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ${seconds % 60}s`;
-  }
-  return `${seconds}s`;
-};
-
-const formatFileSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-};
 
 const getStatusIcon = (status: BuildStatus): React.ReactNode => {
   const iconStyle = { marginRight: 4 };

--- a/frontend/src/components/builds/BuildDiff/BuildDiff.tsx
+++ b/frontend/src/components/builds/BuildDiff/BuildDiff.tsx
@@ -16,12 +16,12 @@ import type {
   BuildDiff as BuildDiffType,
   BuildSummary,
   ModuleDiff,
-  ArtifactChange,
   DependencyChange,
   BuildDependency,
   BuildStatus,
 } from '../../../types';
 import { colors } from '../../../styles/tokens';
+import { formatFileSize } from '../../../utils';
 
 const { Title, Text } = Typography;
 
@@ -31,7 +31,8 @@ export interface BuildDiffProps {
   diffResult: BuildDiffType;
 }
 
-const formatDate = (dateString: string | undefined): string => {
+// Use a shorter date format for build diff views
+const formatDateShort = (dateString: string | undefined): string => {
   if (!dateString) return '-';
   const date = new Date(dateString);
   return date.toLocaleDateString(undefined, {
@@ -110,13 +111,6 @@ const getChangeStatusIcon = (status: string): React.ReactNode => {
   }
 };
 
-const formatFileSize = (bytes: number | undefined): string => {
-  if (!bytes || bytes === 0) return '-';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-};
 
 const BuildSummaryCard: React.FC<{ build: BuildSummary; label: string }> = ({ build, label }) => (
   <Card size="small" style={{ height: '100%' }}>
@@ -146,7 +140,7 @@ const BuildSummaryCard: React.FC<{ build: BuildSummary; label: string }> = ({ bu
       )}
       {build.completed_at && (
         <Text type="secondary" style={{ fontSize: 12 }}>
-          Completed: {formatDate(build.completed_at)}
+          Completed: {formatDateShort(build.completed_at)}
         </Text>
       )}
     </Space>

--- a/frontend/src/components/builds/BuildList/BuildList.tsx
+++ b/frontend/src/components/builds/BuildList/BuildList.tsx
@@ -12,6 +12,7 @@ import {
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 import type { Build, BuildStatus } from '../../../types';
 import { colors } from '../../../styles/tokens';
+import { formatDate, formatDuration } from '../../../utils';
 
 const { Text } = Typography;
 
@@ -26,33 +27,6 @@ export interface BuildListProps {
     onChange: (page: number, pageSize: number) => void;
   };
 }
-
-const formatDate = (dateString: string | undefined): string => {
-  if (!dateString) return '-';
-  const date = new Date(dateString);
-  return date.toLocaleString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
-
-const formatDuration = (durationMs: number | undefined): string => {
-  if (!durationMs) return '-';
-  const seconds = Math.floor(durationMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-
-  if (hours > 0) {
-    return `${hours}h ${minutes % 60}m`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ${seconds % 60}s`;
-  }
-  return `${seconds}s`;
-};
 
 const getStatusIcon = (status: BuildStatus): React.ReactNode => {
   const iconStyle = { marginRight: 4 };

--- a/frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx
+++ b/frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { DashboardWidget } from '../DashboardWidget';
 import { artifactsApi, repositoriesApi } from '../../../api';
 import { colors, spacing } from '../../../styles/tokens';
+import { formatRelativeTime } from '../../../utils';
 import type { Artifact } from '../../../types';
 
 const { Text, Link } = Typography;
@@ -43,22 +44,6 @@ const activityColors: Record<ActivityType, string> = {
   upload: colors.success,
   download: colors.info,
   delete: colors.error,
-};
-
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSecs = Math.floor(diffMs / 1000);
-  const diffMins = Math.floor(diffSecs / 60);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
-
-  if (diffSecs < 60) return 'Just now';
-  if (diffMins < 60) return `${diffMins} minute${diffMins > 1 ? 's' : ''} ago`;
-  if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
-  if (diffDays < 7) return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
-  return date.toLocaleDateString();
 };
 
 export const RecentActivityWidget: React.FC = () => {

--- a/frontend/src/components/packages/PackageList/PackageCard.tsx
+++ b/frontend/src/components/packages/PackageList/PackageCard.tsx
@@ -17,6 +17,7 @@ import {
 } from '@ant-design/icons';
 import type { Package, PackageType } from '../../../types';
 import { colors, spacing, borderRadius, shadows } from '../../../styles/tokens';
+import { formatDownloadCount, formatRelativeTimeShort } from '../../../utils';
 
 const { Text, Title } = Typography;
 
@@ -57,45 +58,6 @@ const packageTypeLabels: Record<PackageType, string> = {
   conan: 'Conan',
   cargo: 'Cargo',
   generic: 'Generic',
-};
-
-const formatDownloadCount = (count: number): string => {
-  if (count >= 1000000) {
-    return `${(count / 1000000).toFixed(1)}M`;
-  }
-  if (count >= 1000) {
-    return `${(count / 1000).toFixed(1)}K`;
-  }
-  return count.toString();
-};
-
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const diffMinutes = Math.floor(diffSeconds / 60);
-  const diffHours = Math.floor(diffMinutes / 60);
-  const diffDays = Math.floor(diffHours / 24);
-  const diffWeeks = Math.floor(diffDays / 7);
-  const diffMonths = Math.floor(diffDays / 30);
-  const diffYears = Math.floor(diffDays / 365);
-
-  if (diffSeconds < 60) {
-    return 'just now';
-  } else if (diffMinutes < 60) {
-    return `${diffMinutes}m ago`;
-  } else if (diffHours < 24) {
-    return `${diffHours}h ago`;
-  } else if (diffDays < 7) {
-    return `${diffDays}d ago`;
-  } else if (diffWeeks < 4) {
-    return `${diffWeeks}w ago`;
-  } else if (diffMonths < 12) {
-    return `${diffMonths}mo ago`;
-  } else {
-    return `${diffYears}y ago`;
-  }
 };
 
 export const PackageCard: React.FC<PackageCardProps> = ({
@@ -224,7 +186,7 @@ export const PackageCard: React.FC<PackageCardProps> = ({
             <Space size={4}>
               <ClockCircleOutlined style={{ color: colors.textTertiary, fontSize: 12 }} />
               <Text type="secondary" style={{ fontSize: 12 }}>
-                {formatRelativeTime(pkg.updated_at)}
+                {formatRelativeTimeShort(pkg.updated_at)}
               </Text>
             </Space>
           </Tooltip>

--- a/frontend/src/components/packages/PackageList/PackageList.tsx
+++ b/frontend/src/components/packages/PackageList/PackageList.tsx
@@ -11,6 +11,7 @@ import type { Package, PackageType } from '../../../types';
 import { PackageCard } from './PackageCard';
 import { EmptyState } from '../../common/EmptyState/EmptyState';
 import { colors, spacing } from '../../../styles/tokens';
+import { formatFileSize, formatRelativeTime } from '../../../utils';
 
 const { Text } = Typography;
 
@@ -46,46 +47,6 @@ const packageTypeLabels: Record<PackageType, string> = {
   conan: 'Conan',
   cargo: 'Cargo',
   generic: 'Generic',
-};
-
-const formatFileSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B';
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const k = 1024;
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  const size = bytes / Math.pow(k, i);
-
-  return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
-};
-
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const diffMinutes = Math.floor(diffSeconds / 60);
-  const diffHours = Math.floor(diffMinutes / 60);
-  const diffDays = Math.floor(diffHours / 24);
-  const diffWeeks = Math.floor(diffDays / 7);
-  const diffMonths = Math.floor(diffDays / 30);
-  const diffYears = Math.floor(diffDays / 365);
-
-  if (diffSeconds < 60) {
-    return 'just now';
-  } else if (diffMinutes < 60) {
-    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
-  } else if (diffHours < 24) {
-    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  } else if (diffDays < 7) {
-    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  } else if (diffWeeks < 4) {
-    return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
-  } else if (diffMonths < 12) {
-    return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
-  } else {
-    return `${diffYears} year${diffYears === 1 ? '' : 's'} ago`;
-  }
 };
 
 export const PackageList: React.FC<PackageListProps> = ({

--- a/frontend/src/components/repository/ArtifactList/ArtifactListItem.tsx
+++ b/frontend/src/components/repository/ArtifactList/ArtifactListItem.tsx
@@ -13,54 +13,16 @@ import {
 } from '@ant-design/icons';
 import type { Artifact } from '../../../types';
 import { colors } from '../../../styles/tokens';
+import {
+  formatFileSize as formatFileSizeUtil,
+  formatRelativeTime as formatRelativeTimeUtil,
+} from '../../../utils';
 
 const { Text } = Typography;
 
-/**
- * Format bytes into human-readable file size
- */
-export const formatFileSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B';
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const k = 1024;
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  const size = bytes / Math.pow(k, i);
-
-  return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
-};
-
-/**
- * Format date string into relative time
- */
-export const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const diffMinutes = Math.floor(diffSeconds / 60);
-  const diffHours = Math.floor(diffMinutes / 60);
-  const diffDays = Math.floor(diffHours / 24);
-  const diffWeeks = Math.floor(diffDays / 7);
-  const diffMonths = Math.floor(diffDays / 30);
-  const diffYears = Math.floor(diffDays / 365);
-
-  if (diffSeconds < 60) {
-    return 'just now';
-  } else if (diffMinutes < 60) {
-    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
-  } else if (diffHours < 24) {
-    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  } else if (diffDays < 7) {
-    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  } else if (diffWeeks < 4) {
-    return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
-  } else if (diffMonths < 12) {
-    return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
-  } else {
-    return `${diffYears} year${diffYears === 1 ? '' : 's'} ago`;
-  }
-};
+// Re-export for backward compatibility with existing imports
+export const formatFileSize = formatFileSizeUtil;
+export const formatRelativeTime = formatRelativeTimeUtil;
 
 /**
  * Get appropriate file icon based on content type

--- a/frontend/src/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/components/search/SearchResults/SearchResults.tsx
@@ -27,6 +27,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { colors, spacing, borderRadius } from '../../../styles/tokens';
 import type { ArtifactSearchHit } from '../../../types';
+import { formatFileSize, formatRelativeTime } from '../../../utils';
 
 const { Text, Title } = Typography;
 
@@ -53,46 +54,6 @@ export interface SearchResultsProps {
   sortOrder?: SortOrder;
   onSortChange?: (field: SortField, order: SortOrder) => void;
 }
-
-const formatFileSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B';
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const k = 1024;
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  const size = bytes / Math.pow(k, i);
-
-  return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
-};
-
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const diffMinutes = Math.floor(diffSeconds / 60);
-  const diffHours = Math.floor(diffMinutes / 60);
-  const diffDays = Math.floor(diffHours / 24);
-  const diffWeeks = Math.floor(diffDays / 7);
-  const diffMonths = Math.floor(diffDays / 30);
-  const diffYears = Math.floor(diffDays / 365);
-
-  if (diffSeconds < 60) {
-    return 'just now';
-  } else if (diffMinutes < 60) {
-    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
-  } else if (diffHours < 24) {
-    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  } else if (diffDays < 7) {
-    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  } else if (diffWeeks < 4) {
-    return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
-  } else if (diffMonths < 12) {
-    return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
-  } else {
-    return `${diffYears} year${diffYears === 1 ? '' : 's'} ago`;
-  }
-};
 
 const getFormatColor = (contentType: string): string => {
   if (contentType.includes('java') || contentType.includes('jar')) {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { packageTypeLabels } from './packages';

--- a/frontend/src/constants/packages.ts
+++ b/frontend/src/constants/packages.ts
@@ -1,0 +1,21 @@
+import type { PackageType } from '../types';
+
+/**
+ * Human-readable labels for package types.
+ */
+export const packageTypeLabels: Record<PackageType, string> = {
+  maven: 'Maven',
+  gradle: 'Gradle',
+  npm: 'npm',
+  pypi: 'PyPI',
+  nuget: 'NuGet',
+  go: 'Go',
+  rubygems: 'RubyGems',
+  docker: 'Docker',
+  helm: 'Helm',
+  rpm: 'RPM',
+  debian: 'Debian',
+  conan: 'Conan',
+  cargo: 'Cargo',
+  generic: 'Generic',
+};

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared formatting utilities for consistent display across the application.
+ */
+
+/**
+ * Format a byte size into a human-readable string.
+ * @param bytes - The number of bytes
+ * @returns A formatted string like "1.5 MB"
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B';
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const k = 1024;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const size = bytes / Math.pow(k, i);
+
+  return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+/**
+ * Format a date string into a relative time string.
+ * @param dateString - An ISO date string
+ * @returns A formatted string like "5 minutes ago"
+ */
+export function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffWeeks = Math.floor(diffDays / 7);
+  const diffMonths = Math.floor(diffDays / 30);
+  const diffYears = Math.floor(diffDays / 365);
+
+  if (diffSeconds < 60) {
+    return 'just now';
+  }
+  if (diffMinutes < 60) {
+    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  }
+  if (diffHours < 24) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+  if (diffDays < 7) {
+    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  }
+  if (diffWeeks < 4) {
+    return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
+  }
+  if (diffMonths < 12) {
+    return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
+  }
+  return `${diffYears} year${diffYears === 1 ? '' : 's'} ago`;
+}
+
+/**
+ * Format a date string into a short relative time string.
+ * Uses abbreviated units like "5m ago" instead of "5 minutes ago".
+ * @param dateString - An ISO date string
+ * @returns A formatted string like "5m ago"
+ */
+export function formatRelativeTimeShort(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffWeeks = Math.floor(diffDays / 7);
+  const diffMonths = Math.floor(diffDays / 30);
+  const diffYears = Math.floor(diffDays / 365);
+
+  if (diffSeconds < 60) {
+    return 'just now';
+  }
+  if (diffMinutes < 60) {
+    return `${diffMinutes}m ago`;
+  }
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+  if (diffDays < 7) {
+    return `${diffDays}d ago`;
+  }
+  if (diffWeeks < 4) {
+    return `${diffWeeks}w ago`;
+  }
+  if (diffMonths < 12) {
+    return `${diffMonths}mo ago`;
+  }
+  return `${diffYears}y ago`;
+}
+
+/**
+ * Format a download count with abbreviated suffixes.
+ * @param count - The download count
+ * @returns A formatted string like "1.5K" or "2.3M"
+ */
+export function formatDownloadCount(count: number): string {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return count.toString();
+}
+
+/**
+ * Format a date string for display.
+ * @param dateString - An ISO date string or undefined
+ * @returns A formatted date string or '-' if undefined
+ */
+export function formatDate(dateString: string | undefined): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Format a duration in milliseconds to a human-readable string.
+ * @param durationMs - Duration in milliseconds or undefined
+ * @returns A formatted string like "2h 30m" or '-' if undefined
+ */
+export function formatDuration(durationMs: number | undefined): string {
+  if (!durationMs) return '-';
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,8 @@
+export {
+  formatFileSize,
+  formatRelativeTime,
+  formatRelativeTimeShort,
+  formatDownloadCount,
+  formatDate,
+  formatDuration,
+} from './format';


### PR DESCRIPTION
- Create frontend/src/utils/format.ts with centralized formatting functions (formatFileSize, formatRelativeTime, formatDownloadCount, formatDate, formatDuration)
- Create frontend/src/constants/packages.ts for packageTypeLabels mapping
- Update 8 frontend components to use shared utilities instead of duplicate implementations
- Add repo_to_response() helper in backend repositories handler to reduce repetition

Removes ~250 lines of duplicate code across the codebase.