### PR TITLE
chore: add SonarCloud project config for Rust analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=artifact-keeper_artifact-keeper
+sonar.organization=artifact-keeper
+
+# Rust backend source
+sonar.sources=backend/src
+sonar.tests=backend/src
+sonar.test.inclusions=**/*test*.rs,**/*tests*.rs
+
+# Exclude build artifacts, generated code, and test fixtures
+sonar.exclusions=target/**,.sqlx/**,.assets/**,scripts/**,data/**,site/**
+
+# Exclude test files and seed data from duplication detection
+sonar.cpd.exclusions=**/*test*.rs,**/*tests*.rs
+
+# Rust source encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- Adds `sonar-project.properties` pointing SonarCloud at `backend/src/` for Rust source analysis
- Excludes build artifacts (`target/`), SQLx cache (`.sqlx/`), test fixtures (`.assets/`), and scripts
- Enables SonarCloud Automatic Analysis via the GitHub App

The project existed on SonarCloud but had zero analyses because it didn't know where the Rust sources were (nested under `backend/src/` instead of repo root).

## Test plan

- [ ] Verify SonarCloud Automatic Analysis triggers on this PR
- [ ] Verify Rust source files appear in the SonarCloud dashboard