### PR TITLE
Skip CI and Docker publish for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,18 @@ on:
     branches: [main, master, develop, 'release/**']
     paths-ignore:
       - 'site/**'
-      - '*.md'
+      - '**/*.md'
       - '.beads/**'
       - 'LICENSE'
+      - 'CLAUDE.md'
   pull_request:
     branches: [main, master, develop, 'release/**']
     paths-ignore:
       - 'site/**'
-      - '*.md'
+      - '**/*.md'
       - '.beads/**'
       - 'LICENSE'
+      - 'CLAUDE.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main, master]
     tags: ['v*']
+    paths-ignore:
+      - '**/*.md'
+      - '.beads/**'
+      - 'LICENSE'
+      - 'CLAUDE.md'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` for markdown files to Docker Publish workflow (had none before)
- Expand CI `paths-ignore` from `*.md` to `**/*.md` to catch all markdown files
- Prevents unnecessary image rebuilds and CI runs when only docs/changelogs change

Affected workflows:
- `ci.yml` — already had paths-ignore, expanded glob pattern
- `docker-publish.yml` — new paths-ignore (only applies to branch pushes, not tag pushes)