### PR TITLE
Add container security scanning, STIG hardening, and cosign signing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,10 +145,154 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  scan-containers:
+    name: Security Scan
+    runs-on: ubuntu-24.04
+    needs: [build-backend, build-openscap]
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download backend amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-digests-amd64
+          path: /tmp/backend-digests
+
+      - name: Download openscap amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: openscap-digests-amd64
+          path: /tmp/openscap-digests
+
+      - name: Resolve image references
+        id: refs
+        run: |
+          BACKEND_DIGEST=$(ls /tmp/backend-digests/)
+          OPENSCAP_DIGEST=$(ls /tmp/openscap-digests/)
+          echo "backend=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:${BACKEND_DIGEST}" >> $GITHUB_OUTPUT
+          echo "openscap=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@sha256:${OPENSCAP_DIGEST}" >> $GITHUB_OUTPUT
+
+      # --- Trivy CVE scanning ---
+      # --ignore-unfixed: only fail on CVEs with available patches.
+      # Unpatched UBI base image CVEs (Red Hat's responsibility) are still
+      # reported in SARIF for visibility but don't block the build.
+      - name: Trivy scan - Backend
+        uses: aquasecurity/trivy-action@v0.31.0
+        with:
+          image-ref: ${{ steps.refs.outputs.backend }}
+          format: 'sarif'
+          output: 'backend-trivy.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Trivy scan - OpenSCAP
+        uses: aquasecurity/trivy-action@v0.31.0
+        if: success() || failure()
+        with:
+          image-ref: ${{ steps.refs.outputs.openscap }}
+          format: 'sarif'
+          output: 'openscap-trivy.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: '.'
+          category: 'container-scanning'
+
+      # --- OpenSCAP STIG compliance scan ---
+      - name: Install OpenSCAP
+        if: always()
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq openscap-utils libopenscap8 rpm2cpio
+
+      - name: Download SCAP Security Guide (RHEL 9 STIG content)
+        if: always()
+        run: |
+          curl -sSfL -o /tmp/ssg.rpm \
+            "https://github.com/ComplianceAsCode/content/releases/latest/download/scap-security-guide-latest.rpm"
+          mkdir -p /tmp/ssg && cd /tmp/ssg && rpm2cpio /tmp/ssg.rpm | cpio -idmv 2>/dev/null
+          SSG_DS=$(find /tmp/ssg -name "ssg-rhel9-ds.xml" | head -1)
+          echo "SSG_DS=${SSG_DS}" >> $GITHUB_ENV
+
+      - name: STIG scan - Backend
+        if: always()
+        run: |
+          docker pull ${{ steps.refs.outputs.backend }}
+          CID=$(docker create ${{ steps.refs.outputs.backend }})
+          mkdir -p /tmp/rootfs/backend
+          docker export ${CID} | tar -xf - -C /tmp/rootfs/backend
+          docker rm ${CID}
+
+          oscap xccdf eval \
+            --profile xccdf_org.ssgproject.content_profile_stig \
+            --results backend-stig-results.xml \
+            --report backend-stig-report.html \
+            --chroot /tmp/rootfs/backend \
+            "${SSG_DS}" || true
+
+      - name: STIG scan - OpenSCAP
+        if: always()
+        run: |
+          docker pull ${{ steps.refs.outputs.openscap }}
+          CID=$(docker create ${{ steps.refs.outputs.openscap }})
+          mkdir -p /tmp/rootfs/openscap
+          docker export ${CID} | tar -xf - -C /tmp/rootfs/openscap
+          docker rm ${CID}
+
+          oscap xccdf eval \
+            --profile xccdf_org.ssgproject.content_profile_stig \
+            --results openscap-stig-results.xml \
+            --report openscap-stig-report.html \
+            --chroot /tmp/rootfs/openscap \
+            "${SSG_DS}" || true
+
+      - name: Upload STIG reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stig-compliance-reports
+          path: |
+            *-stig-report.html
+            *-stig-results.xml
+          retention-days: 90
+
+      - name: STIG compliance summary
+        if: always()
+        run: |
+          echo "## Container Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Trivy CVE Scan" >> $GITHUB_STEP_SUMMARY
+          echo "- **Policy**: Fail on CRITICAL or HIGH severity CVEs" >> $GITHUB_STEP_SUMMARY
+          echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
+          echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### OpenSCAP STIG Compliance" >> $GITHUB_STEP_SUMMARY
+          echo "- **Profile**: DISA STIG for RHEL 9" >> $GITHUB_STEP_SUMMARY
+          echo "- HTML reports uploaded as workflow artifacts" >> $GITHUB_STEP_SUMMARY
+
   merge-backend:
     name: Backend Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: build-backend
+    needs: [build-backend, scan-containers]
     permissions:
       contents: read
       packages: write
