### PR TITLE
Fix pre-release banner overlapping navbar on landing page

### DIFF
--- a/site/src/components/landing/Navbar.astro
+++ b/site/src/components/landing/Navbar.astro
@@ -66,9 +66,16 @@
   const hamburger = navbar?.querySelector('.navbar-hamburger');
   const mobileMenuBtn = document.getElementById('mobile-menu-btn');
   const mobileMenu = document.getElementById('mobile-menu');
+  const banner = document.querySelector('.prerelease-banner') as HTMLElement | null;
 
   function updateNavbar() {
     if (!navbar) return;
+
+    // Position navbar below the pre-release banner
+    const bannerHeight = banner ? banner.offsetHeight : 0;
+    const navTop = Math.max(0, bannerHeight - window.scrollY);
+    navbar.style.top = navTop + 'px';
+
     const scrolled = window.scrollY > 50;
 
     if (scrolled) {
@@ -93,6 +100,7 @@
   }
 
   window.addEventListener('scroll', updateNavbar);
+  window.addEventListener('resize', updateNavbar);
   updateNavbar();
 
   mobileMenuBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- The fixed navbar (`top: 0; z-index: 50`) and the pre-release banner (`z-index: 60`) were rendering on top of each other, making both unreadable
- Dynamically calculates the banner height and offsets the navbar below it using `Math.max(0, bannerHeight - scrollY)`, so the navbar slides up naturally as the user scrolls past the banner
- Added a `resize` listener so the offset recalculates correctly on mobile when the banner text wraps to multiple lines or on orientation change

## Test plan
- [ ] Verify banner and navbar don't overlap on desktop (wide viewport)
- [ ] Verify banner and navbar don't overlap on mobile (narrow viewport)
- [ ] Scroll down — navbar should stick to top after passing the banner
- [ ] Rotate device / resize window — navbar should reposition correctly
- [ ] If no banner is present, navbar should remain at `top: 0` as before