### PR TITLE
Add stale bot for fixed issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Close Fixed Issues
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  close-fixed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: 'status: fixed'
+          days-before-stale: 1
+          days-before-close: 0
+          stale-issue-label: 'closing-soon'
+          stale-issue-message: >
+            This issue was marked as fixed 1 day ago with no further feedback.
+            It will be closed shortly. If the fix doesn't work as expected,
+            please comment and we'll reopen it.
+          close-issue-message: >
+            Closed automatically after 1 day with no feedback since the fix was shipped.
+            Feel free to reopen if you run into any issues.
+          exempt-issue-labels: 'pinned,status: blocked'
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
## Summary
- Adds `actions/stale` workflow that auto-closes issues labeled `status: fixed` after 1 day with no feedback
- Runs every 6 hours + manual dispatch
- Issues labeled `pinned` or `status: blocked` are exempt
- PRs are not affected

## Workflow
1. Fix an issue and apply the `status: fixed` label
2. Bot checks every 6 hours — after 1 day of no comments, adds a warning message
3. Closes immediately after the warning if still no response
4. Reporter can reopen anytime if the fix doesn't work