@@ -165,6 +309,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -195,21 +342,30 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
+        id: inspect
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.meta.outputs.version }}
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Sign image with cosign (keyless)
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}
-          subject-digest: ${{ needs.build-backend.outputs.digest-amd64 }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
   merge-openscap:
     name: OpenSCAP Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: build-openscap
+    needs: [build-openscap, scan-containers]
     permissions:
       contents: read
       packages: write
@@ -226,6 +382,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -256,14 +415,23 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
+        id: inspect
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:${{ steps.meta.outputs.version }}
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
+            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Sign image with cosign (keyless)
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@${{ steps.inspect.outputs.digest }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}
-          subject-digest: ${{ needs.build-openscap.outputs.digest-amd64 }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
         continue-on-error: true
 
@@ -282,3 +450,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### OpenSCAP" >> $GITHUB_STEP_SUMMARY
           echo "\`${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Supply Chain Security" >> $GITHUB_STEP_SUMMARY
+          echo "- All images signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing (GitHub OIDC)" >> $GITHUB_STEP_SUMMARY
+          echo "- Verify: \`cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity-regexp='https://github.com/artifact-keeper/.*' ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,6 +1,6 @@
 # ---------- Base: Rust toolchain on UBI 9 ----------
 # syntax=docker/dockerfile:1
-FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rust-base
+FROM registry.access.redhat.com/ubi9/ubi:latest AS rust-base
 RUN dnf install -y --nodocs \
     gcc gcc-c++ make pkg-config perl-core \
     openssl-devel zlib-devel xz-devel bzip2-devel \
@@ -46,7 +46,7 @@ ENV SQLX_OFFLINE=true
 RUN cargo build --release --bin artifact-keeper
 
 # ---------- Stage 4: Build minimal rootfs ----------
-FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rootfs-builder
+FROM registry.access.redhat.com/ubi9/ubi:latest AS rootfs-builder
 
 # Install only essential runtime libraries into a clean rootfs
 RUN mkdir -p /mnt/rootfs && \
@@ -76,15 +76,52 @@ RUN echo 'artifact:x:1001:0:Artifact Keeper:/home/artifact:/sbin/nologin' >> /mn
     chown -R 1001:0 /mnt/rootfs/data /mnt/rootfs/scan-workspace \
                      /mnt/rootfs/home/artifact /mnt/rootfs/app
 
+# ---------- STIG hardening (applicable subset for ubi-micro) ----------
+# Derived from DISA STIG controls applied in registry.access.redhat.com/ubi9/ubi-stig
+
+# Crypto policy: FIPS-grade defaults for OpenSSL
+RUN if [ -f /mnt/rootfs/etc/pki/tls/openssl.cnf ]; then \
+      echo -e "\n[algorithm_sect]\ndefault_properties = fips=yes" >> /mnt/rootfs/etc/pki/tls/openssl.cnf; \
+    fi
+
+# Disable core dumps (xccdf_org.ssgproject.content_rule_disable_users_coredumps)
+RUN mkdir -p /mnt/rootfs/etc/security/limits.d && \
+    echo "* hard core 0" > /mnt/rootfs/etc/security/limits.d/50-coredump.conf
+
+# Max concurrent login sessions (xccdf_org.ssgproject.content_rule_accounts_max_concurrent_login_sessions)
+RUN echo "* hard maxlogins 10" > /mnt/rootfs/etc/security/limits.d/50-maxlogins.conf
+
+# Ensure no empty passwords (xccdf_org.ssgproject.content_rule_no_empty_passwords)
+RUN sed -i 's/\bnullok\b//g' /mnt/rootfs/etc/pam.d/* 2>/dev/null || true
+
+# Restrictive umask (xccdf_org.ssgproject.content_rule_accounts_umask_etc_login_defs)
+RUN if [ -f /mnt/rootfs/etc/login.defs ]; then \
+      sed -i 's/^UMASK.*/UMASK\t\t077/' /mnt/rootfs/etc/login.defs; \
+    fi
+
+# Clean machine-id (regenerated at runtime)
+RUN rm -f /mnt/rootfs/etc/machine-id && \
+    touch /mnt/rootfs/etc/machine-id && \
+    chmod 0444 /mnt/rootfs/etc/machine-id
+
+# Ensure GPG checking for packages (xccdf_org.ssgproject.content_rule_ensure_gpgcheck_local_packages)
+RUN if [ -f /mnt/rootfs/etc/dnf/dnf.conf ]; then \
+      sed -i 's/^localpkg_gpgcheck.*/localpkg_gpgcheck=1/' /mnt/rootfs/etc/dnf/dnf.conf || \
+      echo "localpkg_gpgcheck=1" >> /mnt/rootfs/etc/dnf/dnf.conf; \
+    fi
+
+# Remove any leftover cache/tmp artifacts
+RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
+
 # ---------- Stage 5: Download scanner CLIs ----------
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS scanners
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS scanners
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 tar gzip && \
     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin && \
     curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin && \
     microdnf clean all
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 # Copy minimal rootfs (glibc, openssl, ca-certs, curl, user/group, dirs)
 COPY --from=rootfs-builder /mnt/rootfs /

--- a/docker/Dockerfile.openscap
+++ b/docker/Dockerfile.openscap
@@ -1,9 +1,10 @@
 # ---------- Stage 1: Build minimal rootfs with OpenSCAP ----------
-FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rootfs-builder
+FROM registry.access.redhat.com/ubi9/ubi:latest AS rootfs-builder
 
 # Add CentOS 9 Stream repo for scap-security-guide (not in UBI repos)
-RUN dnf install -y --nodocs 'dnf-command(config-manager)' && \
-    dnf config-manager --add-repo https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+RUN ARCH=$(uname -m) && \
+    dnf install -y --nodocs 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo "https://mirror.stream.centos.org/9-stream/AppStream/${ARCH}/os/"
 
 # Install OpenSCAP, SCAP content, and Python into a clean rootfs
 RUN mkdir -p /mnt/rootfs && \
@@ -23,8 +24,38 @@ RUN echo 'oscap:x:1001:0:OpenSCAP Scanner:/home/oscap:/sbin/nologin' >> /mnt/roo
     mkdir -p /mnt/rootfs/home/oscap /mnt/rootfs/scan-workspace /mnt/rootfs/usr/local/bin && \
     chown -R 1001:0 /mnt/rootfs/home/oscap /mnt/rootfs/scan-workspace
 
+# ---------- STIG hardening (applicable subset for ubi-micro) ----------
+
+# Crypto policy: FIPS-grade defaults for OpenSSL
+RUN if [ -f /mnt/rootfs/etc/pki/tls/openssl.cnf ]; then \
+      echo -e "\n[algorithm_sect]\ndefault_properties = fips=yes" >> /mnt/rootfs/etc/pki/tls/openssl.cnf; \
+    fi
+
+# Disable core dumps
+RUN mkdir -p /mnt/rootfs/etc/security/limits.d && \
+    echo "* hard core 0" > /mnt/rootfs/etc/security/limits.d/50-coredump.conf
+
+# Max concurrent login sessions
+RUN echo "* hard maxlogins 10" > /mnt/rootfs/etc/security/limits.d/50-maxlogins.conf
+
+# Ensure no empty passwords
+RUN sed -i 's/\bnullok\b//g' /mnt/rootfs/etc/pam.d/* 2>/dev/null || true
+
+# Restrictive umask
+RUN if [ -f /mnt/rootfs/etc/login.defs ]; then \
+      sed -i 's/^UMASK.*/UMASK\t\t077/' /mnt/rootfs/etc/login.defs; \
+    fi
+
+# Clean machine-id
+RUN rm -f /mnt/rootfs/etc/machine-id && \
+    touch /mnt/rootfs/etc/machine-id && \
+    chmod 0444 /mnt/rootfs/etc/machine-id
+
+# Remove leftover cache/tmp
+RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
+
 # ---------- Stage 2: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 # Copy minimal rootfs (oscap, scap-security-guide, python3, libs)
 COPY --from=rootfs-builder /mnt/rootfs /


### PR DESCRIPTION
## Summary
- Update all base images from pinned `ubi9:9.5` to `ubi9:latest` / `ubi-micro:latest` / `ubi-minimal:latest`
- Apply DISA STIG hardening controls to container rootfs (FIPS OpenSSL, core dump disable, maxlogins, restrictive umask, machine-id cleanup, GPG package check, no empty passwords)
- Add `scan-containers` job to `docker-publish.yml` that gates manifest merge:
  - **Trivy**: Scans amd64 images for CVEs, fails on CRITICAL/HIGH, uploads SARIF to GitHub Security tab
  - **OpenSCAP STIG**: Runs RHEL 9 STIG profile against exported container filesystems, uploads HTML reports as 90-day CI artifacts
- Add **cosign keyless signing** (GitHub OIDC via sigstore) to both merge jobs — signs manifest digest after creation

## Pipeline flow
```
build-backend ──┐
build-openscap ─┤──→ scan-containers (Trivy + OpenSCAP) ──→ merge + sign ──→ summary
```

## Verify signatures locally
```bash
cosign verify \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
  --certificate-identity-regexp='https://github.com/artifact-keeper/.*' \
  ghcr.io/artifact-keeper/artifact-keeper-backend:latest
```

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` and verify scan job runs
- [ ] Confirm Trivy SARIF appears in GitHub Security tab
- [ ] Confirm STIG HTML reports uploaded as artifacts
- [ ] Confirm cosign signatures attached to published images
- [ ] Verify images locally with `cosign verify`