### PR TITLE
fix: auto-enable NVD API 2.0 and add proxy passthrough for DTrack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,15 @@ JWT_EXPIRATION_SECS=86400
 # LDAP_URL=ldap://ldap.example.com:389
 # LDAP_BASE_DN=dc=example,dc=com
 
+# Dependency-Track proxy (required if DTrack is behind a corporate proxy)
+# Without this, NVD vulnerability mirroring will silently fail.
+# Supports BASIC, DIGEST, and NTLM authentication.
+# DTRACK_HTTP_PROXY_ADDRESS=proxy.example.com
+# DTRACK_HTTP_PROXY_PORT=8888
+# DTRACK_HTTP_PROXY_USERNAME=
+# DTRACK_HTTP_PROXY_PASSWORD=
+# DTRACK_NO_PROXY=localhost,127.0.0.1
+
 # Edge Node (for edge binary)
 # PRIMARY_URL=https://primary.example.com
 # EDGE_API_KEY=xxx

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -100,6 +100,12 @@ services:
       ALPINE_ENFORCE_AUTHENTICATION: "true"
       ALPINE_CORS_ENABLED: "true"
       ALPINE_CORS_ALLOW_ORIGIN: "*"
+      # Proxy configuration (required for NVD mirroring behind corporate proxies)
+      ALPINE_HTTP_PROXY_ADDRESS: ${DTRACK_HTTP_PROXY_ADDRESS:-}
+      ALPINE_HTTP_PROXY_PORT: ${DTRACK_HTTP_PROXY_PORT:-}
+      ALPINE_HTTP_PROXY_USERNAME: ${DTRACK_HTTP_PROXY_USERNAME:-}
+      ALPINE_HTTP_PROXY_PASSWORD: ${DTRACK_HTTP_PROXY_PASSWORD:-}
+      ALPINE_NO_PROXY: ${DTRACK_NO_PROXY:-localhost,127.0.0.1}
     volumes:
       - dev_dtrack_data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,12 @@ services:
       # Optional: Enable CORS for frontend
       ALPINE_CORS_ENABLED: "true"
       ALPINE_CORS_ALLOW_ORIGIN: "*"
+      # Proxy configuration (required for NVD mirroring behind corporate proxies)
+      ALPINE_HTTP_PROXY_ADDRESS: ${DTRACK_HTTP_PROXY_ADDRESS:-}
+      ALPINE_HTTP_PROXY_PORT: ${DTRACK_HTTP_PROXY_PORT:-}
+      ALPINE_HTTP_PROXY_USERNAME: ${DTRACK_HTTP_PROXY_USERNAME:-}
+      ALPINE_HTTP_PROXY_PASSWORD: ${DTRACK_HTTP_PROXY_PASSWORD:-}
+      ALPINE_NO_PROXY: ${DTRACK_NO_PROXY:-localhost,127.0.0.1}
     volumes:
       - dtrack_data:/data
     ports:

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -77,4 +77,18 @@ fi
 
 echo "$API_KEY" > "$API_KEY_FILE"
 echo "[dtrack-init] API key written to $API_KEY_FILE"
+
+# Enable NVD API 2.0 mirroring (NIST retired legacy feeds; DTrack 4.10.0+ supports API 2.0)
+echo "[dtrack-init] Enabling NVD API 2.0 vulnerability source..."
+NVD_RESULT=$(curl -sf -o /dev/null -w "%{http_code}" \
+  -X POST "$DT_URL/api/v1/configProperty" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"groupName":"vuln-source","propertyName":"nvd.feeds.url","propertyValue":"https://services.nvd.nist.gov/rest/json/cves/2.0"}')
+if [ "$NVD_RESULT" = "200" ]; then
+  echo "[dtrack-init] NVD API 2.0 source configured"
+else
+  echo "[dtrack-init] WARNING: NVD config returned HTTP $NVD_RESULT (may already be set or unsupported)"
+fi
+
 echo "[dtrack-init] Done"


### PR DESCRIPTION
## Summary
- NIST retired legacy NVD feeds, causing DTrack 4.x mirror sync to silently fail
- Extends `docker/init-dtrack.sh` to configure NVD API 2.0 via the DTrack REST API on first boot
- Adds proxy env var passthrough (`ALPINE_HTTP_PROXY_*`) to both compose files so DTrack can reach NVD behind corporate proxies
- Documents proxy config in `.env.example` with a note that NVD mirroring silently fails without it

## Test plan
- [ ] Deploy fresh stack and verify init-dtrack.sh logs "NVD API 2.0 source configured"
- [ ] Set proxy env vars and verify DTrack can mirror NVD through the proxy
- [ ] Verify existing deployments (where API key file already exists) skip the NVD config step gracefully
- [ ] Cherry-pick into `release/1.0.x` after merge

Closes #96