### PR TITLE
chore: release v1.0.0-rc.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend", "edge"]
 
 [workspace.package]
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"


### PR DESCRIPTION
## Summary
- Bump version to 1.0.0-rc.5

## Changes since rc.4
- fix: auto-allow private-network CORS origins in development mode (#84, closes #85)
- fix(ci): handle boolean input coercion in E2E gate (#83)
- docs: document CORS behavior for LAN and production access