### PR TITLE
fix: add explicit permissions to all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
       - 'CLAUDE.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -159,6 +162,9 @@ jobs:
     name: 🔥 Smoke E2E Tests
     runs-on: ak-e2e-runners
     needs: [test-backend-unit]
+    permissions:
+      contents: read
+      packages: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -242,6 +248,9 @@ jobs:
   detect-changes:
     name: 🔍 Detect Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     if: github.event_name == 'pull_request'
     outputs:
       backend: ${{ steps.filter.outputs.backend }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,8 @@ on:
         required: true
         default: 'latest'
 
+permissions: {}
+
 env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ${{ github.repository }}-backend
@@ -464,6 +466,7 @@ jobs:
   summary:
     name: Publish Summary
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [merge-backend, merge-openscap]
     if: always()
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mesh-e2e.yml
+++ b/.github/workflows/mesh-e2e.yml
@@ -18,6 +18,9 @@ on:
         type: string
         default: 'dev'
 
+permissions:
+  contents: read
+
 concurrency:
   group: mesh-e2e
   cancel-in-progress: false

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -6,10 +6,16 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   nightly-e2e:
     name: 🌙 Nightly E2E Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 45
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Add top-level `permissions` blocks to 5 workflow files (ci.yml, e2e.yml, scheduled-tests.yml, mesh-e2e.yml, docker-publish.yml)
- Add job-level permission overrides where jobs need more than `contents: read`
- Resolves 20 code scanning alerts for `actions/missing-workflow-permissions`

## Alerts resolved

| Workflow | Alert count | Fix |
|----------|------------|-----|
| ci.yml | 10 | Top-level `permissions: contents: read` + job overrides for smoke-e2e, detect-changes |
| e2e.yml | 5 | Top-level `permissions: contents: read` |
| scheduled-tests.yml | 3 | Top-level `permissions: contents: read` + job override for nightly-e2e (issues: write) |
| docker-publish.yml | 1 | Top-level `permissions: {}` + explicit empty on summary job |
| mesh-e2e.yml | 1 | Top-level `permissions: contents: read` |

## Test plan

- [ ] CI workflows still run correctly on push/PR
- [ ] Docker publish workflow can still push to GHCR (job-level permissions preserved)
- [ ] Nightly E2E can still create issues on failure