### PR TITLE
chore: bump to 1.1.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.1.0-rc.2"
+version = "1.1.0-rc.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.1.0-rc.2"
+version = "1.1.0-rc.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"


### PR DESCRIPTION
## Summary
Version bump for v1.1.0-rc.3 release.

### Changes since rc.2
- Fix token creation: register missing /auth/tokens routes (#197)
- Fix Podman compatibility and quickstart reliability (#196)
- Rename UserResponse to AdminUserResponse (#187)
- CI: skip Docker publish for docs-only changes (#185)