### PR TITLE
Add Protobuf/BSR to supported formats in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,14 @@ flowchart TD
 
 | Format | Aliases | Ecosystem |
 |--------|---------|-----------|
-| **VS Code** | Cursor, Windsurf, Kiro | Extension marketplace |
+| **VS Code** | | Extension marketplace (VS Code, Cursor, Windsurf, Kiro) |
 | **JetBrains** | | Plugin repository |
+
+### Schemas
+
+| Format | Ecosystem |
+|--------|-----------|
+| **Protobuf / BSR** | Buf Schema Registry, Connect RPC |
 
 ### Other
 


### PR DESCRIPTION
## Summary
- Added Protobuf / BSR to the supported package formats table under a new "Schemas" category
- Fixed VS Code row — Cursor/Windsurf/Kiro are compatible clients, not enum aliases

Caught during doc sync audit.