### PR TITLE
chore: release v1.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-edge"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend", "edge"]
 
 [workspace.package]
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"


### PR DESCRIPTION
## Summary

- Bump version to `1.0.0-rc.4`

## Changes since v1.0.0-rc.3

- **fix**: Enable TLS support for SQLx PostgreSQL connections (`tls-rustls` feature) (#80)
- **feat**: Enable TLS on docker-compose PostgreSQL via auto-generated certificates
- **fix**: Gitignore `.pki/` directory — certs are now generated at runtime by a `pg-certs` init container