### PR TITLE
feat: make admin user optional for SSO-only deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@ ENVIRONMENT=development
 JWT_SECRET=change-this-in-production-use-at-least-32-bytes
 JWT_EXPIRATION_SECS=86400
 
+# Admin provisioning
+# Set to "true" to skip the built-in admin user on first boot.
+# Use this for SSO-only deployments where admin roles are assigned via
+# group mapping (OIDC/LDAP/SAML). When set, no local admin account is
+# created and admin access must come from an SSO provider group.
+# SKIP_ADMIN_PROVISIONING=true
+
 # OIDC (optional)
 # OIDC_ISSUER=https://auth.example.com
 # OIDC_CLIENT_ID=artifact-registry

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -495,6 +495,18 @@ async fn init_peer_identity(db: &sqlx::PgPool, config: &Config) -> Result<uuid::
 async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<bool> {
     use std::path::Path;
 
+    // Skip admin provisioning when SSO handles admin assignment (issue #211)
+    if std::env::var("SKIP_ADMIN_PROVISIONING")
+        .unwrap_or_default()
+        .eq_ignore_ascii_case("true")
+    {
+        tracing::info!(
+            "SKIP_ADMIN_PROVISIONING=true — skipping built-in admin user creation. \
+             Admin access must be granted via SSO group mapping."
+        );
+        return Ok(false);
+    }
+
     let password_file = Path::new(storage_path).join("admin.password");
 
     // Check if an admin user already exists


### PR DESCRIPTION
## Summary

- Adds `SKIP_ADMIN_PROVISIONING` environment variable (default: unset/false)
- When set to `true`, the built-in `admin` user is not created on first boot
- Intended for SSO-only deployments where admin roles are assigned via OIDC/LDAP/SAML group mapping
- Documents the new variable in `.env.example`

## Frontend follow-up

The web UI login page (in artifact-keeper-web) should detect SSO-only mode via the `/api/v1/auth/sso/providers` endpoint and hide the local username/password form when SSO providers are configured and no local admin exists.

## Test plan

- [ ] Default behavior unchanged: admin user still created when env var is unset
- [ ] `SKIP_ADMIN_PROVISIONING=true` skips admin creation, logs informational message
- [ ] SSO group mapping still correctly grants admin role to SSO users
- [ ] Existing deployments with admin user are not affected

Co-Authored-By: Ash A. <ash@dragonpaw.org>

Closes #211