### PR TITLE
fix: remove invalid continue-on-error from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
     with:
       image_tag: dev
     secrets: inherit
-    continue-on-error: true
 
   # ════════════════════════════════════════════════════════════════════════════
   # BUILD BINARIES


### PR DESCRIPTION
## Summary
GitHub Actions doesn't support `continue-on-error` on jobs using reusable workflows (`uses:`). This was preventing the release workflow from parsing at all.

The mesh-e2e-gate job is already optional in the dependency chain — `build-binaries` only depends on `e2e-gate`, not `mesh-e2e-gate`.

Needed to unblock the v1.1.0-rc.1 release pipeline.