### PR TITLE
fix: update alpine/helm Docker tag from 3.14 to 3.16

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -285,7 +285,7 @@ services:
     profiles: ["deb", "all"]
 
   helm-test:
-    image: alpine/helm:3.14
+    image: alpine/helm:3.16
     container_name: e2e-test-helm
     depends_on:
       setup:


### PR DESCRIPTION
## Summary
- The `alpine/helm:3.14` image was removed from Docker Hub, causing the Helm native client E2E test to fail with `manifest unknown`
- Updated to `alpine/helm:3.16` which is available and fully compatible with the existing test script

## Test plan
- [ ] CI lint + unit tests pass
- [ ] E2E helm profile can pull the image successfully