### PR TITLE
fix: frontend-backend API compat (profile routes, multipart upload, DT metrics)

### DIFF
--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -36,6 +36,7 @@ pub mod peer;
 pub mod peers;
 pub mod permissions;
 pub mod plugins;
+pub mod profile;
 pub mod promotion;
 pub mod pub_registry;
 pub mod puppet;

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -1,0 +1,100 @@
+//! Profile handlers — endpoints scoped to the authenticated user.
+
+use axum::{
+    extract::{Extension, Path, State},
+    routing::{delete, get},
+    Json, Router,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::api::middleware::auth::AuthExtension;
+use crate::api::SharedState;
+use crate::error::Result;
+use crate::services::auth_service::AuthService;
+
+use super::users::{ApiTokenCreatedResponse, ApiTokenListResponse, ApiTokenResponse};
+
+/// Create profile routes
+pub fn router() -> Router<SharedState> {
+    Router::new()
+        .route(
+            "/access-tokens",
+            get(list_access_tokens).post(create_access_token),
+        )
+        .route("/access-tokens/:token_id", delete(revoke_access_token))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateAccessTokenRequest {
+    pub name: String,
+    pub scopes: Option<Vec<String>>,
+    pub expires_in_days: Option<i64>,
+}
+
+/// List the authenticated user's API tokens.
+async fn list_access_tokens(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+) -> Result<Json<ApiTokenListResponse>> {
+    let tokens = sqlx::query!(
+        r#"
+        SELECT id, name, token_prefix, scopes, expires_at, last_used_at, created_at
+        FROM api_tokens
+        WHERE user_id = $1
+        ORDER BY created_at DESC
+        "#,
+        auth.user_id
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| crate::error::AppError::Database(e.to_string()))?;
+
+    let items = tokens
+        .into_iter()
+        .map(|t| ApiTokenResponse {
+            id: t.id,
+            name: t.name,
+            token_prefix: t.token_prefix,
+            scopes: t.scopes,
+            expires_at: t.expires_at,
+            last_used_at: t.last_used_at,
+            created_at: t.created_at,
+        })
+        .collect();
+
+    Ok(Json(ApiTokenListResponse { items }))
+}
+
+/// Create an API token for the authenticated user.
+async fn create_access_token(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Json(payload): Json<CreateAccessTokenRequest>,
+) -> Result<Json<ApiTokenCreatedResponse>> {
+    let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
+    let scopes = payload.scopes.unwrap_or_else(|| vec!["read".to_string()]);
+    let (token, token_id) = auth_service
+        .generate_api_token(auth.user_id, &payload.name, scopes, payload.expires_in_days)
+        .await?;
+
+    Ok(Json(ApiTokenCreatedResponse {
+        id: token_id,
+        name: payload.name,
+        token,
+    }))
+}
+
+/// Revoke an API token belonging to the authenticated user.
+async fn revoke_access_token(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Path(token_id): Path<Uuid>,
+) -> Result<()> {
+    let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
+    auth_service
+        .revoke_api_token(token_id, auth.user_id)
+        .await?;
+    Ok(())
+}

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     body::Bytes,
-    extract::{Extension, Path, Query, State},
+    extract::{Extension, Multipart, Path, Query, State},
     http::header,
     response::IntoResponse,
     routing::get,
@@ -55,11 +55,15 @@ pub fn router() -> Router<SharedState> {
         )
         .route("/:key/members/:member_key", delete(remove_virtual_member))
         // Artifact routes nested under repository
-        .route("/:key/artifacts", get(list_artifacts))
+        .route(
+            "/:key/artifacts",
+            get(list_artifacts).post(upload_artifact_multipart),
+        )
         .route(
             "/:key/artifacts/*path",
             get(get_artifact_metadata)
                 .put(upload_artifact)
+                .post(upload_artifact_multipart_with_path)
                 .delete(delete_artifact),
         )
         // Download uses a separate route prefix to avoid wildcard conflict
@@ -578,6 +582,73 @@ pub async fn upload_artifact(
         created_at: artifact.created_at,
         metadata: None,
     }))
