### PR TITLE
docs: Fill documentation gaps for v1.0.0-a2 features

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -56,8 +56,11 @@ export default defineConfig({
           label: 'Security',
           items: [
             { label: 'Vulnerability Scanning', slug: 'docs/security/scanning' },
+            { label: 'OpenSCAP Compliance', slug: 'docs/security/openscap' },
+            { label: 'SBOM & Dependency-Track', slug: 'docs/security/sbom' },
             { label: 'Security Policies', slug: 'docs/security/policies' },
             { label: 'Artifact Signing', slug: 'docs/security/signing' },
+            { label: 'Security Testing', slug: 'docs/security/red-team' },
           ],
         },
         {
@@ -70,6 +73,7 @@ export default defineConfig({
           label: 'Advanced',
           items: [
             { label: 'Authentication & RBAC', slug: 'docs/advanced/auth' },
+            { label: 'Staging & Promotion', slug: 'docs/advanced/staging-promotion' },
             { label: 'Storage Backends', slug: 'docs/advanced/storage' },
             { label: 'Edge Nodes', slug: 'docs/advanced/edge-nodes' },
             { label: 'WASM Plugins', slug: 'docs/advanced/plugins' },

--- a/site/src/content/docs/docs/advanced/auth.mdx
+++ b/site/src/content/docs/docs/advanced/auth.mdx
@@ -241,6 +241,172 @@ OIDC_NAME_CLAIM=name
 OIDC_GROUPS_CLAIM=groups
 ```
 
+## SAML 2.0 SSO
+
+Integrate with enterprise identity providers (Okta, Azure AD, ADFS, Shibboleth) using SAML 2.0.
+
+### Configuration
+
+SAML providers are managed via the admin API:
+
+```bash
+# Create a SAML provider
+curl -X POST https://registry.example.com/api/v1/admin/sso/saml \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Okta",
+    "entity_id": "https://www.okta.com/exk1234567890",
+    "sso_url": "https://yourcompany.okta.com/app/artifact-keeper/sso/saml",
+    "certificate": "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----",
+    "sp_entity_id": "artifact-keeper",
+    "attribute_mapping": {
+      "username": "NameID",
+      "email": "email",
+      "display_name": "displayName",
+      "groups": "groups"
+    }
+  }'
+```
+
+Or configure via environment variables:
+
+```bash
+SAML_IDP_SSO_URL=https://yourcompany.okta.com/app/artifact-keeper/sso/saml
+SAML_IDP_ISSUER=https://www.okta.com/exk1234567890
+SAML_IDP_CERTIFICATE="-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----"
+SAML_SP_ENTITY_ID=artifact-keeper
+SAML_ACS_URL=https://registry.example.com/auth/saml/acs
+SAML_SIGN_REQUESTS=false
+SAML_REQUIRE_SIGNED_ASSERTIONS=true
+```
+
+### SAML Login Flow
+
+1. User clicks "Login with SAML" in the web UI
+2. Artifact Keeper generates an AuthnRequest and redirects to the IdP
+3. User authenticates with the IdP
+4. IdP POSTs a SAML Response to the Assertion Consumer Service (ACS)
+5. Artifact Keeper validates the assertion, creates/updates the user
+6. A short-lived exchange code redirects the user back to the web UI with tokens
+
+### Attribute Mapping
+
+Map SAML assertion attributes to user fields:
+
+```bash
+SAML_USERNAME_ATTR=NameID          # Or a custom attribute name
+SAML_EMAIL_ATTR=email
+SAML_DISPLAY_NAME_ATTR=displayName
+SAML_GROUPS_ATTR=groups
+```
+
+### Group-to-Role Mapping
+
+Map IdP groups to Artifact Keeper roles:
+
+```bash
+SAML_ADMIN_GROUP=ArtifactKeeper-Admins    # Members get admin role
+SAML_GROUP_ROLE_MAP="Developers:developer;QA:viewer"
+```
+
+### Managing SAML Providers
+
+```bash
+# List all SAML providers
+curl https://registry.example.com/api/v1/admin/sso/saml \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Enable/disable a provider
+curl -X PATCH https://registry.example.com/api/v1/admin/sso/saml/{id}/toggle \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Delete a provider
+curl -X DELETE https://registry.example.com/api/v1/admin/sso/saml/{id} \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+## Two-Factor Authentication (TOTP)
+
+Artifact Keeper supports time-based one-time passwords (TOTP) for two-factor authentication, compatible with any authenticator app (Google Authenticator, Authy, 1Password, etc.).
+
+### Enabling 2FA
+
+#### Step 1: Generate TOTP Secret
+
+```bash
+curl -X POST https://registry.example.com/api/v1/auth/totp/setup \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response:
+
+```json
+{
+  "secret": "JBSWY3DPEBLW64TMMQ======",
+  "qr_code_url": "otpauth://totp/ArtifactKeeper:user@example.com?secret=JBSWY3DPEBLW64TMMQ&issuer=ArtifactKeeper"
+}
+```
+
+Scan the `qr_code_url` with your authenticator app, or manually enter the `secret`.
+
+#### Step 2: Verify and Enable
+
+Enter a code from your authenticator to confirm setup:
+
+```bash
+curl -X POST https://registry.example.com/api/v1/auth/totp/enable \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "123456"}'
+```
+
+Response includes 10 backup codes -- **save these securely**:
+
+```json
+{
+  "backup_codes": [
+    "AAAA-BBBB",
+    "CCCC-DDDD",
+    "..."
+  ]
+}
+```
+
+### Login with 2FA
+
+When TOTP is enabled, the login flow adds a verification step:
+
+```bash
+# Step 1: Normal login (returns totp_required)
+curl -X POST https://registry.example.com/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "user", "password": "pass"}'
+
+# Response:
+# { "totp_required": true, "totp_token": "eyJ..." }
+
+# Step 2: Verify TOTP code
+curl -X POST https://registry.example.com/api/v1/auth/totp/verify \
+  -H "Content-Type: application/json" \
+  -d '{"totp_token": "eyJ...", "code": "123456"}'
+
+# Response: Normal login response with access_token and refresh_token
+```
+
+### Backup Codes
+
+If you lose access to your authenticator app, use a backup code in place of the TOTP code. Each backup code can only be used once.
+
+### Disabling 2FA
+
+```bash
+curl -X POST https://registry.example.com/api/v1/auth/totp/disable \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"password": "your-password", "code": "123456"}'
+```
+
 ## Security Best Practices
 
 ### Strong JWT Secrets

--- a/site/src/content/docs/docs/advanced/staging-promotion.mdx
+++ b/site/src/content/docs/docs/advanced/staging-promotion.mdx
@@ -1,0 +1,212 @@
+---
+title: "Staging & Promotion"
+description: "Staging repositories and artifact promotion workflow with policy gates"
+---
+
+Artifact Keeper supports a staging-to-release promotion workflow. Upload artifacts to a staging repository, then promote them to a release repository after security and license policy checks pass.
+
+## How It Works
+
+```text
+Upload          Policy Gate         Release
+  |                 |                 |
+  v                 v                 v
+[Staging Repo] --> [CVE + License] --> [Local Repo]
+                    Check
+```
+
+1. Upload artifacts to a **staging** repository
+2. Promote artifacts to a **local** (release) repository via API
+3. Policy gates evaluate CVE severity and license compliance before allowing promotion
+4. Promotion history is recorded for audit
+
+## Creating a Staging Repository
+
+```bash
+curl -X POST https://registry.example.com/api/v1/repositories \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "maven-staging",
+    "name": "Maven Staging",
+    "format": "maven",
+    "repo_type": "staging"
+  }'
+```
+
+Staging repositories accept uploads just like local repositories, but are intended as a holding area before promotion.
+
+## Promoting Artifacts
+
+### Single Artifact
+
+```bash
+curl -X POST https://registry.example.com/api/v1/repositories/maven-staging/artifacts/{artifact_id}/promote \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "target_repository": "maven-release",
+    "notes": "Approved for release after QA sign-off"
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "promoted": true,
+  "source": "maven-staging/com/example/app-1.0.jar",
+  "target": "maven-release/com/example/app-1.0.jar",
+  "promotion_id": "550e8400-e29b-41d4-a716-446655440000",
+  "policy_violations": [],
+  "message": null
+}
+```
+
+### Bulk Promotion
+
+Promote multiple artifacts at once:
+
+```bash
+curl -X POST https://registry.example.com/api/v1/repositories/maven-staging/promote \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "target_repository": "maven-release",
+    "artifact_ids": [
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440002"
+    ],
+    "notes": "Sprint 42 release batch"
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "total": 2,
+  "promoted": 2,
+  "failed": 0,
+  "results": [...]
+}
+```
+
+Bulk promotion is not transactional -- partial success is possible. Check individual results.
+
+## Policy Gates
+
+When promoting, Artifact Keeper evaluates security and license policies against each artifact. If any policy check fails with a **Block** action, the promotion is rejected.
+
+### CVE Security Policies
+
+Configure maximum CVE severity thresholds per repository:
+
+- **Critical CVEs** always block promotion
+- **High/Medium/Low** blocked based on your configured `max_severity`
+- **Unscanned artifacts** can optionally be blocked with `block_unscanned`
+
+When blocked, the response includes violation details:
+
+```json
+{
+  "promoted": false,
+  "policy_violations": [
+    {
+      "rule": "cve-severity-threshold",
+      "severity": "critical",
+      "message": "3 critical CVEs found: CVE-2024-1234, CVE-2024-5678, CVE-2024-9012"
+    }
+  ],
+  "message": "Promotion blocked by policy violations"
+}
+```
+
+### License Compliance Policies
+
+Control which open-source licenses are acceptable:
+
+- **Denied licenses** (e.g., GPL-3.0) block promotion immediately
+- **Allowed licenses** can be configured as an allowlist
+- **Unknown licenses** can be allowed or blocked via `allow_unknown`
+
+### Skipping Policy Checks
+
+For emergency releases, you can bypass policy evaluation:
+
+```bash
+curl -X POST .../artifacts/{id}/promote \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "target_repository": "maven-release",
+    "skip_policy_check": true,
+    "notes": "Emergency hotfix - policy override approved by security team"
+  }'
+```
+
+The policy skip is recorded in the promotion history for audit purposes.
+
+## Promotion History
+
+View the audit trail of all promotions for a repository:
+
+```bash
+curl "https://registry.example.com/api/v1/repositories/maven-staging/promotion-history?per_page=20" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "items": [
+    {
+      "id": "...",
+      "artifact_path": "com/example/app-1.0.jar",
+      "source_repo_key": "maven-staging",
+      "target_repo_key": "maven-release",
+      "promoted_by_username": "admin",
+      "policy_result": { "passed": true, "action": "allow", "violations": [] },
+      "notes": "Sprint 42 release",
+      "created_at": "2026-02-08T12:00:00Z"
+    }
+  ],
+  "pagination": { "page": 1, "per_page": 20, "total": 1 }
+}
+```
+
+Filter by artifact:
+
+```bash
+curl ".../promotion-history?artifact_id=550e8400-..." \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Validation Rules
+
+The promotion handler enforces:
+
+1. **Source must be a staging repository** -- local, remote, and virtual repos cannot promote
+2. **Target must be a local repository** -- you can only promote into release repos
+3. **Format must match** -- a Maven staging repo can only promote to a Maven release repo
+4. **Authentication required** -- all promotion endpoints require a valid token
+
+## Typical Workflow
+
+```bash
+# 1. Create staging and release repos
+curl -X POST .../repositories -d '{"key":"npm-staging","format":"npm","repo_type":"staging"}'
+curl -X POST .../repositories -d '{"key":"npm-release","format":"npm","repo_type":"local"}'
+
+# 2. Upload to staging (use native npm client)
+npm publish --registry https://registry.example.com/api/v1/npm/npm-staging/
+
+# 3. Run scans (automatic on upload)
+
+# 4. Promote when ready
+curl -X POST .../repositories/npm-staging/artifacts/{id}/promote \
+  -d '{"target_repository":"npm-release"}'
+
+# 5. Consumers pull from release repo
+npm install my-package --registry https://registry.example.com/api/v1/npm/npm-release/
+```

