### PR TITLE
chore: Prepare v1.0.0-a2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-a2] - 2026-02-08
+
+Second alpha release with staging promotion workflow, Dependency-Track monitoring, red team security hardening, and landing page refresh.
+
+### Added
+- **Staging Promotion Workflow**
+  - New staging repository type for promotion-based artifact lifecycle
+  - Promotion API endpoints for staging → release workflow
+  - Policy gate integration for automated promotion decisions
+  - Simplified promotion policy and handler code (#49)
+- **Dependency-Track Monitoring** (#57)
+  - Backend API for Dependency-Track integration
+  - OpenSCAP and Dependency-Track added to health monitoring dashboard
+- **Red Team Security Testing Suite** (#52)
+- **STS Credential Rotation E2E Tests** (#56)
+- **Pre-release banner** on landing page and README
+
+### Changed
+- Updated landing page to LCARS color scheme with new brand colors
+- Pre-release banner changed from warning to release announcement
+
+### Fixed
+- Refresh credentials before presigned URL generation (#55)
+- Calculate storage_used_bytes for repository list view (#58)
+- Position banner above navbar without overlap
+- CI fixes: fmt, clippy, and broken migration (#48)
+- CI fixes: PKI file handling in E2E tests (tar archive, explicit patterns)
+
+### Security
+- Hardened 7 vulnerabilities identified by red team scan (#53)
+
 ## [1.0.0-a1] - 2026-02-06
 
 First public alpha release, announced on Hacker News.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Artifact Keeper
 
-> [!CAUTION]
-> **🚧 Pre-Release Notice 🚧**
->
-> Please wait for **`v1.0.0-rc2`** before testing. We're actively incorporating community feedback to ensure a great first-use experience. Thank you for your patience!
+> [!NOTE]
+> **v1.0.0-a2 is now available for testing!** See the [release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.0.0-a2) to get started.
 
 [![CI](https://github.com/artifact-keeper/artifact-keeper/actions/workflows/ci.yml/badge.svg)](https://github.com/artifact-keeper/artifact-keeper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/site/src/components/landing/PreReleaseBanner.astro
+++ b/site/src/components/landing/PreReleaseBanner.astro
@@ -1,24 +1,24 @@
 ---
-// Pre-release warning banner
+// Pre-release announcement banner
 ---
 
 <div class="prerelease-banner">
   <div class="banner-content">
-    <span class="banner-icon">🚧</span>
+    <span class="banner-icon">🚀</span>
     <span class="banner-text">
-      <strong>Pre-Release:</strong> Please wait for <code>v1.0.0-rc2</code> before testing.
-      We're incorporating feedback from the community to ensure a great first-use experience.
+      <strong>Alpha Release:</strong> <code>v1.0.0-a2</code> is now available for testing.
+      Check the <a href="https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.0.0-a2" class="banner-link">release notes</a> to get started.
     </span>
-    <span class="banner-icon">🚧</span>
+    <span class="banner-icon">🚀</span>
   </div>
 </div>
 
 <style>
   .prerelease-banner {
-    background: linear-gradient(135deg, #f59e0b 0%, #d97706 50%, #f59e0b 100%);
+    background: linear-gradient(135deg, #10b981 0%, #059669 50%, #10b981 100%);
     background-size: 200% 200%;
     animation: gradient-shift 3s ease infinite;
-    color: #1a1a1a;
+    color: #fff;
     padding: 0.75rem 1.5rem;
     text-align: center;
     font-size: 0.9rem;
@@ -28,7 +28,7 @@
     left: 0;
     right: 0;
     z-index: 60;
-    box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
+    box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
   }
 
   @keyframes gradient-shift {
@@ -67,11 +67,21 @@
     border-radius: 4px;
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
     font-weight: 700;
-    color: #7c2d12;
+    color: #064e3b;
   }
 
   .banner-text strong {
     font-weight: 700;
+  }
+
+  .banner-link {
+    color: #fff;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .banner-link:hover {
+    text-decoration-thickness: 2px;
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- Update pre-release banner from amber warning ("wait for rc2") to green announcement ("v1.0.0-a2 is available for testing")
- Update README.md notice from `[!CAUTION]` to `[!NOTE]` with link to release notes
- Add `[1.0.0-a2]` changelog entry covering 25 commits since a1

## Context
Release prep for `v1.0.0-a2` across artifact-keeper, artifact-keeper-web, artifact-keeper-ios, and artifact-keeper-android.