### PR TITLE
chore: add CI support for release maintenance branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master, develop, 'release/**']
     paths-ignore:
       - 'site/**'
       - '*.md'
@@ -10,7 +10,7 @@ on:
       - '.beads/**'
       - 'LICENSE'
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, master, develop, 'release/**']
     paths-ignore:
       - 'site/**'
       - '*.md'
@@ -80,7 +80,7 @@ jobs:
     name: 🔗 Backend Integration Tests
     runs-on: ubuntu-latest
     needs: lint-rust
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && github.event_name == 'push'
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -185,7 +185,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push
@@ -246,7 +246,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ cargo clippy --workspace
 cargo test --workspace --lib
 ```
 
-### Integration Tests (Tier 2) - Main Branch Only
+### Integration Tests (Tier 2) - Main & Release Branches Only
 ```bash
 # Backend integration tests (requires PostgreSQL)
 cargo test --workspace
@@ -146,6 +146,36 @@ Branch naming conventions:
 - `fix/` — bug fixes
 - `chore/` — maintenance, dependencies, CI
 - `docs/` — documentation only
+
+### Maintenance Branches
+
+Long-lived `release/X.Y.x` branches exist for shipping bug fixes to older release series:
+
+- **`release/1.0.x`** — maintenance branch for the 1.0 series (created from `v1.0.0-rc.5`)
+- **`main`** — continues with 1.1.x (and beyond) development
+
+**Bug fix workflow for maintenance branches:**
+1. Create a fix branch from the maintenance branch:
+   ```bash
+   git checkout release/1.0.x && git pull
+   git checkout -b fix/short-description
+   ```
+2. Push and create a PR **targeting `release/1.0.x`** (not main):
+   ```bash
+   git push -u origin fix/short-description
+   gh pr create --base release/1.0.x --fill
+   ```
+3. Tag releases from the maintenance branch:
+   ```bash
+   git checkout release/1.0.x && git pull
+   git tag v1.0.1 && git push origin v1.0.1
+   ```
+4. Cherry-pick to the maintenance branch when a fix on `main` also applies to 1.0.x.
+
+**Docker image tags:**
+- `:latest` is only set for stable releases (no `-rc`, `-beta`, etc.)
+- `:1.0`, `:1.1` series tags are set automatically via semver parsing
+- `:dev` is only set for `main` branch pushes
 
 ### Other Git Rules
 


### PR DESCRIPTION
## Summary
Adds CI and Docker publish support for long-lived `release/X.Y.x` maintenance branches so we can ship 1.0.x bug fixes while `main` moves to 1.1.x.

## Changes
- **ci.yml**: Add `release/**` glob to push/PR branch triggers. Run integration tests on release branch pushes (previously main-only).
- **docker-publish.yml**: Only set Docker `:latest` tag on stable releases (tags without `-rc`, `-beta`, etc.), preventing a 1.0.x patch from overwriting `:latest` after 1.1.0 ships.
- **CLAUDE.md**: Document maintenance branch workflow — how to create fix PRs against `release/1.0.x`, tag releases, and cherry-pick.

## After merge
1. Create the `release/1.0.x` branch from `v1.0.0-rc.5`
2. Add branch protection rule for `release/**` in GitHub Settings

## Test plan
- [x] CI passes on this PR
- [x] After merge, create `release/1.0.x` branch and verify CI triggers on a test PR against it