### PR TITLE
fix(ci): Use dev tag for main builds, latest only on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -184,7 +184,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push
@@ -244,7 +245,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push


### PR DESCRIPTION
## Summary
- Push to main now tags Docker images as `dev` instead of `latest`
- Only version tag pushes (`v*`) set the `latest` tag
- Applies to both backend and openscap images

## Why
Previously every push to main overwrote `:latest`, meaning anyone running `docker compose pull` between releases would get untested dev builds. Now `:latest` always points to the most recent release, and `:dev` tracks main HEAD.

| Trigger | Before | After |
|---------|--------|-------|
| Push to main | `latest`, `main`, SHA | `dev`, `main`, SHA |
| Tag `v1.0.0-a2` | `1.0.0-a2`, SHA | `1.0.0-a2`, `latest`, SHA |