### PR TITLE
Pin Docker base images for Dependabot and add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "artifact-keeper/maintainers"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "artifact-keeper/maintainers"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore"

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,6 +1,6 @@
 # ---------- Base: Rust toolchain on UBI 9 ----------
 # syntax=docker/dockerfile:1
-FROM registry.access.redhat.com/ubi9/ubi:latest AS rust-base
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rust-base
 RUN dnf install -y --nodocs \
     gcc gcc-c++ make pkg-config perl-core \
     openssl-devel zlib-devel xz-devel bzip2-devel \
@@ -46,7 +46,7 @@ ENV SQLX_OFFLINE=true
 RUN cargo build --release --bin artifact-keeper
 
 # ---------- Stage 4: Build minimal rootfs ----------
-FROM registry.access.redhat.com/ubi9/ubi:latest AS rootfs-builder
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rootfs-builder
 
 # Install only essential runtime libraries into a clean rootfs
 RUN mkdir -p /mnt/rootfs && \
@@ -114,14 +114,14 @@ RUN if [ -f /mnt/rootfs/etc/dnf/dnf.conf ]; then \
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Download scanner CLIs ----------
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS scanners
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS scanners
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 tar gzip && \
     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin && \
     curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin && \
     microdnf clean all
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
 
 # Copy minimal rootfs (glibc, openssl, ca-certs, curl, user/group, dirs)
 COPY --from=rootfs-builder /mnt/rootfs /

--- a/docker/Dockerfile.openscap
+++ b/docker/Dockerfile.openscap
@@ -1,5 +1,5 @@
 # ---------- Stage 1: Build minimal rootfs with OpenSCAP ----------
-FROM registry.access.redhat.com/ubi9/ubi:latest AS rootfs-builder
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS rootfs-builder
 
 # Add CentOS 9 Stream repo for scap-security-guide (not in UBI repos)
 RUN ARCH=$(uname -m) && \
@@ -55,7 +55,7 @@ RUN rm -f /mnt/rootfs/etc/machine-id && \
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 2: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
 
 # Copy minimal rootfs (oscap, scap-security-guide, python3, libs)
 COPY --from=rootfs-builder /mnt/rootfs /


### PR DESCRIPTION
## Summary
- Pin all Docker base images from `:latest` to `9.5` so Dependabot can track and auto-PR version bumps (e.g. 9.5 → 9.6 → 9.7)
- Add `.github/dependabot.yml` with weekly checks for Docker images and GitHub Actions

## What Dependabot will do
When Red Hat publishes `ubi9:9.6`, Dependabot will auto-create a PR updating all `FROM` lines across `Dockerfile.backend`, `Dockerfile.openscap`, etc.

## Test plan
- [ ] Verify Dependabot picks up the config (Settings > Code security > Dependabot)
- [ ] Confirm no `:latest` tags remain in production Dockerfiles