### PR TITLE
fix: resolve CI and Docker Publish pipeline failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,10 @@ jobs:
           chmod +x "$DOCKER_CONFIG/cli-plugins/docker-compose"
           docker compose version
 
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -190,7 +190,7 @@ jobs:
       # Unpatched UBI base image CVEs (Red Hat's responsibility) are still
       # reported in SARIF for visibility but don't block the build.
       - name: Trivy scan - Backend
-        uses: aquasecurity/trivy-action@v0.31.0
+        uses: aquasecurity/trivy-action@0.34.0
         with:
           image-ref: ${{ steps.refs.outputs.backend }}
           format: 'sarif'
@@ -200,7 +200,7 @@ jobs:
           exit-code: '1'
 
       - name: Trivy scan - OpenSCAP
-        uses: aquasecurity/trivy-action@v0.31.0
+        uses: aquasecurity/trivy-action@0.34.0
         if: success() || failure()
         with:
           image-ref: ${{ steps.refs.outputs.openscap }}


### PR DESCRIPTION
## Summary

- **Docker Publish**: Fix `aquasecurity/trivy-action` version tag — trivy-action uses `0.x.0` tags (no `v` prefix). `v0.31.0` doesn't exist. Updated to `0.34.0` (latest).
- **CI smoke-e2e**: Add Docker Hub login step (conditional on `DOCKERHUB_USERNAME` secret) to avoid anonymous pull rate limits. The E2E job pulls ~6 images from Docker Hub unauthenticated, which hits the 100 pulls/6h limit on the self-hosted runner.

## What was failing

| Pipeline | Job | Root Cause |
|----------|-----|-----------|
| Docker Publish | Security Scan | `aquasecurity/trivy-action@v0.31.0` — tag doesn't exist (no `v` prefix) |
| CI | Smoke E2E | Docker Hub anonymous pull rate limit (exit code 18) |

Neither failure is related to the UBI base image bumps in PRs #171-#173.

## Follow-up required

Add Docker Hub credentials as repo secrets to fully resolve the rate limit issue:

```bash
gh secret set DOCKERHUB_USERNAME
gh secret set DOCKERHUB_TOKEN
```

Without these secrets, the Docker Hub login step will be skipped (guarded by `if` conditional) and anonymous pulls will continue, which may hit rate limits intermittently.

## Test plan

- [ ] Verify `trivy-action@0.34.0` resolves correctly in Docker Publish
- [ ] Verify CI passes with the Docker Hub login step (skipped if no secrets)
- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets, re-run to confirm authenticated pulls