--- a/site/src/content/docs/docs/advanced/storage.mdx
+++ b/site/src/content/docs/docs/advanced/storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Storage Backends"
-description: "Filesystem and S3-compatible storage options for artifact data"
+description: "Filesystem, S3, Azure Blob, and Google Cloud Storage backends for artifact data"
 ---
 
 Artifact Keeper supports multiple storage backends to accommodate different deployment scenarios and scale requirements.
@@ -302,6 +302,99 @@ S3_REDIRECT_DOWNLOADS=false
 ```
 
 All downloads will stream through the backend with `X-Artifact-Storage: proxy`.
+
+### Azure Blob Storage
+
+Use Azure Blob Storage for Azure-native deployments.
+
+#### Configuration
+
+```bash
+STORAGE_BACKEND=azure
+AZURE_STORAGE_ACCOUNT=myaccount
+AZURE_STORAGE_CONTAINER=artifacts
+AZURE_STORAGE_ACCESS_KEY=base64-encoded-account-key
+```
+
+#### Optional Settings
+
+```bash
+AZURE_STORAGE_ENDPOINT=https://custom.endpoint.com   # Azure Government/China clouds
+AZURE_REDIRECT_DOWNLOADS=true                        # Enable SAS URL redirects
+AZURE_SAS_EXPIRY=3600                               # SAS token lifetime in seconds (default: 1 hour)
+STORAGE_PATH_FORMAT=native                           # native, artifactory, or migration
+```
+
+#### Direct Downloads with SAS URLs
+
+When `AZURE_REDIRECT_DOWNLOADS=true`, artifact downloads redirect to a Shared Access Signature (SAS) URL:
+
+```http
+HTTP/1.1 302 Found
+Location: https://myaccount.blob.core.windows.net/artifacts/path?sv=2021-06-08&st=...&se=...&sr=b&sp=r&sig=...
+X-Artifact-Storage: redirect-azure
+```
+
+SAS tokens are read-only and expire after `AZURE_SAS_EXPIRY` seconds.
+
+### Google Cloud Storage (GCS)
+
+Use GCS for Google Cloud deployments.
+
+#### Configuration
+
+```bash
+STORAGE_BACKEND=gcs
+GCS_BUCKET=my-bucket
+GCS_PROJECT_ID=my-project
+GCS_SERVICE_ACCOUNT_EMAIL=sa@my-project.iam.gserviceaccount.com
+```
+
+Provide the service account private key via file or inline:
+
+```bash
+# Option A: Key file path
+GCS_PRIVATE_KEY_PATH=/path/to/service-account-key.pem
+
+# Option B: Inline (escaped newlines)
+GCS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIIEv..."
+```
+
+#### Optional Settings
+
+```bash
+GCS_REDIRECT_DOWNLOADS=true        # Enable signed URL redirects
+GCS_SIGNED_URL_EXPIRY=3600         # Signed URL lifetime in seconds (default: 1 hour, max: 7 days)
+STORAGE_PATH_FORMAT=native         # native, artifactory, or migration
+```
+
+#### Direct Downloads with V4 Signed URLs
+
+When `GCS_REDIRECT_DOWNLOADS=true`, artifact downloads redirect to a GCS V4 signed URL:
+
+```http
+HTTP/1.1 302 Found
+Location: https://storage.googleapis.com/my-bucket/path?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=...&X-Goog-Signature=...
+X-Artifact-Storage: redirect-gcs
+```
+
+GCS enforces a maximum signed URL lifetime of 7 days (604800 seconds).
+
+### Artifactory Migration Mode
+
+All cloud backends (S3, Azure, GCS) support a migration mode for zero-downtime migration from Artifactory:
+
+```bash
+STORAGE_PATH_FORMAT=migration
+```
+
+| Mode | Write Path | Read Path | Use Case |
+|------|-----------|-----------|----------|
+| `native` | `{sha[0:2]}/{sha[2:4]}/{sha}` | Native only | New deployments |
+| `artifactory` | `{sha[0:2]}/{sha}` | Artifactory only | Post-migration |
+| `migration` | Native format | Both native + artifactory fallback | During migration |
+
+Start with `migration` mode, then switch to `native` after confirming all artifacts are accessible.
 
 ## MinIO as S3 Alternative
 

--- a/site/src/content/docs/docs/security/openscap.mdx
+++ b/site/src/content/docs/docs/security/openscap.mdx
@@ -1,0 +1,103 @@
+---
+title: "OpenSCAP Compliance"
+description: "SCAP compliance scanning for container images and system packages"
+---
+
+Artifact Keeper integrates [OpenSCAP](https://www.open-scap.org/) for XCCDF compliance evaluation against industry-standard SCAP security content. This complements Trivy and Grype vulnerability scanning with configuration compliance checks.
+
+## What OpenSCAP Scans
+
+OpenSCAP evaluates artifacts against Security Content Automation Protocol (SCAP) profiles:
+
+- **Container images** (OCI manifests) -- checks filesystem configuration inside images
+- **RPM packages** (.rpm) -- evaluates against RHEL/Fedora security baselines
+- **Debian packages** (.deb) -- evaluates against Debian/Ubuntu security baselines
+
+Other artifact types (JAR, NPM, PyPI wheels, etc.) are not applicable and are skipped.
+
+## Architecture
+
+```text
+Upload                   Artifact Keeper              OpenSCAP Container
+  |                           |                              |
+  |-- Upload artifact ------> |                              |
+  |                           |-- Write to scan workspace -> |
+  |                           |-- POST /scan ------------->  |
+  |                           |                     oscap xccdf eval
+  |                           |<-- Findings JSON ----------  |
+  |                           |-- Store in scan_results      |
+```
+
+The OpenSCAP container runs the `oscap` CLI wrapped in a Python HTTP service on port 8091. Artifacts are shared via a Docker volume (`scan_workspace`).
+
+## Configuration
+
+OpenSCAP runs as a Docker service alongside the backend:
+
+```yaml
+# docker-compose.yml (already included)
+openscap:
+  image: ghcr.io/artifact-keeper/artifact-keeper-openscap:latest
+  ports:
+    - "8091:8091"
+  volumes:
+    - scan_workspace:/scan-workspace:ro
+```
+
+Backend configuration:
+
+```bash
+OPENSCAP_URL=http://openscap:8091   # Set automatically in docker compose
+```
+
+No additional configuration is needed -- the default docker compose stack includes OpenSCAP.
+
+## SCAP Profiles
+
+OpenSCAP ships with the [SCAP Security Guide (SSG)](https://github.com/ComplianceAsCode/content) which provides profiles for:
+
+| Profile | Target OS | Description |
+|---------|-----------|-------------|
+| `standard` | Fedora/RHEL | Basic security baseline |
+| `cis` | RHEL/CentOS | CIS Benchmark compliance |
+| `stig` | RHEL | DISA STIG compliance |
+| `pci-dss` | RHEL | PCI DSS requirements |
+| `hipaa` | RHEL | HIPAA security controls |
+
+The scanner auto-detects the appropriate SCAP content based on the artifact's OS family (RHEL, Fedora, CentOS, Rocky, Alma, Oracle Linux, Debian, Ubuntu).
+
+## Scan Results
+
+OpenSCAP findings appear alongside Trivy and Grype results in the security scan view. Each finding includes:
+
+- **Rule ID** -- the XCCDF rule identifier (e.g., `xccdf_org.ssgproject.content_rule_no_empty_passwords`)
+- **Result** -- fail, error, or unknown (passing rules are filtered out)
+- **Severity** -- high, medium, low, or info
+- **Title** -- human-readable rule description
+- **References** -- CCE identifiers and other references from the SCAP content
+
+## Health Monitoring
+
+OpenSCAP health is checked via the system health dashboard:
+
+```bash
+curl https://registry.example.com/api/v1/admin/health
+```
+
+The response includes OpenSCAP status:
+
+```json
+{
+  "services": {
+    "openscap": {
+      "status": "ok",
+      "version": "openscap 1.4.0",
+      "content_files": ["rhel9", "fedora", "centos8"]
+    }
+  }
+}
+```
+
+## Disabling OpenSCAP
+
+If you don't need compliance scanning, remove the `openscap` service from your docker compose file, or unset `OPENSCAP_URL`. The backend will skip OpenSCAP scans when the service is unavailable.

--- a/site/src/content/docs/docs/security/red-team.mdx
+++ b/site/src/content/docs/docs/security/red-team.mdx
@@ -1,0 +1,103 @@
+---
+title: "Security Testing"
+description: "Red team security testing suite for validating Artifact Keeper hardening"
+---
+
+Artifact Keeper includes a comprehensive red team testing suite with 15 automated security tests covering OWASP Top 10 vulnerabilities and enterprise security concerns.
+
+## Running the Tests
+
+```bash
+# Run all 15 tests
+./scripts/redteam/run-all.sh
+
+# Run a specific test
+./scripts/redteam/run-all.sh --test 04-auth
+
+# Filter by severity
+./scripts/redteam/run-all.sh --severity HIGH
+```
+
+The test suite expects a running Artifact Keeper instance (default: `http://backend:8080`). Configure the target via environment variables:
+
+```bash
+REGISTRY_URL="http://localhost:8080"
+GRPC_URL="localhost:9090"
+ADMIN_USER="admin"
+ADMIN_PASS="admin123"
+```
+
+## Test Suite
+
+| # | Test | What It Checks |
+|---|------|---------------|
+| 01 | Service Discovery | Only expected ports (8080, 9090) are exposed |
+| 02 | Security Headers | X-Frame-Options, CSP, HSTS, X-Content-Type-Options |
+| 03 | CORS Policy | Cross-origin resource sharing is properly restricted |
+| 04 | Auth Bypass | Protected endpoints enforce authentication; format-specific uploads require auth |
+| 05 | Default Credentials | No hardcoded or weak default admin credentials |
+| 06 | gRPC Unauth | gRPC service (port 9090) requires authentication |
+| 07 | OCI DoS | Resistance to denial-of-service via oversized OCI layer uploads |
+| 08 | Path Traversal | Artifact download cannot escape repository root (URL-encoded, Unicode, double-encoded variants) |
+| 09 | SQL Injection | Parameterized queries prevent injection in search and filter parameters |
+| 10 | Rate Limiting | Brute force and DoS protection on login and API endpoints |
+| 11 | WASM Plugin Security | Plugin sandboxing and capability restrictions |
+| 12 | Info Disclosure | No stack traces, internal paths, or version numbers leaked |
+| 13 | SSRF Prevention | Webhook URL validation blocks private IPs, cloud metadata endpoints, and internal services |
+| 14 | API Key Exposure | Sensitive fields (api_key, password_hash, totp_secret) never appear in API responses |
+| 15 | Metrics Auth | Prometheus/metrics endpoints require authentication |
+
+## Report Output
+
+Tests generate a JSON report at `results/redteam-report.json`:
+
+```json
+{
+  "timestamp": "2026-02-08T12:34:56Z",
+  "target": "http://backend:8080",
+  "findings": [
+    {
+      "severity": "HIGH",
+      "test": "auth-bypass/pypi-upload-noauth",
+      "description": "PyPI artifact upload accepted without authentication",
+      "evidence": "POST /api/v1/pypi/test-pypi/ returned 200"
+    }
+  ],
+  "summary": {
+    "pass": 42,
+    "fail": 0,
+    "warn": 5,
+    "info": 8
+  }
+}
+```
+
+## Severity Levels
+
+| Level | Meaning |
+|-------|---------|
+| CRITICAL | Immediate security risk -- path traversal, secret exposure, auth bypass |
+| HIGH | Significant vulnerability -- SQL injection, unauthenticated uploads, SSRF |
+| MEDIUM | Defense-in-depth gap -- missing security headers, unexpected ports |
+| LOW | Information disclosure -- version numbers, technology hints |
+| INFO | Informational -- port mapping, connectivity status |
+
+## CI/CD Integration
+
+The test runner exits with non-zero status if any findings are detected, making it suitable as a CI gate:
+
+```yaml
+# GitHub Actions example
+- name: Red Team Security Tests
+  run: |
+    docker compose up -d
+    ./scripts/redteam/run-all.sh
+```
+
+## Vulnerabilities Found and Fixed
+
+The v1.0.0-a2 red team scan identified and hardened 7 vulnerabilities, including:
+
+- **Peer API key exposure** -- `GET /api/v1/peers` previously returned plaintext `api_key` field. Now redacted from all API responses.
+- **SSRF via webhook URLs** -- webhook creation now validates URLs against private IP ranges and cloud metadata endpoints.
+- Test 14 includes regression tests to ensure these fixes are not accidentally reverted.


### PR DESCRIPTION
## Summary
Fills the critical documentation gaps identified in the v1.0.0-a2 doc audit.

### New pages
- **Staging & Promotion** (`advanced/staging-promotion.mdx`) -- staging repo type, promotion API (single + bulk), policy gates (CVE + license), promotion history, validation rules
- **OpenSCAP Compliance** (`security/openscap.mdx`) -- SCAP profiles, architecture, scan results, health monitoring
- **Security Testing** (`security/red-team.mdx`) -- 15-test red team suite, severity levels, report format, CI integration

### Updated pages
- **Auth** (`advanced/auth.mdx`) -- Added SAML 2.0 SSO section (config, login flow, attribute mapping, group-to-role mapping, admin API) and TOTP 2FA section (setup, enable, login flow, backup codes, disable)
- **Storage** (`advanced/storage.mdx`) -- Added Azure Blob Storage (SAS URLs, config) and Google Cloud Storage (V4 signed URLs, config), plus Artifactory migration mode docs

### Sidebar
- Added OpenSCAP, SBOM & Dependency-Track, Staging & Promotion, Security Testing to navigation