### PR TITLE
fix: remove 4 GB upload limit for Incus/LXC container images

### DIFF
--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -47,7 +47,7 @@ pub fn router() -> Router<SharedState> {
             "/:repo_key/images/:product/:version/:filename",
             get(download_image).put(upload_image).delete(delete_image),
         )
-        .layer(DefaultBodyLimit::max(4 * 1024 * 1024 * 1024)) // 4 GB for container images
+        .layer(DefaultBodyLimit::disable()) // No size limit — container images can be very large
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes the hardcoded 4 GB body limit on the Incus/LXC handler, replacing it with `DefaultBodyLimit::disable()`
- Container images can easily exceed 4 GB — the OCI/Docker handler already disables this limit for the same reason
- Incus/LXC should be treated the same as Docker since they're the same class of large artifacts

Closes #217