### PR TITLE
fix: correct AuthExtension type in promotion handlers

### DIFF
--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -19,9 +19,7 @@ use crate::models::sbom::PolicyAction;
 use crate::services::promotion_policy_service::PromotionPolicyService;
 use crate::services::repository_service::RepositoryService;
 
-fn require_auth(auth: Option<AuthExtension>) -> Result<AuthExtension> {
-    auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))
-}
+
 
 pub fn router() -> Router<SharedState> {
     Router::new()
@@ -142,11 +140,10 @@ fn failed_response(source: String, target: String, message: String) -> Promotion
 
 pub async fn promote_artifact(
     State(state): State<SharedState>,
-    Extension(auth): Extension<Option<AuthExtension>>,
+    Extension(auth): Extension<AuthExtension>,
     Path((repo_key, artifact_id)): Path<(String, Uuid)>,
     Json(req): Json<PromoteArtifactRequest>,
 ) -> Result<Json<PromotionResponse>> {
-    let auth = require_auth(auth)?;
     let repo_service = RepositoryService::new(state.db.clone());
 
     let source_repo = repo_service.get_by_key(&repo_key).await?;
@@ -309,11 +306,10 @@ pub async fn promote_artifact(
 
 pub async fn promote_artifacts_bulk(
     State(state): State<SharedState>,
-    Extension(auth): Extension<Option<AuthExtension>>,
+    Extension(auth): Extension<AuthExtension>,
     Path(repo_key): Path<String>,
     Json(req): Json<BulkPromoteRequest>,
 ) -> Result<Json<BulkPromotionResponse>> {
-    let auth = require_auth(auth)?;
     let repo_service = RepositoryService::new(state.db.clone());
 
     let source_repo = repo_service.get_by_key(&repo_key).await?;


### PR DESCRIPTION
## Summary
- The promotion routes use `auth_middleware` which provides `AuthExtension` directly, but the handlers were extracting `Option<AuthExtension>`
- This type mismatch caused Axum to fail at runtime with `Extension of type Option<AuthExtension> was not found`, returning 500 on all promotion requests
- Changes both `promote_artifact` and `promote_artifacts_bulk` to extract `Extension<AuthExtension>` directly
- Removes the now-unnecessary `require_auth` helper

## Test plan
- [x] Verified the route definition uses `auth_middleware` (not `optional_auth_middleware`)
- [ ] Promotion endpoint returns 200 after rebuild
- [ ] Bulk promotion endpoint returns 200 after rebuild