### PR TITLE
chore: bump version to 1.1.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"


### PR DESCRIPTION
## Summary
Version bump for release candidate 2.

### Changes since rc.1
- Container hardening: UBI 9 Micro STIG-approved base images
- CI workflow fix: `secrets` context cannot be used in step `if:` conditions
- Trivy security scan made non-blocking (unfixed base image CVEs)
- Native test script fixes (PyPI sed, NPM auth, Cargo deps)
- E2E settings page URL fix
- Backend DNS alias ExternalName service for Helm deployments

## Test plan
- [x] All native smoke tests pass (PyPI, NPM, Cargo)
- [x] 19 authenticated API endpoints pass
- [x] CI pipeline green