### PR TITLE
fix: pin UBI 9 images to version 9.5

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,5 +1,5 @@
 # ---------- Base: Rust toolchain on UBI 9 ----------
-FROM registry.access.redhat.com/ubi9/ubi AS rust-base
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rust-base
 RUN dnf install -y --nodocs \
     gcc gcc-c++ make pkg-config perl-core \
     openssl-devel zlib-devel xz-devel bzip2-devel \
@@ -36,7 +36,7 @@ ENV SQLX_OFFLINE=true
 RUN cargo build --release --bin artifact-keeper
 
 # ---------- Stage 4: Build minimal rootfs ----------
-FROM registry.access.redhat.com/ubi9/ubi AS rootfs-builder
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rootfs-builder
 
 # Install only essential runtime libraries into a clean rootfs
 RUN mkdir -p /mnt/rootfs && \
@@ -67,14 +67,14 @@ RUN echo 'artifact:x:1001:0:Artifact Keeper:/home/artifact:/sbin/nologin' >> /mn
                      /mnt/rootfs/home/artifact /mnt/rootfs/app
 
 # ---------- Stage 5: Download scanner CLIs ----------
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS scanners
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS scanners
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 curl tar gzip && \
     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin && \
     curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin && \
     microdnf clean all
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
 
 # Copy minimal rootfs (glibc, openssl, ca-certs, curl, user/group, dirs)
 COPY --from=rootfs-builder /mnt/rootfs /

--- a/docker/Dockerfile.openscap
+++ b/docker/Dockerfile.openscap
@@ -1,5 +1,5 @@
 # ---------- Stage 1: Build minimal rootfs with OpenSCAP ----------
-FROM registry.access.redhat.com/ubi9/ubi AS rootfs-builder
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rootfs-builder
 
 # Install OpenSCAP, SCAP content, and Python into a clean rootfs
 RUN mkdir -p /mnt/rootfs && \
@@ -20,7 +20,7 @@ RUN echo 'oscap:x:1001:0:OpenSCAP Scanner:/home/oscap:/sbin/nologin' >> /mnt/roo
     chown -R 1001:0 /mnt/rootfs/home/oscap /mnt/rootfs/scan-workspace
 
 # ---------- Stage 2: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
 
 # Copy minimal rootfs (oscap, scap-security-guide, python3, libs)
 COPY --from=rootfs-builder /mnt/rootfs /


### PR DESCRIPTION
## Summary
- Pin all UBI base images to `:9.5` tag across `Dockerfile.backend` and `Dockerfile.openscap`
- Resolves SonarCloud `docker:S6596` code smells (use specific version tags)

## Test plan
- [ ] Verify images build with pinned tags