### PR TITLE
Complete sync policy engine: peer labels, auto-evaluate, periodic re-eval

### DIFF
--- a/.sqlx/query-0026019d50481bf9a5174478422f825d85959de7427543821fcf5f0cec9b71b5.json
+++ b/.sqlx/query-0026019d50481bf9a5174478422f825d85959de7427543821fcf5f0cec9b71b5.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-0068d46eafae7f640db30b4fb99de8d0541f2971f0115d45c835d9cf61386df2.json
+++ b/.sqlx/query-0068d46eafae7f640db30b4fb99de8d0541f2971f0115d45c835d9cf61386df2.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }
@@ -223,7 +224,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-32f3ec8b490abed12f639651af4a5347b59999eb194a2137b2bcf236b00216a7.json
+++ b/.sqlx/query-32f3ec8b490abed12f639651af4a5347b59999eb194a2137b2bcf236b00216a7.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-6ccae2e872da4850c96d329452a1fa610c459985a464f416aadd5ed38fac0fb4.json
+++ b/.sqlx/query-6ccae2e872da4850c96d329452a1fa610c459985a464f416aadd5ed38fac0fb4.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-835b9dcf2f054b5bd6563277b0194179f39c394416c13b2cc5989827e3c8e96d.json
+++ b/.sqlx/query-835b9dcf2f054b5bd6563277b0194179f39c394416c13b2cc5989827e3c8e96d.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }
@@ -220,7 +221,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-8e71cd28dd731b118b023a6fc3456bc5bcba60e68723b0f1fb0e667063386238.json
+++ b/.sqlx/query-8e71cd28dd731b118b023a6fc3456bc5bcba60e68723b0f1fb0e667063386238.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-970f343d1d04542db54517b3e1db597d01f3e6c67ab2ee1d0a2d14c7b169cd4e.json
+++ b/.sqlx/query-970f343d1d04542db54517b3e1db597d01f3e6c67ab2ee1d0a2d14c7b169cd4e.json
@@ -79,7 +79,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/.sqlx/query-d54bbea9b8a936d8ac779c4aaada5f853ecd1124989d98715f6ca7e531731c4f.json
+++ b/.sqlx/query-d54bbea9b8a936d8ac779c4aaada5f853ecd1124989d98715f6ca7e531731c4f.json
@@ -64,7 +64,8 @@
                 "vagrant",
                 "opkg",
                 "p2",
-                "bazel"
+                "bazel",
+                "protobuf"
               ]
             }
           }

