### PR TITLE
fix: resolve duplicate operationId in OpenAPI spec

### DIFF
--- a/backend/src/api/handlers/repository_labels.rs
+++ b/backend/src/api/handlers/repository_labels.rs
@@ -104,6 +104,7 @@ fn labels_list_response(labels: Vec<RepositoryLabel>) -> LabelsListResponse {
 /// List all labels on a repository
 #[utoipa::path(
     get,
+    operation_id = "list_repo_labels",
     path = "/{key}/labels",
     context_path = "/api/v1/repositories",
     tag = "repository-labels",
@@ -135,6 +136,7 @@ async fn list_labels(
 /// Set all labels on a repository (replaces existing)
 #[utoipa::path(
     put,
+    operation_id = "set_repo_labels",
     path = "/{key}/labels",
     context_path = "/api/v1/repositories",
     tag = "repository-labels",
@@ -187,6 +189,7 @@ async fn set_labels(
 /// Add or update a single label
 #[utoipa::path(
     post,
+    operation_id = "add_repo_label",
     path = "/{key}/labels/{label_key}",
     context_path = "/api/v1/repositories",
     tag = "repository-labels",
@@ -233,6 +236,7 @@ async fn add_label(
 /// Delete a label by key
 #[utoipa::path(
     delete,
+    operation_id = "delete_repo_label",
     path = "/{key}/labels/{label_key}",
     context_path = "/api/v1/repositories",
     tag = "repository-labels",

--- a/backend/src/api/handlers/sync_policies.rs
+++ b/backend/src/api/handlers/sync_policies.rs
@@ -315,6 +315,7 @@ fn parse_selector<T: serde::de::DeserializeOwned + Default>(value: Option<serde_
 /// List all sync policies
 #[utoipa::path(
     get,
+    operation_id = "list_sync_policies",
     path = "",
     context_path = "/api/v1/sync-policies",
     tag = "peers",
@@ -335,6 +336,7 @@ async fn list_policies(State(state): State<SharedState>) -> Result<Json<SyncPoli
 /// Create a new sync policy
 #[utoipa::path(
     post,
+    operation_id = "create_sync_policy",
     path = "",
     context_path = "/api/v1/sync-policies",
     tag = "peers",
@@ -375,6 +377,7 @@ async fn create_policy(
 /// Get a sync policy by ID
 #[utoipa::path(
     get,
+    operation_id = "get_sync_policy",
     path = "/{id}",
     context_path = "/api/v1/sync-policies",
     tag = "peers",
@@ -400,6 +403,7 @@ async fn get_policy(
 /// Update a sync policy
 #[utoipa::path(
     put,
+    operation_id = "update_sync_policy",
     path = "/{id}",
     context_path = "/api/v1/sync-policies",
     tag = "peers",
@@ -450,6 +454,7 @@ async fn update_policy(
 /// Delete a sync policy
 #[utoipa::path(
     delete,
+    operation_id = "delete_sync_policy",
     path = "/{id}",
     context_path = "/api/v1/sync-policies",
     tag = "peers",
@@ -522,6 +527,7 @@ async fn evaluate_policies(
 /// Preview what a policy would match (dry-run)
 #[utoipa::path(
     post,
+    operation_id = "preview_sync_policy",
     path = "/preview",
     context_path = "/api/v1/sync-policies",
     tag = "peers",


### PR DESCRIPTION
## Summary
- Add explicit `operation_id` to sync_policies handlers (prefixed `sync_`) to avoid collision with security policy handlers
- Add explicit `operation_id` to repository_labels handlers (prefixed `repo_`) to avoid collision with peer_instance_labels handlers

## Problem
SDK generation failed because Spectral lint found 10 duplicate `operationId` values:
- `list_policies`, `create_policy`, `get_policy`, `update_policy`, `delete_policy` (sync_policies vs security)
- `preview_policy` (sync_policies vs lifecycle)
- `list_labels`, `set_labels`, `add_label`, `delete_label` (repository_labels vs peer_instance_labels)