+}
+
+/// Upload artifact via multipart/form-data POST (with path in URL).
+///
+/// Accepts a multipart form with a `file` field. The URL path is used as the
+/// artifact path, falling back to the uploaded filename.
+async fn upload_artifact_multipart_with_path(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((key, path)): Path<(String, String)>,
+    multipart: Multipart,
+) -> Result<Json<ArtifactResponse>> {
+    let (body, filename) = extract_multipart_file(multipart).await?;
+    // Prefer the URL path; fall back to the filename from the form field
+    let artifact_path = if path.is_empty() || path == "/" {
+        filename
+    } else {
+        path
+    };
+    upload_artifact(
+        State(state),
+        Extension(auth),
+        Path((key, artifact_path)),
+        body,
+    )
+    .await
+}
+
+/// Upload artifact via multipart/form-data POST (no path in URL).
+///
+/// The artifact path comes from the `file` field's filename.
+async fn upload_artifact_multipart(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(key): Path<String>,
+    multipart: Multipart,
+) -> Result<Json<ArtifactResponse>> {
+    let (body, filename) = extract_multipart_file(multipart).await?;
+    upload_artifact(
+        State(state),
+        Extension(auth),
+        Path((key, filename)),
+        body,
+    )
+    .await
+}
+
+/// Extract the first file field from a multipart form.
+async fn extract_multipart_file(mut multipart: Multipart) -> Result<(Bytes, String)> {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| AppError::Validation(format!("Invalid multipart data: {e}")))?
+    {
+        // Accept any field that has a filename (i.e. a file upload)
+        let filename = field.file_name().map(|s| s.to_string());
+        if let Some(filename) = filename {
+            let data: Bytes = field
+                .bytes()
+                .await
+                .map_err(|e| AppError::Validation(format!("Failed to read file: {e}")))?;
+            return Ok((data, filename));
+        }
+    }
+    Err(AppError::Validation(
+        "No file field found in multipart form".to_string(),
+    ))
 }
 
 /// Download artifact

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -155,6 +155,14 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
+        // Profile routes (authenticated user context) with auth middleware
+        .nest(
+            "/profile",
+            handlers::profile::router().layer(middleware::from_fn_with_state(
+                auth_service.clone(),
+                auth_middleware,
+            )),
+        )
         // Group routes with auth middleware
         .nest(
             "/groups",

--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -189,28 +189,35 @@ pub struct DtPolicy {
 /// Project-level metrics from Dependency-Track
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DtProjectMetrics {
+    #[serde(default)]
     pub critical: i64,
+    #[serde(default)]
     pub high: i64,
+    #[serde(default)]
     pub medium: i64,
+    #[serde(default)]
     pub low: i64,
+    #[serde(default)]
     pub unassigned: i64,
+    #[serde(default)]
     pub vulnerabilities: Option<i64>,
-    #[serde(rename = "findingsTotal")]
+    #[serde(default, rename = "findingsTotal")]
     pub findings_total: i64,
-    #[serde(rename = "findingsAudited")]
+    #[serde(default, rename = "findingsAudited")]
     pub findings_audited: i64,
-    #[serde(rename = "findingsUnaudited")]
+    #[serde(default, rename = "findingsUnaudited")]
     pub findings_unaudited: i64,
+    #[serde(default)]
     pub suppressions: i64,
-    #[serde(rename = "inheritedRiskScore")]
+    #[serde(default, rename = "inheritedRiskScore")]
     pub inherited_risk_score: f64,
-    #[serde(rename = "policyViolationsFail")]
+    #[serde(default, rename = "policyViolationsFail")]
     pub policy_violations_fail: i64,
-    #[serde(rename = "policyViolationsWarn")]
+    #[serde(default, rename = "policyViolationsWarn")]
     pub policy_violations_warn: i64,
-    #[serde(rename = "policyViolationsInfo")]
+    #[serde(default, rename = "policyViolationsInfo")]
     pub policy_violations_info: i64,
-    #[serde(rename = "policyViolationsTotal")]
+    #[serde(default, rename = "policyViolationsTotal")]
     pub policy_violations_total: i64,
     #[serde(rename = "firstOccurrence")]
     pub first_occurrence: Option<i64>,
@@ -221,29 +228,37 @@ pub struct DtProjectMetrics {
 /// Portfolio-level metrics from Dependency-Track
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DtPortfolioMetrics {
+    #[serde(default)]
     pub critical: i64,
+    #[serde(default)]
     pub high: i64,
+    #[serde(default)]
     pub medium: i64,
+    #[serde(default)]
     pub low: i64,
+    #[serde(default)]
     pub unassigned: i64,
+    #[serde(default)]
     pub vulnerabilities: Option<i64>,
-    #[serde(rename = "findingsTotal")]
+    #[serde(default, rename = "findingsTotal")]
     pub findings_total: i64,
-    #[serde(rename = "findingsAudited")]
+    #[serde(default, rename = "findingsAudited")]
     pub findings_audited: i64,
-    #[serde(rename = "findingsUnaudited")]
+    #[serde(default, rename = "findingsUnaudited")]
     pub findings_unaudited: i64,
+    #[serde(default)]
     pub suppressions: i64,
-    #[serde(rename = "inheritedRiskScore")]
+    #[serde(default, rename = "inheritedRiskScore")]
     pub inherited_risk_score: f64,
-    #[serde(rename = "policyViolationsFail")]
+    #[serde(default, rename = "policyViolationsFail")]
     pub policy_violations_fail: i64,
-    #[serde(rename = "policyViolationsWarn")]
+    #[serde(default, rename = "policyViolationsWarn")]
     pub policy_violations_warn: i64,
-    #[serde(rename = "policyViolationsInfo")]
+    #[serde(default, rename = "policyViolationsInfo")]
     pub policy_violations_info: i64,
-    #[serde(rename = "policyViolationsTotal")]
+    #[serde(default, rename = "policyViolationsTotal")]
     pub policy_violations_total: i64,
+    #[serde(default)]
     pub projects: i64,
 }
 


### PR DESCRIPTION
## Summary
Fixes artifact-keeper/artifact-keeper-web#111 — three bugs reported when accessing the UI from a LAN deployment.

- **Token creation 404**: Added `/api/v1/profile/access-tokens` endpoints (GET/POST/DELETE) that resolve the authenticated user from the JWT, matching the frontend's expected API surface.
- **File upload 502/broken pipe**: Added POST + `multipart/form-data` upload handlers alongside the existing PUT + raw bytes on artifact routes. The frontend's FormData-based uploads are now accepted without any frontend changes.
- **DT portfolio metrics 500**: Added `#[serde(default)]` to all numeric fields in `DtProjectMetrics` and `DtPortfolioMetrics` so null/missing fields from fresh Dependency-Track installs no longer cause parse failures.

## Files Changed
- `backend/src/api/handlers/profile.rs` — new profile route handlers
- `backend/src/api/handlers/mod.rs` — register profile module
- `backend/src/api/routes.rs` — mount `/profile` routes with auth middleware
- `backend/src/api/handlers/repositories.rs` — add multipart POST upload handlers
- `backend/src/services/dependency_track_service.rs` — serde defaults on metrics structs

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 490 passed, 0 failed
- [ ] Deploy and verify token creation from profile page
- [ ] Deploy and verify file upload from repository page
- [ ] Deploy and verify DT metrics with fresh DT install