### PR TITLE
Simplify quality gates code

### DIFF
--- a/backend/src/models/quality.rs
+++ b/backend/src/models/quality.rs
@@ -5,10 +5,6 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
-// ---------------------------------------------------------------------------
-// Database row structs
-// ---------------------------------------------------------------------------
-
 /// A single quality check execution record for an artifact.
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct QualityCheckResult {
@@ -111,27 +107,9 @@ pub struct QualityGate {
     pub updated_at: DateTime<Utc>,
 }
 
-/// A persisted record of a quality gate evaluation against an artifact.
-#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
-pub struct QualityGateEvaluationRecord {
-    pub id: Uuid,
-    pub artifact_id: Uuid,
-    pub quality_gate_id: Uuid,
-    pub passed: bool,
-    pub action: String,
-    pub health_score: Option<i32>,
-    pub details: Option<serde_json::Value>,
-    pub evaluated_at: DateTime<Utc>,
-}
-
-// ---------------------------------------------------------------------------
-// Non-persisted types used by the quality check service
-// ---------------------------------------------------------------------------
-
 /// A raw issue produced by a quality checker before it is persisted.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawQualityIssue {
-    /// Severity level: "critical", "high", "medium", "low", or "info".
     pub severity: String,
     pub category: String,
     pub title: String,

--- a/backend/src/services/metadata_checker.rs
+++ b/backend/src/services/metadata_checker.rs
@@ -8,10 +8,6 @@ use serde_json::{json, Value};
 
 use crate::models::quality::{QualityCheckOutput, RawQualityIssue};
 
-// ---------------------------------------------------------------------------
-// Point allocations
-// ---------------------------------------------------------------------------
-
 const POINTS_VERSION: i32 = 20;
 const POINTS_DESCRIPTION: i32 = 20;
 const POINTS_LICENSE: i32 = 30;
@@ -19,10 +15,6 @@ const POINTS_AUTHOR: i32 = 15;
 const POINTS_DOCS: i32 = 15;
 
 const PASSING_THRESHOLD: i32 = 50;
-
-// ---------------------------------------------------------------------------
-// MetadataCompletenessChecker
-// ---------------------------------------------------------------------------
 
 /// Quality checker that scores an artifact based on the completeness of its
 /// metadata fields. Designed to work across all 45+ package formats without
@@ -61,7 +53,7 @@ impl MetadataCompletenessChecker {
         let mut issues: Vec<RawQualityIssue> = Vec::new();
 
         // 1. Version present (20 pts)
-        let has_version = artifact_version.is_some() && !artifact_version.unwrap().is_empty();
+        let has_version = artifact_version.is_some_and(|v| !v.is_empty());
         if has_version {
             score += POINTS_VERSION;
         } else {
@@ -184,10 +176,6 @@ impl MetadataCompletenessChecker {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 /// Returns `true` if `val` is a non-empty JSON string.
 fn is_non_empty_string(val: &Value) -> bool {
     match val {
@@ -210,10 +198,6 @@ fn has_non_empty_field(obj: &Value, key: &str) -> bool {
         Some(Value::Bool(_)) | Some(Value::Number(_)) => true,
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

- Remove section divider comments across all quality gates files (code is self-documenting via doc comments)
- Delete unused `QualityGateEvaluationRecord` struct from models
- Extract `yaml_str_field()` helper in helm lint checker (deduplicates 5 identical YAML field lookups)
- Extract `check_min_score()` / `check_max_issues()` helpers in gate evaluation (replaces 7 inlined violation blocks)
- Refactor `compute_weighted_health_score()` from 4 `if let` blocks to array + `fold`
- Replace 5 separate `.filter().count()` grade passes with single-pass `match` loop in dashboard handler
- Use `is_some_and()` instead of `is_some() && unwrap()` in metadata checker

**Net: -158 lines** (293 removed, 135 added) across 5 files. All 709 tests pass, clippy clean.

## Test plan

- [x] `cargo test --workspace --lib` — 709 pass
- [x] `cargo clippy --workspace` — 0 warnings
- [x] `cargo fmt --check` — clean