### PR TITLE
fix: correct native test script bugs found during smoke testing

### DIFF
--- a/scripts/native-tests/test-cargo.sh
+++ b/scripts/native-tests/test-cargo.sh
@@ -82,8 +82,6 @@ mkdir -p "$WORK_DIR/test-install"
 cd "$WORK_DIR/test-install"
 cargo init --name test-consumer
 cat >> Cargo.toml << EOF
-
-[dependencies]
 test-crate-native = { version = "$TEST_VERSION", registry = "test-registry" }
 EOF
 

--- a/scripts/native-tests/test-npm.sh
+++ b/scripts/native-tests/test-npm.sh
@@ -44,7 +44,7 @@ EOF
 # Configure npm registry
 echo "==> Configuring npm registry..."
 npm config set registry "$NPM_REGISTRY"
-npm config set //${NPM_REGISTRY#http*://}:_authToken "$(echo -n 'admin:admin123' | base64)"
+npm config set //${NPM_REGISTRY#http*://}:_auth "$(echo -n 'admin:admin123' | base64)"
 
 if [ -n "$CA_CERT" ] && [ -f "$CA_CERT" ]; then
     npm config set cafile "$CA_CERT"

--- a/scripts/native-tests/test-pypi.sh
+++ b/scripts/native-tests/test-pypi.sh
@@ -99,7 +99,7 @@ echo "✅ PEP 691 JSON API works"
 echo "==> [5/6] Installing package with pip..."
 pip3 install \
   --index-url "$PYPI_URL/simple/" \
-  --trusted-host "$(echo "$REGISTRY_URL" | sed 's|https\?://||' | cut -d: -f1)" \
+  --trusted-host "$(echo "$REGISTRY_URL" | sed -E 's|https?://||' | cut -d: -f1)" \
   "test-package-native==$TEST_VERSION" 2>&1 | tail -3
 
 # Verify installation


### PR DESCRIPTION
## Summary
- **PyPI** (`test-pypi.sh`): Use `sed -E` for macOS BSD sed compatibility — `\?` is not valid in basic regex mode
- **NPM** (`test-npm.sh`): Use `_auth` (Basic Auth) instead of `_authToken` (Bearer) — the endpoint returns `www-authenticate: Basic realm="npm"`
- **Cargo** (`test-cargo.sh`): Remove duplicate `[dependencies]` section — `cargo init` already generates one

## Test plan
- [ ] Run `./scripts/native-tests/test-pypi.sh` on macOS — pip install step should pass
- [ ] Run `./scripts/native-tests/test-npm.sh` — npm publish should authenticate successfully
- [ ] Run `./scripts/native-tests/test-cargo.sh` — no duplicate key warnings