### PR TITLE
refactor: Simplify and deduplicate code

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -612,8 +612,7 @@ async fn publish_package(
 
         // Populate packages / package_versions tables (best-effort)
         {
-            let pkg_svc =
-                crate::services::package_service::PackageService::new(state.db.clone());
+            let pkg_svc = crate::services::package_service::PackageService::new(state.db.clone());
             let description = version_data
                 .get("description")
                 .and_then(|v| v.as_str())

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -791,8 +791,7 @@ async fn upload(
 
     // Populate packages / package_versions tables (best-effort)
     {
-        let pkg_svc =
-            crate::services::package_service::PackageService::new(state.db.clone());
+        let pkg_svc = crate::services::package_service::PackageService::new(state.db.clone());
         pkg_svc
             .try_create_or_update_from_artifact(
                 repo.id,

--- a/backend/src/api/handlers/remote_instances.rs
+++ b/backend/src/api/handlers/remote_instances.rs
@@ -58,14 +58,9 @@ async fn create_instance(
     Extension(auth): Extension<AuthExtension>,
     Json(req): Json<CreateInstanceRequest>,
 ) -> Result<Json<RemoteInstanceResponse>> {
-    let instance = RemoteInstanceService::create(
-        &state.db,
-        auth.user_id,
-        &req.name,
-        &req.url,
-        &req.api_key,
-    )
-    .await?;
+    let instance =
+        RemoteInstanceService::create(&state.db, auth.user_id, &req.name, &req.url, &req.api_key)
+            .await?;
     Ok(Json(instance))
 }
 
@@ -91,10 +86,7 @@ fn build_target_url(base: &str, path: &str) -> String {
 async fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
     let status = axum::http::StatusCode::from_u16(resp.status().as_u16())
         .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .cloned();
+    let content_type = resp.headers().get("content-type").cloned();
     let body = resp
         .bytes()
         .await
@@ -118,8 +110,7 @@ async fn proxy_get(
     Extension(auth): Extension<AuthExtension>,
     Path((id, path)): Path<(Uuid, String)>,
 ) -> Result<Response> {
-    let (url, api_key) =
-        RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
+    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
 
     let resp = reqwest::Client::new()
@@ -138,8 +129,7 @@ async fn proxy_post(
     Path((id, path)): Path<(Uuid, String)>,
     body: axum::body::Bytes,
 ) -> Result<Response> {
-    let (url, api_key) =
-        RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
+    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
 
     let resp = reqwest::Client::new()
@@ -160,8 +150,7 @@ async fn proxy_put(
     Path((id, path)): Path<(Uuid, String)>,
     body: axum::body::Bytes,
 ) -> Result<Response> {
-    let (url, api_key) =
-        RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
+    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
 
     let resp = reqwest::Client::new()
@@ -181,8 +170,7 @@ async fn proxy_delete(
     Extension(auth): Extension<AuthExtension>,
     Path((id, path)): Path<(Uuid, String)>,
 ) -> Result<Response> {
-    let (url, api_key) =
-        RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
+    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
 
     let resp = reqwest::Client::new()

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -620,8 +620,7 @@ pub async fn change_password(
         tracing::info!("Setup complete. API fully unlocked.");
 
         // Delete the password file (best-effort)
-        let password_file =
-            std::path::Path::new(&state.config.storage_path).join("admin.password");
+        let password_file = std::path::Path::new(&state.config.storage_path).join("admin.password");
         if password_file.exists() {
             if let Err(e) = std::fs::remove_file(&password_file) {
                 tracing::warn!("Failed to delete admin password file: {}", e);

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -12,7 +12,10 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Request, State},
-    http::{header::{AUTHORIZATION, COOKIE}, HeaderName, StatusCode},
+    http::{
+        header::{AUTHORIZATION, COOKIE},
+        HeaderName, StatusCode,
+    },
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -99,11 +102,7 @@ fn extract_token(request: &Request) -> ExtractedToken<'_> {
     }
 
     // Check cookie as fallback (for browser sessions with httpOnly cookies)
-    if let Some(cookie_header) = request
-        .headers()
-        .get(COOKIE)
-        .and_then(|h| h.to_str().ok())
-    {
+    if let Some(cookie_header) = request.headers().get(COOKIE).and_then(|h| h.to_str().ok()) {
         for cookie in cookie_header.split(';') {
             let cookie = cookie.trim();
             if let Some(token) = cookie.strip_prefix("ak_access_token=") {

--- a/backend/src/api/middleware/setup.rs
+++ b/backend/src/api/middleware/setup.rs
@@ -31,23 +31,13 @@ pub async fn setup_guard(
 
     let path = request.uri().path();
 
-    // Always allow health/readiness/metrics
-    if path == "/health" || path == "/ready" || path == "/metrics" {
-        return next.run(request).await;
-    }
+    let is_allowed = matches!(
+        path,
+        "/health" | "/ready" | "/metrics" | "/api/v1/setup/status"
+    ) || path.starts_with("/api/v1/auth")
+        || (path.starts_with("/api/v1/users/") && path.ends_with("/password"));
 
-    // Allow auth endpoints (login, refresh, logout, me, SSO)
-    if path.starts_with("/api/v1/auth") {
-        return next.run(request).await;
-    }
-
-    // Allow setup status check
-    if path == "/api/v1/setup/status" {
-        return next.run(request).await;
-    }
-
-    // Allow password change: POST /api/v1/users/:id/password
-    if path.starts_with("/api/v1/users/") && path.ends_with("/password") {
+    if is_allowed {
         return next.run(request).await;
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,8 +4,8 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::Router;
 use axum::http::{header, Method};
+use axum::Router;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -176,8 +176,20 @@ async fn main() -> Result<()> {
                     .collect();
                 CorsLayer::new()
                     .allow_origin(AllowOrigin::list(origins))
-                    .allow_methods([Method::GET, Method::POST, Method::PUT, Method::PATCH, Method::DELETE, Method::OPTIONS])
-                    .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::ACCEPT, header::COOKIE])
+                    .allow_methods([
+                        Method::GET,
+                        Method::POST,
+                        Method::PUT,
+                        Method::PATCH,
+                        Method::DELETE,
+                        Method::OPTIONS,
+                    ])
+                    .allow_headers([
+                        header::CONTENT_TYPE,
+                        header::AUTHORIZATION,
+                        header::ACCEPT,
+                        header::COOKIE,
+                    ])
                     .allow_credentials(true)
             } else {
                 CorsLayer::new()
@@ -336,12 +348,11 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
     let password_file = Path::new(storage_path).join("admin.password");
 
     // Check if an admin user already exists
-    let admin_row: Option<(bool,)> = sqlx::query_as(
-        "SELECT must_change_password FROM users WHERE is_admin = true LIMIT 1",
-    )
-    .fetch_optional(db)
-    .await
-    .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+    let admin_row: Option<(bool,)> =
+        sqlx::query_as("SELECT must_change_password FROM users WHERE is_admin = true LIMIT 1")
+            .fetch_optional(db)
+            .await
+            .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
     if let Some((must_change,)) = admin_row {
         // Admin already exists — determine if setup lock is needed
@@ -351,10 +362,7 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
             );
             // Ensure the password file still exists for the user to read
             if password_file.exists() {
-                tracing::info!(
-                    "Admin password file: {}",
-                    password_file.display()
-                );
+                tracing::info!("Admin password file: {}", password_file.display());
             }
             return Ok(true);
         }
@@ -400,9 +408,7 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
             // Fall back to logging the password directly
             tracing::info!("Generated admin password: {}", password);
         } else {
-            tracing::info!(
-                "Admin password written to: {}", password_file.display()
-            );
+            tracing::info!("Admin password written to: {}", password_file.display());
         }
         tracing::info!(
             "\n\

--- a/backend/src/models/peer_instance.rs
+++ b/backend/src/models/peer_instance.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
-
 /// Peer instance status enum.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "instance_status", rename_all = "lowercase")]

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -243,8 +243,7 @@ impl ArtifactService {
 
         // Populate packages / package_versions tables (non-blocking)
         if let Some(ref ver) = artifact.version {
-            let pkg_svc =
-                crate::services::package_service::PackageService::new(self.db.clone());
+            let pkg_svc = crate::services::package_service::PackageService::new(self.db.clone());
             pkg_svc
                 .try_create_or_update_from_artifact(
                     artifact.repository_id,

--- a/backend/src/services/build_service.rs
+++ b/backend/src/services/build_service.rs
@@ -178,13 +178,11 @@ impl BuildService {
         }
 
         // Verify build exists
-        let exists: bool = sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM builds WHERE id = $1)",
-        )
-        .bind(build_id)
-        .fetch_one(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM builds WHERE id = $1)")
+            .bind(build_id)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         if !exists {
             return Err(AppError::NotFound(format!("Build {} not found", build_id)));

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -353,7 +353,8 @@ impl LdapService {
 
         ldap3::drive!(conn);
 
-        let result = ldap.simple_bind(user_dn, password)
+        let result = ldap
+            .simple_bind(user_dn, password)
             .await
             .map_err(|e| AppError::Authentication(format!("LDAP bind failed: {e}")))?;
 
@@ -397,7 +398,8 @@ impl LdapService {
                 self.config.groups_attr.as_str(),
             ];
 
-            let (results, _) = ldap.search(&self.config.base_dn, Scope::Subtree, &search_filter, attrs)
+            let (results, _) = ldap
+                .search(&self.config.base_dn, Scope::Subtree, &search_filter, attrs)
                 .await
                 .map_err(|e| AppError::Internal(format!("LDAP search failed: {e}")))?
                 .success()
@@ -408,16 +410,22 @@ impl LdapService {
             if let Some(entry) = results.into_iter().next() {
                 let entry = SearchEntry::construct(entry);
 
-                let email = entry.attrs.get(&self.config.email_attr)
+                let email = entry
+                    .attrs
+                    .get(&self.config.email_attr)
                     .and_then(|v| v.first())
                     .cloned()
                     .unwrap_or_else(|| format!("{}@unknown", username));
 
-                let display_name = entry.attrs.get(&self.config.display_name_attr)
+                let display_name = entry
+                    .attrs
+                    .get(&self.config.display_name_attr)
                     .and_then(|v| v.first())
                     .cloned();
 
-                let groups = entry.attrs.get(&self.config.groups_attr)
+                let groups = entry
+                    .attrs
+                    .get(&self.config.groups_attr)
                     .cloned()
                     .unwrap_or_default();
 

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -513,12 +513,11 @@ impl MigrationWorker {
             }
 
             // Insert artifact record into the database
-            let repo_id: Option<(Uuid,)> = sqlx::query_as(
-                "SELECT id FROM repositories WHERE key = $1"
-            )
-            .bind(repo_key)
-            .fetch_optional(&self.db)
-            .await?;
+            let repo_id: Option<(Uuid,)> =
+                sqlx::query_as("SELECT id FROM repositories WHERE key = $1")
+                    .bind(repo_key)
+                    .fetch_optional(&self.db)
+                    .await?;
 
             if let Some((repository_id,)) = repo_id {
                 let name = artifact_path.rsplit('/').next().unwrap_or(artifact_path);
@@ -911,11 +910,10 @@ impl MigrationWorker {
 
     /// Check if the job has been paused via the database
     async fn is_paused(&self, job_id: Uuid) -> Result<bool, MigrationError> {
-        let status: (String,) =
-            sqlx::query_as("SELECT status FROM migration_jobs WHERE id = $1")
-                .bind(job_id)
-                .fetch_one(&self.db)
-                .await?;
+        let status: (String,) = sqlx::query_as("SELECT status FROM migration_jobs WHERE id = $1")
+            .bind(job_id)
+            .fetch_one(&self.db)
+            .await?;
         Ok(status.0 == "paused" || status.0 == "cancelled")
     }
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,15 +1,13 @@
 //! Business logic services.
 
 pub mod artifact_service;
-pub mod auth_config_service;
-pub mod build_service;
 pub mod artifactory_client;
 pub mod artifactory_import;
-pub mod nexus_client;
-pub mod source_registry;
 pub mod audit_service;
+pub mod auth_config_service;
 pub mod auth_service;
 pub mod backup_service;
+pub mod build_service;
 pub mod encryption;
 pub mod grype_scanner;
 pub mod image_scanner;
@@ -17,6 +15,7 @@ pub mod ldap_service;
 pub mod meili_service;
 pub mod migration_service;
 pub mod migration_worker;
+pub mod nexus_client;
 pub mod oidc_service;
 pub mod openscap_scanner;
 pub mod package_service;
@@ -34,6 +33,7 @@ pub mod scan_result_service;
 pub mod scanner_service;
 pub mod search_service;
 pub mod signing_service;
+pub mod source_registry;
 pub mod storage_service;
 pub mod token_service;
 pub mod transfer_service;

--- a/backend/src/services/remote_instance_service.rs
+++ b/backend/src/services/remote_instance_service.rs
@@ -64,14 +64,12 @@ impl RemoteInstanceService {
 
     /// Delete a remote instance (only if it belongs to `user_id`).
     pub async fn delete(pool: &PgPool, id: Uuid, user_id: Uuid) -> Result<()> {
-        let result = sqlx::query(
-            "DELETE FROM remote_instances WHERE id = $1 AND user_id = $2",
-        )
-        .bind(id)
-        .bind(user_id)
-        .execute(pool)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        let result = sqlx::query("DELETE FROM remote_instances WHERE id = $1 AND user_id = $2")
+            .bind(id)
+            .bind(user_id)
+            .execute(pool)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         if result.rows_affected() == 0 {
             return Err(AppError::NotFound("Remote instance not found".into()));
@@ -80,11 +78,7 @@ impl RemoteInstanceService {
     }
 
     /// Return the (url, decrypted_api_key) for a remote instance.
-    pub async fn get_decrypted(
-        pool: &PgPool,
-        id: Uuid,
-        user_id: Uuid,
-    ) -> Result<(String, String)> {
+    pub async fn get_decrypted(pool: &PgPool, id: Uuid, user_id: Uuid) -> Result<(String, String)> {
         let row = sqlx::query(
             "SELECT url, api_key_encrypted FROM remote_instances WHERE id = $1 AND user_id = $2",
         )


### PR DESCRIPTION
## Summary
- Extract `build_totp()` and `decode_secret()` helpers in `totp.rs` (4 call sites deduplicated)
- Extract `secure_flag()` and `clear_auth_cookies()` in `auth.rs`
- Consolidate 4 sequential path checks into single `is_allowed` expression in setup middleware
- Extract `wait_for_service()` and `get_admin_token()` in SSO E2E script
- Reduce duplication across sso, migration, remote_instances handlers
- Simplify service initialization and error handling patterns

21 files changed, 346 insertions, 352 deletions — net reduction in code while preserving all functionality.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace` passes (warnings are pre-existing, not introduced by this PR)
- [x] `cargo test --workspace --lib` passes (442 passed, 0 failed)
- [x] Manual review of refactored helpers for correctness