### PR TITLE
Fix: pin trivy and grype versions to resolve container CVEs

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -115,9 +115,11 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Download scanner CLIs ----------
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS scanners
+ARG TRIVY_VERSION=v0.69.1
+ARG GRYPE_VERSION=v0.108.0
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 tar gzip && \
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin && \
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin ${TRIVY_VERSION} && \
+    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin ${GRYPE_VERSION} && \
     microdnf clean all
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------


### PR DESCRIPTION
## Summary
- Pin Trivy to `v0.69.1` and Grype to `v0.108.0` in `docker/Dockerfile.backend` Stage 5
- Resolves code-scanning alert #16 (CRITICAL, CVE-2025-68121) and #17 (MEDIUM, CVE-2026-25934)
- Versions are now explicit `ARG` defaults for reproducible builds

Closes #200