### PR TITLE
fix(site): Fix pre-release banner overlapping content on mobile

### DIFF
--- a/site/src/components/landing/Navbar.astro
+++ b/site/src/components/landing/Navbar.astro
@@ -4,7 +4,7 @@
 <nav
   id="navbar"
   class="fixed left-0 right-0 z-50 transition-all duration-300"
-  style="top: 44px;"
+  style="top: 0;"
 >
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">

--- a/site/src/components/landing/PreReleaseBanner.astro
+++ b/site/src/components/landing/PreReleaseBanner.astro
@@ -23,10 +23,6 @@
     text-align: center;
     font-size: 0.9rem;
     font-weight: 500;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
     z-index: 60;
     box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
   }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,8 +19,6 @@ import Footer from '../components/landing/Footer.astro';
 <LandingLayout>
   <PreReleaseBanner />
   <Navbar />
-  <!-- Spacer for fixed banner (44px) + fixed navbar (64px) -->
-  <div style="height: 44px;"></div>
   <Hero />
   <PainPoints />
   <ComparisonTable />


### PR DESCRIPTION
## Summary
- Remove `position: fixed` from the pre-release banner so it flows naturally in the document
- Adjust navbar `top` from `44px` to `0` since the banner no longer needs a fixed offset
- Remove the hardcoded 44px spacer div from the landing page

On mobile devices, the banner text wraps to multiple lines making it taller than the assumed 44px, causing it to overlap the hero content. With normal flow positioning, the banner pushes content down by its actual height regardless of screen size.

## Test plan
- [ ] Verify banner renders correctly on desktop (no visual change)
- [ ] Verify banner no longer covers content on mobile viewports
- [ ] Verify navbar still sticks to top when scrolling