### PR TITLE
Upload Trivy reports as artifacts, add scheduled scan, bump grype

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -198,7 +198,7 @@ jobs:
       # exit-code: 0 means scan results are informational — unfixed base image
       # CVEs (Red Hat's responsibility) should not block image publishing.
       - name: Trivy scan - Backend
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.34.1
         with:
           image-ref: ${{ steps.refs.outputs.backend }}
           format: 'sarif'
@@ -208,7 +208,7 @@ jobs:
           exit-code: '0'
 
       - name: Trivy scan - OpenSCAP
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.34.1
         if: always()
         with:
           image-ref: ${{ steps.refs.outputs.openscap }}
@@ -231,6 +231,16 @@ jobs:
         with:
           sarif_file: 'openscap-trivy.sarif'
           category: 'trivy-openscap'
+
+      - name: Upload Trivy reports
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: trivy-scan-reports
+          path: |
+            backend-trivy.sarif
+            openscap-trivy.sarif
+          retention-days: 90
 
       # --- OpenSCAP STIG compliance scan ---
       - name: Install OpenSCAP

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -1,0 +1,148 @@
+name: Scheduled Container Scan
+
+on:
+  schedule:
+    # Every Monday at 6 AM UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ${{ github.repository }}-backend
+  OPENSCAP_IMAGE: ${{ github.repository }}-openscap
+
+jobs:
+  trivy-scan:
+    name: Weekly Trivy Scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trivy scan - Backend
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest
+          format: 'sarif'
+          output: 'backend-trivy.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Trivy scan - OpenSCAP
+        uses: aquasecurity/trivy-action@0.34.1
+        if: always()
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:latest
+          format: 'sarif'
+          output: 'openscap-trivy.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Upload Backend Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'backend-trivy.sarif'
+          category: 'trivy-backend-scheduled'
+
+      - name: Upload OpenSCAP Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'openscap-trivy.sarif'
+          category: 'trivy-openscap-scheduled'
+
+      - name: Upload Trivy reports
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: trivy-weekly-reports
+          path: |
+            backend-trivy.sarif
+            openscap-trivy.sarif
+          retention-days: 90
+
+      - name: Check for new findings and create issue
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+
+            let totalFindings = 0;
+            const summaries = [];
+
+            for (const [name, file] of [['Backend', 'backend-trivy.sarif'], ['OpenSCAP', 'openscap-trivy.sarif']]) {
+              if (!fs.existsSync(file)) {
+                summaries.push(`- **${name}**: Scan skipped or failed`);
+                continue;
+              }
+              const sarif = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const results = sarif.runs?.[0]?.results || [];
+              const count = results.length;
+              totalFindings += count;
+              summaries.push(`- **${name}**: ${count} finding(s)`);
+            }
+
+            console.log(`Total findings: ${totalFindings}`);
+            console.log(summaries.join('\n'));
+
+            if (totalFindings > 0) {
+              // Check if there's already an open issue for container findings
+              const existing = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'security',
+                per_page: 100
+              });
+
+              const hasExisting = existing.data.some(i =>
+                i.title.includes('Container scan findings')
+              );
+
+              if (!hasExisting) {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: `Container scan findings detected (${new Date().toISOString().split('T')[0]})`,
+                  body: [
+                    '## Weekly Container Scan Results',
+                    '',
+                    `Trivy found **${totalFindings}** CRITICAL/HIGH finding(s) with available fixes:`,
+                    '',
+                    ...summaries,
+                    '',
+                    `[View scan run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                    '',
+                    'SARIF reports have been uploaded to the Security tab and as workflow artifacts.',
+                  ].join('\n'),
+                  labels: ['security']
+                });
+              }
+            }
+
+      - name: Scan summary
+        if: always()
+        run: |
+          echo "## Weekly Container Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
+          echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "SARIF reports uploaded to Security tab and as workflow artifacts." >> $GITHUB_STEP_SUMMARY

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -116,7 +116,7 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 # ---------- Stage 5: Download scanner CLIs ----------
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS scanners
 ARG TRIVY_VERSION=v0.69.1
-ARG GRYPE_VERSION=v0.108.0
+ARG GRYPE_VERSION=v0.109.0
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 tar gzip && \
     curl --proto '=https' --tlsv1.2 -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin "${TRIVY_VERSION}" && \
     curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin "${GRYPE_VERSION}" && \


### PR DESCRIPTION
## Summary

- Upload Trivy SARIF reports as downloadable workflow artifacts (90-day retention) so scan results are available for all builds, not just in the Security tab
- Add `scheduled-container-scan.yml` workflow that runs weekly Trivy scans against the latest published images and auto-creates GitHub issues when new CRITICAL/HIGH findings are detected
- Bump grype from v0.108.0 to v0.109.0 to clear CRITICAL CVE-2025-68121 (Go stdlib)
- Bump trivy-action from 0.34.0 to 0.34.1

## Test plan

- [ ] Verify `docker-publish.yml` YAML is valid and CI passes
- [ ] Confirm Trivy SARIF files appear as downloadable artifacts in the workflow run
- [ ] Trigger `scheduled-container-scan.yml` manually via workflow_dispatch and verify it scans latest images
- [ ] Verify STIG reports still upload correctly (no regression)

Closes #186