--- a/backend/migrations/052_peer_instance_labels.sql
+++ b/backend/migrations/052_peer_instance_labels.sql
@@ -1,0 +1,16 @@
+-- Peer instance labels: key:value tags for sync policy matching
+CREATE TABLE IF NOT EXISTS peer_instance_labels (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    peer_instance_id UUID NOT NULL REFERENCES peer_instances(id) ON DELETE CASCADE,
+    label_key VARCHAR(128) NOT NULL,
+    label_value VARCHAR(256) NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(peer_instance_id, label_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_peer_instance_labels_peer ON peer_instance_labels(peer_instance_id);
+CREATE INDEX IF NOT EXISTS idx_peer_instance_labels_key_value ON peer_instance_labels(label_key, label_value);
+
+COMMENT ON TABLE peer_instance_labels IS 'Key:value labels on peer instances for sync policy matching and organization';
+COMMENT ON COLUMN peer_instance_labels.label_key IS 'Label key (e.g. region, tier, environment)';
+COMMENT ON COLUMN peer_instance_labels.label_value IS 'Label value (e.g. us-east, critical, production). Empty string for bare tags.';

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -33,6 +33,7 @@ pub mod nuget;
 pub mod oci_v2;
 pub mod packages;
 pub mod peer;
+pub mod peer_instance_labels;
 pub mod peers;
 pub mod permissions;
 pub mod plugins;

--- a/backend/src/api/handlers/peer_instance_labels.rs
+++ b/backend/src/api/handlers/peer_instance_labels.rs
@@ -1,0 +1,471 @@
+//! Peer instance label management handlers.
+
+use axum::{
+    extract::{Extension, Path, State},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::{OpenApi, ToSchema};
+use uuid::Uuid;
+
+use crate::api::middleware::auth::AuthExtension;
+use crate::api::SharedState;
+use crate::error::{AppError, Result};
+use crate::services::peer_instance_label_service::{PeerInstanceLabel, PeerInstanceLabelService};
+use crate::services::peer_instance_service::PeerInstanceService;
+use crate::services::repository_label_service::LabelEntry;
+use crate::services::sync_policy_service::SyncPolicyService;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(list_labels, set_labels, add_label, delete_label),
+    components(schemas(PeerLabelResponse, SetPeerLabelsRequest, PeerLabelEntrySchema, AddPeerLabelRequest, PeerLabelsListResponse)),
+    tags((name = "peer-instance-labels", description = "Peer instance label management"))
+)]
+pub struct PeerInstanceLabelsApiDoc;
+
+/// Create peer instance label routes (nested under /api/v1/peers/:id/labels).
+pub fn peer_labels_router() -> Router<SharedState> {
+    Router::new()
+        .route("/:id/labels", get(list_labels).put(set_labels))
+        .route(
+            "/:id/labels/:label_key",
+            post(add_label).delete(delete_label),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Request / Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PeerLabelResponse {
+    pub id: Uuid,
+    pub peer_instance_id: Uuid,
+    pub key: String,
+    pub value: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PeerLabelsListResponse {
+    pub items: Vec<PeerLabelResponse>,
+    pub total: usize,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetPeerLabelsRequest {
+    pub labels: Vec<PeerLabelEntrySchema>,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema, Clone)]
+pub struct PeerLabelEntrySchema {
+    pub key: String,
+    #[serde(default)]
+    pub value: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AddPeerLabelRequest {
+    #[serde(default)]
+    pub value: String,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_auth(auth: Option<AuthExtension>) -> Result<AuthExtension> {
+    auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))
+}
+
+fn label_to_response(label: PeerInstanceLabel) -> PeerLabelResponse {
+    PeerLabelResponse {
+        id: label.id,
+        peer_instance_id: label.peer_instance_id,
+        key: label.label_key,
+        value: label.label_value,
+        created_at: label.created_at,
+    }
+}
+
+fn labels_list_response(labels: Vec<PeerInstanceLabel>) -> PeerLabelsListResponse {
+    let items: Vec<PeerLabelResponse> = labels.into_iter().map(label_to_response).collect();
+    let total = items.len();
+    PeerLabelsListResponse { items, total }
+}
+
+/// Fire-and-forget sync policy re-evaluation for a peer.
+async fn trigger_peer_policy_evaluation(db: &sqlx::PgPool, peer_id: Uuid) {
+    let svc = SyncPolicyService::new(db.clone());
+    if let Err(e) = svc.evaluate_for_peer(peer_id).await {
+        tracing::warn!(
+            "Sync policy re-evaluation failed for peer {}: {}",
+            peer_id,
+            e
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// List all labels on a peer instance
+#[utoipa::path(
+    get,
+    path = "/{id}/labels",
+    context_path = "/api/v1/peers",
+    tag = "peer-instance-labels",
+    params(
+        ("id" = Uuid, Path, description = "Peer instance ID")
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Labels retrieved", body = PeerLabelsListResponse),
+        (status = 404, description = "Peer instance not found")
+    )
+)]
+async fn list_labels(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<PeerLabelsListResponse>> {
+    let _auth = require_auth(auth)?;
+
+    let peer_service = PeerInstanceService::new(state.db.clone());
+    let _peer = peer_service.get_by_id(id).await?;
+
+    let label_service = PeerInstanceLabelService::new(state.db.clone());
+    let labels = label_service.get_labels(id).await?;
+
+    Ok(Json(labels_list_response(labels)))
+}
+
+/// Set all labels on a peer instance (replaces existing)
+#[utoipa::path(
+    put,
+    path = "/{id}/labels",
+    context_path = "/api/v1/peers",
+    tag = "peer-instance-labels",
+    params(
+        ("id" = Uuid, Path, description = "Peer instance ID")
+    ),
+    request_body = SetPeerLabelsRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Labels updated", body = PeerLabelsListResponse),
+        (status = 404, description = "Peer instance not found")
+    )
+)]
+async fn set_labels(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<SetPeerLabelsRequest>,
+) -> Result<Json<PeerLabelsListResponse>> {
+    let _auth = require_auth(auth)?;
+
+    let peer_service = PeerInstanceService::new(state.db.clone());
+    let _peer = peer_service.get_by_id(id).await?;
+
+    let entries: Vec<LabelEntry> = payload
+        .labels
+        .into_iter()
+        .map(|l| LabelEntry {
+            key: l.key,
+            value: l.value,
+        })
+        .collect();
+
+    let label_service = PeerInstanceLabelService::new(state.db.clone());
+    let labels = label_service.set_labels(id, &entries).await?;
+
+    trigger_peer_policy_evaluation(&state.db, id).await;
+
+    Ok(Json(labels_list_response(labels)))
+}
+
+/// Add or update a single label on a peer instance
+#[utoipa::path(
+    post,
+    path = "/{id}/labels/{label_key}",
+    context_path = "/api/v1/peers",
+    tag = "peer-instance-labels",
+    params(
+        ("id" = Uuid, Path, description = "Peer instance ID"),
+        ("label_key" = String, Path, description = "Label key to set")
+    ),
+    request_body = AddPeerLabelRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Label added/updated", body = PeerLabelResponse),
+        (status = 404, description = "Peer instance not found")
+    )
+)]
+async fn add_label(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((id, label_key)): Path<(Uuid, String)>,
+    Json(payload): Json<AddPeerLabelRequest>,
+) -> Result<Json<PeerLabelResponse>> {
+    let _auth = require_auth(auth)?;
+
+    let peer_service = PeerInstanceService::new(state.db.clone());
+    let _peer = peer_service.get_by_id(id).await?;
+
+    let label_service = PeerInstanceLabelService::new(state.db.clone());
+    let label = label_service
+        .add_label(id, &label_key, &payload.value)
+        .await?;
+
+    trigger_peer_policy_evaluation(&state.db, id).await;
+
+    Ok(Json(label_to_response(label)))
+}
+
+/// Delete a label by key from a peer instance
+#[utoipa::path(
+    delete,
+    path = "/{id}/labels/{label_key}",
+    context_path = "/api/v1/peers",
+    tag = "peer-instance-labels",
+    params(
+        ("id" = Uuid, Path, description = "Peer instance ID"),
+        ("label_key" = String, Path, description = "Label key to remove")
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 204, description = "Label removed"),
+        (status = 404, description = "Peer instance or label not found")
+    )
+)]
+async fn delete_label(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((id, label_key)): Path<(Uuid, String)>,
+) -> Result<axum::http::StatusCode> {
+    let _auth = require_auth(auth)?;
+
+    let peer_service = PeerInstanceService::new(state.db.clone());
+    let _peer = peer_service.get_by_id(id).await?;
+
+    let label_service = PeerInstanceLabelService::new(state.db.clone());
+    label_service.remove_label(id, &label_key).await?;
+
+    trigger_peer_policy_evaluation(&state.db, id).await;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_peer_labels_request_deserialization() {
+        let json =
+            r#"{"labels": [{"key": "region", "value": "us-east"}, {"key": "tier", "value": "1"}]}"#;
+        let req: SetPeerLabelsRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.labels.len(), 2);
+        assert_eq!(req.labels[0].key, "region");
+        assert_eq!(req.labels[0].value, "us-east");
+    }
+
+    #[test]
+    fn test_set_peer_labels_request_empty_labels() {
+        let json = r#"{"labels": []}"#;
+        let req: SetPeerLabelsRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.labels.len(), 0);
+    }
+
+    #[test]
+    fn test_add_peer_label_request_with_value() {
+        let json = r#"{"value": "us-west-2"}"#;
+        let req: AddPeerLabelRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.value, "us-west-2");
+    }
+
+    #[test]
+    fn test_add_peer_label_request_empty_value_default() {
+        let json = r#"{}"#;
+        let req: AddPeerLabelRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.value, "");
+    }
+
+    #[test]
+    fn test_peer_label_response_serialization() {
+        let resp = PeerLabelResponse {
+            id: uuid::Uuid::nil(),
+            peer_instance_id: uuid::Uuid::nil(),
+            key: "region".to_string(),
+            value: "eu-west-1".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("region"));
+        assert!(json.contains("eu-west-1"));
+        assert!(json.contains("peer_instance_id"));
+    }
+
+    #[test]
+    fn test_peer_labels_list_response_serialization() {
+        let resp = PeerLabelsListResponse {
+            items: vec![PeerLabelResponse {
+                id: uuid::Uuid::nil(),
+                peer_instance_id: uuid::Uuid::nil(),
+                key: "env".to_string(),
+                value: "prod".to_string(),
+                created_at: chrono::Utc::now(),
+            }],
+            total: 1,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"total\":1"));
+        assert!(json.contains("\"items\""));
+    }
+
+    #[test]
+    fn test_label_to_response_mapping() {
+        let label = PeerInstanceLabel {
+            id: uuid::Uuid::nil(),
+            peer_instance_id: uuid::Uuid::nil(),
+            label_key: "region".to_string(),
+            label_value: "us-east-1".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let resp = label_to_response(label);
+        assert_eq!(resp.key, "region");
+        assert_eq!(resp.value, "us-east-1");
+        assert_eq!(resp.id, uuid::Uuid::nil());
+    }
+
+    #[test]
+    fn test_labels_list_response_helper() {
+        let labels = vec![
+            PeerInstanceLabel {
+                id: uuid::Uuid::nil(),
+                peer_instance_id: uuid::Uuid::nil(),
+                label_key: "a".to_string(),
+                label_value: "1".to_string(),
+                created_at: chrono::Utc::now(),
+            },
+            PeerInstanceLabel {
+                id: uuid::Uuid::nil(),
+                peer_instance_id: uuid::Uuid::nil(),
+                label_key: "b".to_string(),
+                label_value: "2".to_string(),
+                created_at: chrono::Utc::now(),
+            },
+        ];
+        let resp = labels_list_response(labels);
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].key, "a");
+        assert_eq!(resp.items[1].key, "b");
+    }
+
+    #[test]
+    fn test_labels_list_response_empty() {
+        let resp = labels_list_response(vec![]);
+        assert_eq!(resp.total, 0);
+        assert!(resp.items.is_empty());
+    }
+
+    #[test]
+    fn test_peer_label_response_json_contract() {
+        let resp = PeerLabelResponse {
+            id: uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            peer_instance_id: uuid::Uuid::parse_str("660e8400-e29b-41d4-a716-446655440000")
+                .unwrap(),
+            key: "region".to_string(),
+            value: "us-east-1".to_string(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-01-15T10:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+
+        assert!(json.get("id").is_some(), "Missing 'id' field");
+        assert!(
+            json.get("peer_instance_id").is_some(),
+            "Missing 'peer_instance_id' field"
+        );
+        assert!(json.get("key").is_some(), "Missing 'key' field");
+        assert!(json.get("value").is_some(), "Missing 'value' field");
+        assert!(
+            json.get("created_at").is_some(),
+            "Missing 'created_at' field"
+        );
+
+        let obj = json.as_object().unwrap();
+        assert_eq!(
+            obj.len(),
+            5,
+            "PeerLabelResponse should have exactly 5 fields, got: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_peer_labels_list_response_json_contract() {
+        let resp = PeerLabelsListResponse {
+            items: vec![],
+            total: 0,
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+
+        assert!(json.get("items").is_some(), "Missing 'items' field");
+        assert!(json.get("total").is_some(), "Missing 'total' field");
+        assert!(json["items"].is_array());
+        assert_eq!(json["total"], 0);
+    }
+
+    #[test]
+    fn test_set_peer_labels_request_rejects_missing_labels_field() {
+        let json = r#"{}"#;
+        let result = serde_json::from_str::<SetPeerLabelsRequest>(json);
+        assert!(
+            result.is_err(),
+            "SetPeerLabelsRequest should require 'labels' field"
+        );
+    }
+
+    #[test]
+    fn test_peer_label_entry_schema_with_default_value() {
+        let json = r#"{"key": "production"}"#;
+        let entry: PeerLabelEntrySchema = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.key, "production");
+        assert_eq!(entry.value, "");
+    }
+
+    #[test]
+    fn test_peer_label_entry_schema_roundtrip() {
+        let entry = PeerLabelEntrySchema {
+            key: "region".to_string(),
+            value: "eu-west-1".to_string(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let deserialized: PeerLabelEntrySchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.key, "region");
+        assert_eq!(deserialized.value, "eu-west-1");
+    }
+
+    #[test]
+    fn test_label_to_response_maps_db_fields_to_api_fields() {
+        let label = PeerInstanceLabel {
+            id: uuid::Uuid::new_v4(),
+            peer_instance_id: uuid::Uuid::new_v4(),
+            label_key: "db_field_name".to_string(),
+            label_value: "db_field_value".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let resp = label_to_response(label.clone());
+
+        assert_eq!(resp.key, label.label_key);
+        assert_eq!(resp.value, label.label_value);
+        assert_eq!(resp.id, label.id);
+        assert_eq!(resp.peer_instance_id, label.peer_instance_id);
+    }
+}

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -118,6 +118,7 @@ pub fn build_openapi() -> utoipa::openapi::OpenApi {
     doc.merge(super::handlers::tree::TreeApiDoc::openapi());
     doc.merge(super::handlers::repository_labels::RepositoryLabelsApiDoc::openapi());
     doc.merge(super::handlers::sync_policies::SyncPoliciesApiDoc::openapi());
+    doc.merge(super::handlers::peer_instance_labels::PeerInstanceLabelsApiDoc::openapi());
 
     doc
 }

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -229,6 +229,7 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         .nest(
             "/peers",
             handlers::peers::router()
+                .merge(handlers::peer_instance_labels::peer_labels_router())
                 .nest("/:id/transfer", handlers::transfer::router())
                 .nest("/:id/connections", handlers::peer::peer_router())
                 .nest("/:id/chunks", handlers::peer::chunk_router())

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -20,6 +20,7 @@ pub mod nexus_client;
 pub mod oidc_service;
 pub mod openscap_scanner;
 pub mod package_service;
+pub mod peer_instance_label_service;
 pub mod peer_instance_service;
 pub mod peer_service;
 pub mod plugin_registry;

--- a/backend/src/services/peer_instance_label_service.rs
+++ b/backend/src/services/peer_instance_label_service.rs
@@ -1,0 +1,229 @@
+//! Peer instance label management service.
+//!
+//! Provides CRUD operations for key:value labels on peer instances,
+//! used for sync policy matching and organizational grouping.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::{AppError, Result};
+use crate::services::repository_label_service::LabelEntry;
+
+/// A label attached to a peer instance.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct PeerInstanceLabel {
+    pub id: Uuid,
+    pub peer_instance_id: Uuid,
+    pub label_key: String,
+    pub label_value: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Service for managing peer instance labels.
+pub struct PeerInstanceLabelService {
+    db: PgPool,
+}
+
+impl PeerInstanceLabelService {
+    pub fn new(db: PgPool) -> Self {
+        Self { db }
+    }
+
+    /// Get all labels for a peer instance, ordered by key.
+    pub async fn get_labels(&self, peer_instance_id: Uuid) -> Result<Vec<PeerInstanceLabel>> {
+        let labels: Vec<PeerInstanceLabel> = sqlx::query_as(
+            r#"
+            SELECT id, peer_instance_id, label_key, label_value, created_at
+            FROM peer_instance_labels
+            WHERE peer_instance_id = $1
+            ORDER BY label_key
+            "#,
+        )
+        .bind(peer_instance_id)
+        .fetch_all(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(labels)
+    }
+
+    /// Replace all labels on a peer instance with the given set.
+    pub async fn set_labels(
+        &self,
+        peer_instance_id: Uuid,
+        labels: &[LabelEntry],
+    ) -> Result<Vec<PeerInstanceLabel>> {
+        let mut tx = self.db.begin().await?;
+
+        sqlx::query("DELETE FROM peer_instance_labels WHERE peer_instance_id = $1")
+            .bind(peer_instance_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        for label in labels {
+            sqlx::query(
+                r#"
+                INSERT INTO peer_instance_labels (peer_instance_id, label_key, label_value)
+                VALUES ($1, $2, $3)
+                "#,
+            )
+            .bind(peer_instance_id)
+            .bind(&label.key)
+            .bind(&label.value)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
+        tx.commit().await?;
+
+        self.get_labels(peer_instance_id).await
+    }
+
+    /// Add or update a single label (upsert by key).
+    pub async fn add_label(
+        &self,
+        peer_instance_id: Uuid,
+        key: &str,
+        value: &str,
+    ) -> Result<PeerInstanceLabel> {
+        let label: PeerInstanceLabel = sqlx::query_as(
+            r#"
+            INSERT INTO peer_instance_labels (peer_instance_id, label_key, label_value)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (peer_instance_id, label_key) DO UPDATE SET label_value = $3
+            RETURNING id, peer_instance_id, label_key, label_value, created_at
+            "#,
+        )
+        .bind(peer_instance_id)
+        .bind(key)
+        .bind(value)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(label)
+    }
+
+    /// Remove a label by key. Returns true if a label was deleted.
+    pub async fn remove_label(&self, peer_instance_id: Uuid, key: &str) -> Result<bool> {
+        let result = sqlx::query(
+            "DELETE FROM peer_instance_labels WHERE peer_instance_id = $1 AND label_key = $2",
+        )
+        .bind(peer_instance_id)
+        .bind(key)
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Find peer instances matching all given label selectors.
+    ///
+    /// Each selector specifies a key and optional value. If the value is empty,
+    /// any peer with that key (regardless of value) matches. All selectors
+    /// must match (AND semantics).
+    pub async fn find_peers_by_labels(&self, selectors: &[LabelEntry]) -> Result<Vec<Uuid>> {
+        if selectors.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut peer_ids: Option<Vec<Uuid>> = None;
+
+        for selector in selectors {
+            let ids: Vec<Uuid> = if selector.value.is_empty() {
+                sqlx::query_scalar(
+                    "SELECT peer_instance_id FROM peer_instance_labels WHERE label_key = $1",
+                )
+                .bind(&selector.key)
+                .fetch_all(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?
+            } else {
+                sqlx::query_scalar(
+                    "SELECT peer_instance_id FROM peer_instance_labels WHERE label_key = $1 AND label_value = $2",
+                )
+                .bind(&selector.key)
+                .bind(&selector.value)
+                .fetch_all(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?
+            };
+
+            peer_ids = Some(match peer_ids {
+                None => ids,
+                Some(existing) => existing.into_iter().filter(|id| ids.contains(id)).collect(),
+            });
+        }
+
+        Ok(peer_ids.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peer_instance_label_serialization() {
+        let label = PeerInstanceLabel {
+            id: Uuid::nil(),
+            peer_instance_id: Uuid::nil(),
+            label_key: "region".to_string(),
+            label_value: "us-east-1".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let json: serde_json::Value = serde_json::to_value(&label).unwrap();
+        assert!(json.get("label_key").is_some());
+        assert!(json.get("label_value").is_some());
+        assert!(json.get("peer_instance_id").is_some());
+    }
+
+    #[test]
+    fn test_peer_instance_label_clone() {
+        let label = PeerInstanceLabel {
+            id: Uuid::new_v4(),
+            peer_instance_id: Uuid::new_v4(),
+            label_key: "tier".to_string(),
+            label_value: "critical".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let cloned = label.clone();
+        assert_eq!(cloned.id, label.id);
+        assert_eq!(cloned.label_key, "tier");
+    }
+
+    #[test]
+    fn test_peer_instance_label_field_names() {
+        let label = PeerInstanceLabel {
+            id: Uuid::nil(),
+            peer_instance_id: Uuid::nil(),
+            label_key: "env".to_string(),
+            label_value: "prod".to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let json: serde_json::Value = serde_json::to_value(&label).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(
+            obj.len(),
+            5,
+            "PeerInstanceLabel should have exactly 5 fields"
+        );
+        assert!(obj.contains_key("id"));
+        assert!(obj.contains_key("peer_instance_id"));
+        assert!(obj.contains_key("label_key"));
+        assert!(obj.contains_key("label_value"));
+        assert!(obj.contains_key("created_at"));
+    }
+
+    #[test]
+    fn test_service_new() {
+        fn _assert_constructor_exists(_db: sqlx::PgPool) {
+            let _svc = PeerInstanceLabelService::new(_db);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes the declarative sync policy engine by filling the three remaining gaps:

- **Peer instance labels**: New `peer_instance_labels` table, `PeerInstanceLabelService`, and REST API (`GET/PUT/POST/DELETE /api/v1/peers/:id/labels`). Enables `PeerSelector.match_labels` to resolve peers by label instead of returning empty.
- **Auto-evaluate triggers**: Repository label changes, peer label changes, and new peer registration now automatically re-evaluate sync policies and update `peer_repo_subscriptions`.
- **Periodic re-evaluation**: 5-minute scheduler tick calls `evaluate_policies()` to catch any drift.

## Changes

| File | Change |
|------|--------|
| `migrations/052_peer_instance_labels.sql` | New table mirroring `repository_labels` |
| `services/peer_instance_label_service.rs` | CRUD + `find_peers_by_labels()` with AND semantics |
| `handlers/peer_instance_labels.rs` | REST API with auto-evaluate on every mutation |
| `services/sync_policy_service.rs` | `resolve_peers()` now queries real peer labels |
| `handlers/repository_labels.rs` | Triggers `evaluate_for_repository()` on label changes |
| `handlers/peers.rs` | Triggers `evaluate_for_peer()` on peer registration |
| `services/scheduler_service.rs` | 5-min periodic `evaluate_policies()` tick |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace` — clean
- [x] `cargo test --workspace --lib` — 673 tests pass
- [x] SQLx offline cache updated
- [ ] Integration test: create peer → add labels → create policy with `match_labels` → verify subscription
- [ ] Integration test: change repo label → verify subscription re-evaluated