### PR TITLE
Enforce HTTPS in Dockerfile curl commands

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -12,7 +12,7 @@ RUN dnf install -y --nodocs \
       aarch64) PROTOC_ARCH="linux-aarch_64" ;; \
       *)       echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    curl -sSfL "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-${PROTOC_ARCH}.zip" \
+    curl --proto '=https' --tlsv1.2 -sSfL "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-${PROTOC_ARCH}.zip" \
       -o /tmp/protoc.zip && \
     unzip -q /tmp/protoc.zip -d /usr/local && rm /tmp/protoc.zip && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.93.0 && \
@@ -118,8 +118,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS scanners
 ARG TRIVY_VERSION=v0.69.1
 ARG GRYPE_VERSION=v0.108.0
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 tar gzip && \
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin "${TRIVY_VERSION}" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin "${GRYPE_VERSION}" && \
+    curl --proto '=https' --tlsv1.2 -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin "${TRIVY_VERSION}" && \
+    curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin "${GRYPE_VERSION}" && \
     microdnf clean all
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------

--- a/docker/Dockerfile.redteam
+++ b/docker/Dockerfile.redteam
@@ -28,15 +28,15 @@ RUN git clone --depth 1 https://github.com/sullo/nikto.git /opt/nikto && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH="linux_x86_64"; \
     elif [ "$ARCH" = "aarch64" ]; then ARCH="linux_arm64"; fi && \
-    GRPCURL_VERSION=$(curl -sL https://api.github.com/repos/fullstorydev/grpcurl/releases/latest | jq -r .tag_name) && \
-    curl -sL "https://github.com/fullstorydev/grpcurl/releases/download/${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION#v}_${ARCH}.tar.gz" | \
+    GRPCURL_VERSION=$(curl --proto '=https' --tlsv1.2 -sL https://api.github.com/repos/fullstorydev/grpcurl/releases/latest | jq -r .tag_name) && \
+    curl --proto '=https' --tlsv1.2 -sL "https://github.com/fullstorydev/grpcurl/releases/download/${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION#v}_${ARCH}.tar.gz" | \
     tar -xz -C /usr/local/bin grpcurl && \
     chmod +x /usr/local/bin/grpcurl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH="linux_amd64"; \
     elif [ "$ARCH" = "aarch64" ]; then ARCH="linux_arm64"; fi && \
-    NUCLEI_VERSION=$(curl -sL https://api.github.com/repos/projectdiscovery/nuclei/releases/latest | jq -r .tag_name) && \
-    curl -sL "https://github.com/projectdiscovery/nuclei/releases/download/${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION#v}_${ARCH}.zip" -o /tmp/nuclei.zip && \
+    NUCLEI_VERSION=$(curl --proto '=https' --tlsv1.2 -sL https://api.github.com/repos/projectdiscovery/nuclei/releases/latest | jq -r .tag_name) && \
+    curl --proto '=https' --tlsv1.2 -sL "https://github.com/projectdiscovery/nuclei/releases/download/${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION#v}_${ARCH}.zip" -o /tmp/nuclei.zip && \
     unzip -o /tmp/nuclei.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/nuclei && \
     rm /tmp/nuclei.zip


### PR DESCRIPTION
## Summary

- Add `--proto '=https' --tlsv1.2` to 7 curl commands in `docker/Dockerfile.backend` and `docker/Dockerfile.redteam` that were missing HTTPS enforcement
- Prevents potential HTTP redirect attacks where a 301/302 could downgrade to insecure HTTP
- Resolves all 7 open SonarCloud security hotspots (`docker:S6506`) on main

## Files Changed

- `docker/Dockerfile.backend`: protoc download (line 15), trivy installer (line 121), grype installer (line 122)
- `docker/Dockerfile.redteam`: grpcurl API + download (lines 31-32), nuclei API + download (lines 38-39)

## Test plan

- [ ] Docker build still succeeds: `docker build -f docker/Dockerfile.backend .`
- [ ] SonarCloud re-scan shows 0 hotspots on this branch

Closes #250