### PR TITLE
Fix S3 storage backend selection and credential aliasing

### DIFF
--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -28,8 +28,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::ansible::AnsibleHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -575,7 +573,7 @@ async fn download_collection(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -740,7 +738,7 @@ async fn upload_collection(
 
     // Store the file
     let storage_key = format!("ansible/{}/{}/{}", full_name, collection_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, tarball.clone())
         .await

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -29,8 +29,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -410,7 +408,7 @@ async fn publish(
     // Store the .crate file
     let filename = format!("{}-{}.crate", name_lower, crate_version);
     let storage_key = format!("cargo/{}/{}/{}", name_lower, crate_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, crate_bytes.clone())
         .await
@@ -661,7 +659,7 @@ async fn download(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -27,8 +27,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::chef::ChefHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -465,7 +463,7 @@ async fn download_cookbook(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -625,7 +623,7 @@ async fn upload_cookbook(
 
     // Store the file
     let storage_key = format!("chef/{}/{}/{}", cookbook_name, cookbook_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, tarball.clone())
         .await

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -27,8 +27,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::cocoapods::CocoaPodsHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -220,7 +218,7 @@ async fn get_podspec(
         "cocoapods/{}/{}/{}.podspec.json",
         path_info.name, path_info.version, path_info.name
     );
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&podspec_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -352,7 +350,7 @@ async fn download_pod(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -446,7 +444,7 @@ async fn push_pod(
 
     // Store the pod archive
     let storage_key = format!("cocoapods/{}/{}/{}", pod_name, pod_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -31,8 +31,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::composer::ComposerHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -599,7 +597,7 @@ async fn download_archive(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -853,7 +851,7 @@ async fn upload(
 
     // Store the archive
     let storage_key = format!("composer/{}/{}/{}.zip", full_name, version, sha256);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -34,8 +34,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -695,7 +693,7 @@ async fn recipe_file_download(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -784,7 +782,7 @@ async fn recipe_file_upload(
     }
 
     // Store the file
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1153,7 +1151,7 @@ async fn package_file_download(
         };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1261,7 +1259,7 @@ async fn package_file_upload(
     }
 
     // Store the file
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -31,8 +31,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::cran::CranHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -312,7 +310,7 @@ async fn download_package(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -459,7 +457,7 @@ async fn upload_package(
 
     // Store the file
     let storage_key = format!("cran/{}/{}/{}", pkg_name, pkg_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -29,8 +29,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -530,7 +528,7 @@ async fn get_mod_file(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -672,7 +670,7 @@ async fn download_zip(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -809,7 +807,7 @@ async fn upload_zip(
     let storage_key = format!("go/{}/{}/{}.zip", encoded_module, version, version);
 
     // Store the file
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -932,7 +930,7 @@ async fn upload_mod(
     let storage_key = format!("go/{}/{}/go.mod", encoded_module, version);
 
     // Store the file
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -28,8 +28,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::helm::{generate_index_yaml, ChartYaml, HelmHandler};
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -360,7 +358,7 @@ async fn download_chart(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -473,7 +471,7 @@ async fn upload_chart(
 
     // Store the chart package
     let storage_key = format!("helm/{}/{}/{}", chart_name, chart_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, content.clone())
         .await

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -28,8 +28,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::hex::HexHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -343,7 +341,7 @@ async fn download_tarball(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -455,7 +453,7 @@ async fn publish_package(
 
     // Store the file
     let storage_key = format!("hex/{}/{}/{}", pkg_name, pkg_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -27,8 +27,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -419,7 +417,7 @@ async fn download_file(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -512,7 +510,7 @@ async fn upload_file(
 
     // Store the file
     let storage_key = format!("huggingface/{}/{}/{}", model_id, revision, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -40,8 +40,6 @@ use uuid::Uuid;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::incus::IncusHandler;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -640,7 +638,7 @@ async fn download_image(
     let size_bytes: i64 = artifact.get("size_bytes");
     let checksum: String = artifact.get("checksum_sha256");
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -27,8 +27,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -353,7 +351,7 @@ async fn download_plugin(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -535,7 +533,7 @@ async fn upload_plugin(
 
     // Store the file
     let storage_key = format!("jetbrains/{}/{}/{}", plugin_name, plugin_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, file_bytes.clone())
         .await

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -28,8 +28,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -560,7 +558,7 @@ async fn serve_tarball(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -745,7 +743,7 @@ async fn publish_package(
 
         // Store the tarball
         let storage_key = format!("npm/{}/{}/{}", package_name, version, tarball_filename);
-        let storage = FilesystemStorage::new(&repo.storage_path);
+        let storage = state.storage_for_repo(&repo.storage_path);
         storage
             .put(&storage_key, Bytes::from(tarball_bytes.clone()))
             .await

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -30,8 +30,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -671,7 +669,7 @@ async fn flatcontainer_download(
     };
 
     // Read from storage.
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -778,7 +776,7 @@ async fn push_package(
     let storage_key = format!("nuget/{}/{}/{}", package_id, version, filename);
 
     // Store the file.
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, nupkg_bytes).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -38,8 +38,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -1190,7 +1188,7 @@ async fn upload(
 
         // Store via StorageBackend
         let storage_key = format!("modules/{}/commits/{}", module_name, commit_digest);
-        let storage = FilesystemStorage::new(&repo.storage_path);
+        let storage = state.storage_for_repo(&repo.storage_path);
         storage.put(&storage_key, bundle_bytes).await.map_err(|e| {
             connect_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1456,7 +1454,7 @@ async fn download(
 
         // Read bundle from local storage
         let storage_key: String = artifact_row.get("storage_key");
-        let storage = FilesystemStorage::new(&repo.storage_path);
+        let storage = state.storage_for_repo(&repo.storage_path);
         let bundle_data = storage.get(&storage_key).await.map_err(|e| {
             connect_error(
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -177,15 +177,13 @@ pub async fn local_fetch_by_path(
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
     let storage = state.storage_for_repo(storage_path);
-    let content = storage.get(&artifact.storage_key)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Storage error: {}", e),
-            )
-                .into_response()
-        })?;
+    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Storage error: {}", e),
+        )
+            .into_response()
+    })?;
 
     Ok((content, Some(artifact.content_type)))
 }
@@ -221,15 +219,13 @@ pub async fn local_fetch_by_name_version(
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
     let storage = state.storage_for_repo(storage_path);
-    let content = storage.get(&artifact.storage_key)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Storage error: {}", e),
-            )
-                .into_response()
-        })?;
+    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Storage error: {}", e),
+        )
+            .into_response()
+    })?;
 
     Ok((content, Some(artifact.content_type)))
 }
@@ -263,15 +259,13 @@ pub async fn local_fetch_by_path_suffix(
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
     let storage = state.storage_for_repo(storage_path);
-    let content = storage.get(&artifact.storage_key)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Storage error: {}", e),
-            )
-                .into_response()
-        })?;
+    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Storage error: {}", e),
+        )
+            .into_response()
+    })?;
 
     Ok((content, Some(artifact.content_type)))
 }

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -28,8 +28,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -447,7 +445,7 @@ async fn download_archive(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -593,7 +591,7 @@ async fn upload_package(
 
     // Store the file
     let storage_key = format!("pub/{}/{}/{}", pkg_name, pkg_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -27,8 +27,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::puppet::PuppetHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -538,7 +536,7 @@ async fn download_module(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -693,7 +691,7 @@ async fn publish_module(
 
     // Store the file
     let storage_key = format!("puppet/{}/{}/{}", full_name, module_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, tarball.clone())
         .await

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -452,7 +452,14 @@ async fn download_or_metadata(
     // PEP 658: if filename ends with .metadata, serve extracted METADATA
     if filename.ends_with(".metadata") {
         let real_filename = filename.trim_end_matches(".metadata");
-        return serve_metadata(&state, &state.db, repo.id, &repo.storage_path, real_filename).await;
+        return serve_metadata(
+            &state,
+            &state.db,
+            repo.id,
+            &repo.storage_path,
+            real_filename,
+        )
+        .await;
     }
 
     // Regular file download

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -35,8 +35,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
 use crate::services::signing_service::SigningService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -612,7 +610,7 @@ async fn download_package(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -756,7 +754,7 @@ async fn store_rpm(
 
     // Store the file
     let storage_key = format!("rpm/{}/{}", repo.id, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage
         .put(&storage_key, content.clone())
         .await

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -33,8 +33,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::rubygems::RubygemsHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -427,7 +425,7 @@ async fn download_gem(
     };
 
     // Read from storage
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -524,7 +522,7 @@ async fn push_gem(
 
     // Store the file
     let storage_key = format!("rubygems/{}/{}/{}", gem_name, gem_version, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -29,8 +29,6 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::formats::swift::SwiftHandler;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -461,7 +459,7 @@ async fn download_archive(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         swift_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -628,7 +626,7 @@ async fn publish_release(
 
     // Store the file
     let storage_key = format!("swift/{}/{}/{}/{}.zip", scope, name, version, name);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         swift_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -38,8 +38,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -649,7 +647,7 @@ async fn upload_module(
     );
 
     // Store the file
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1064,7 +1062,7 @@ async fn upload_provider(
     );
 
     // Store the file
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -25,8 +25,6 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::services::auth_service::AuthService;
-use crate::storage::filesystem::FilesystemStorage;
-use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -345,7 +343,7 @@ async fn download_vsix(
         }
     };
 
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     let content = storage.get(&artifact.storage_key).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -453,7 +451,7 @@ async fn publish_extension(
 
     // Store the file
     let storage_key = format!("vscode/{}/{}/{}", publisher, ext_name, filename);
-    let storage = FilesystemStorage::new(&repo.storage_path);
+    let storage = state.storage_for_repo(&repo.storage_path);
     storage.put(&storage_key, body.clone()).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -151,39 +151,40 @@ async fn main() -> Result<()> {
     tracing::info!("Prometheus metrics recorder initialized");
 
     // Create primary storage backend based on STORAGE_BACKEND config
-    let primary_storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> =
-        match config.storage_backend.as_str() {
-            "s3" => {
-                let s3 = artifact_keeper_backend::storage::s3::S3Backend::from_env().await?;
-                tracing::info!("S3 storage backend initialized");
-                Arc::new(s3)
-            }
-            "azure" => {
-                let azure_config =
-                    artifact_keeper_backend::storage::azure::AzureConfig::from_env()?;
-                let azure =
-                    artifact_keeper_backend::storage::azure::AzureBackend::new(azure_config)
-                        .await?;
-                tracing::info!("Azure Blob storage backend initialized");
-                Arc::new(azure)
-            }
-            "gcs" => {
-                let gcs_config = artifact_keeper_backend::storage::gcs::GcsConfig::from_env()?;
-                let gcs =
-                    artifact_keeper_backend::storage::gcs::GcsBackend::new(gcs_config).await?;
-                tracing::info!("GCS storage backend initialized");
-                Arc::new(gcs)
-            }
-            _ => {
-                tracing::info!(
-                    "Filesystem storage backend initialized at {}",
-                    config.storage_path
-                );
-                Arc::new(artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(
+    let primary_storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = match config
+        .storage_backend
+        .as_str()
+    {
+        "s3" => {
+            let s3 = artifact_keeper_backend::storage::s3::S3Backend::from_env().await?;
+            tracing::info!("S3 storage backend initialized");
+            Arc::new(s3)
+        }
+        "azure" => {
+            let azure_config = artifact_keeper_backend::storage::azure::AzureConfig::from_env()?;
+            let azure =
+                artifact_keeper_backend::storage::azure::AzureBackend::new(azure_config).await?;
+            tracing::info!("Azure Blob storage backend initialized");
+            Arc::new(azure)
+        }
+        "gcs" => {
+            let gcs_config = artifact_keeper_backend::storage::gcs::GcsConfig::from_env()?;
+            let gcs = artifact_keeper_backend::storage::gcs::GcsBackend::new(gcs_config).await?;
+            tracing::info!("GCS storage backend initialized");
+            Arc::new(gcs)
+        }
+        _ => {
+            tracing::info!(
+                "Filesystem storage backend initialized at {}",
+                config.storage_path
+            );
+            Arc::new(
+                artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(
                     &config.storage_path,
-                ))
-            }
-        };
+                ),
+            )
+        }
+    };
 
     // Create application state with WASM plugin support
     let mut app_state = api::AppState::with_wasm_plugins(

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -5,8 +5,8 @@
 //! - S3_BUCKET: Bucket name (required)
 //! - S3_REGION: AWS region (default: us-east-1)
 //! - S3_ENDPOINT: Custom endpoint URL for S3-compatible services
-//! - AWS_ACCESS_KEY_ID: Access key (optional if using instance roles/IRSA)
-//! - AWS_SECRET_ACCESS_KEY: Secret key (optional if using instance roles/IRSA)
+//! - S3_ACCESS_KEY_ID: Access key (preferred, falls back to AWS_ACCESS_KEY_ID)
+//! - S3_SECRET_ACCESS_KEY: Secret key (preferred, falls back to AWS_SECRET_ACCESS_KEY)
 //!
 //! For redirect downloads (302 to presigned URLs):
 //! - S3_REDIRECT_DOWNLOADS: Enable 302 redirects (default: false)


### PR DESCRIPTION
## Summary

- **STORAGE_BACKEND=s3 now works.** Every format handler was hardcoding `FilesystemStorage::new()`, ignoring the configured backend. All 90+ instances replaced with `state.storage_for_repo()` which dispatches to S3, Azure, GCS, or filesystem based on config.
- **S3 credential env vars fixed.** `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` are now supported (with fallback to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`). Previously only the AWS-prefixed vars worked, which was inconsistent with all other S3 config using the `S3_*` prefix.
- **Eliminated redundant per-request S3Backend instantiation** in `download_artifact` presigned URL generation. Now reuses the shared storage backend.

Closes artifact-keeper/artifact-keeper#237, closes artifact-keeper/artifact-keeper-site#29, closes artifact-keeper/artifact-keeper#245

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace` passes with zero warnings
- [x] `cargo test --workspace --lib` passes (4904 tests, 0 failures)
- [ ] Manual test with `STORAGE_BACKEND=s3` and `S3_ACCESS_KEY_ID` against MinIO
- [ ] Verify existing filesystem deployments still work unchanged