### PR TITLE
fix: add protoc and vendored openssl to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,19 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y protobuf-compiler pkg-config libssl-dev
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -86,7 +94,7 @@ jobs:
         env:
           SQLX_OFFLINE: true
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
 
       - name: Package binary
         run: |
@@ -95,7 +103,11 @@ jobs:
           chmod +x dist/${{ matrix.name }}
           cd dist
           tar -czvf ${{ matrix.name }}.tar.gz ${{ matrix.name }}
-          sha256sum ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
+          if command -v sha256sum &>/dev/null; then
+            sha256sum ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
+          else
+            shasum -a 256 ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -173,6 +173,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "mime_guess",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2874,6 +2875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +2891,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,9 @@ wasmtime-wasi = "24.0"
 
 # Git operations
 git2 = "0.19"
+
+# OpenSSL (vendored feature for cross-compilation in release builds)
+openssl = { version = "0.10" }
 meilisearch-sdk = "0.27"
 
 # OpenAPI

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,7 +8,11 @@ license.workspace = true
 name = "artifact-keeper"
 path = "src/main.rs"
 
+[features]
+vendored-openssl = ["openssl/vendored"]
+
 [dependencies]
+openssl = { workspace = true, optional = true }
 # Async runtime
 tokio.workspace = true
 


### PR DESCRIPTION
## Summary
- Install `protoc` on Linux (`apt`) and macOS (`brew`) for gRPC proto compilation
- Add `vendored-openssl` cargo feature that builds OpenSSL from source, eliminating system OpenSSL dependency for cross-compilation
- Fix `sha256sum` command on macOS (falls back to `shasum -a 256`)

## Problem
Release workflow binary builds failed on all 4 platforms:
- **x86_64-linux / aarch64-apple-darwin**: `Could not find protoc`
- **x86_64-apple-darwin**: `failed to run custom build command for openssl-sys`
- **aarch64-unknown-linux-gnu**: `failed to run custom build command for openssl-sys` (cross-compile, no arm64 headers)

## Changes
- `release.yml`: Add platform-specific protoc installation steps, use `--features vendored-openssl`
- `Cargo.toml`: Add `openssl` workspace dependency
- `backend/Cargo.toml`: Add `vendored-openssl` feature (optional, only for release builds)