### PR TITLE
fix: ensure admin login works on fresh installs and fix dtrack startup race

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -122,6 +122,8 @@ services:
     image: alpine:3.20
     container_name: artifact-keeper-dev-dtrack-init
     depends_on:
+      postgres:
+        condition: service_healthy
       dependency-track-apiserver:
         condition: service_healthy
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     image: alpine:3.20
     container_name: artifact-keeper-dtrack-init
     depends_on:
+      postgres:
+        condition: service_healthy
       dependency-track-apiserver:
         condition: service_healthy
     volumes:


### PR DESCRIPTION
## Summary
- Fixes admin login failing on fresh Docker installs by explicitly setting `auth_provider = 'local'` and using `ON CONFLICT DO UPDATE` instead of `DO NOTHING` for the admin user provisioning
- Adds startup repair: on every boot, if an existing admin has a non-local `auth_provider`, it gets corrected automatically
- Fixes race condition where `dtrack-init` could start before PostgreSQL finished initializing by adding `postgres: condition: service_healthy` to its `depends_on`

## Test plan
- [ ] Fresh `docker compose up` with empty volumes — admin login should work with password from `admin.password`
- [ ] `docker compose down && docker compose up` with existing volumes — admin login still works
- [ ] Delete only the postgres volume, keep storage volume, restart — admin password gets re-synced
- [ ] Verify `dtrack-init` waits for both postgres and dependency-track before running

Closes #93