### PR TITLE
chore: add cargo-llvm-cov code coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,34 @@ jobs:
           SQLX_OFFLINE: true
         run: cargo test --workspace --lib --verbose
 
+  coverage:
+    name: 📊 Code Coverage
+    runs-on: ubuntu-latest
+    needs: lint-rust
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+
+      - name: Generate coverage report
+        env:
+          SQLX_OFFLINE: true
+        run: cargo llvm-cov --workspace --lib --lcov --output-path lcov.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-coverage
+          path: lcov.info
+
   # ════════════════════════════════════════════════════════════════════════════
   # TIER 2: INTEGRATION (Main Branch Push Only)
   # ════════════════════════════════════════════════════════════════════════════
@@ -327,7 +355,7 @@ jobs:
   ci-complete:
     name: ✅ CI Complete
     runs-on: ubuntu-latest
-    needs: [lint-rust, test-backend-unit, test-backend-integration, smoke-e2e, build-backend-image, build-openscap-image, security-audit]
+    needs: [lint-rust, test-backend-unit, coverage, test-backend-integration, smoke-e2e, build-backend-image, build-openscap-image, security-audit]
     if: always()
     steps:
       - name: Check CI status
@@ -381,6 +409,13 @@ jobs:
               tier1_pass=false
             fi
           done
+
+          # Coverage (non-blocking)
+          if [[ "${{ needs.coverage.result }}" == "success" ]]; then
+            echo "✅ coverage" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ coverage: ${{ needs.coverage.result }}" >> $GITHUB_STEP_SUMMARY
+          fi
 
           # Security audit (non-blocking)
           if [[ "${{ needs.security-audit.result }}" == "success" ]]; then


### PR DESCRIPTION
## Summary

- Adds a new `coverage` CI job that uses `cargo-llvm-cov` to generate LCOV coverage reports from backend unit tests
- Runs in parallel with `test-backend-unit` after `lint-rust` passes, keeping the existing test job untouched and fast
- Uploads `lcov.info` as a GitHub Actions artifact for downstream consumption (Codecov, SonarCloud, etc.)
- Tracked as non-blocking in the `ci-complete` status gate

## Test plan

- [ ] Verify the `coverage` job appears in the CI workflow and runs after `lint-rust`
- [ ] Verify the existing `test-backend-unit` job is unchanged
- [ ] Verify `lcov.info` is uploaded as an artifact after a successful run
- [ ] Verify `ci-complete` reports coverage status without blocking on failure