### PR TITLE
fix: redact sensitive fields in Debug implementations

### DIFF
--- a/backend/src/models/api_token.rs
+++ b/backend/src/models/api_token.rs
@@ -1,5 +1,7 @@
 //! API token model.
 
+use std::fmt;
+
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::FromRow;
@@ -10,7 +12,7 @@ use uuid::Uuid;
 /// Tokens are stored as hashes with only a prefix stored in plaintext
 /// for identification purposes. The full token is only returned once
 /// during creation and cannot be retrieved later.
-#[derive(Debug, Clone, FromRow, Serialize)]
+#[derive(Clone, FromRow, Serialize)]
 pub struct ApiToken {
     pub id: Uuid,
     pub user_id: Uuid,
@@ -27,8 +29,22 @@ pub struct ApiToken {
     pub repo_selector: Option<serde_json::Value>,
 }
 
+impl fmt::Debug for ApiToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiToken")
+            .field("id", &self.id)
+            .field("user_id", &self.user_id)
+            .field("name", &self.name)
+            .field("token_hash", &"[REDACTED]")
+            .field("token_prefix", &self.token_prefix)
+            .field("scopes", &self.scopes)
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Response type for API token creation (includes the actual token only once).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct ApiTokenCreated {
     pub id: Uuid,
     pub user_id: Uuid,
@@ -40,4 +56,15 @@ pub struct ApiTokenCreated {
     pub created_at: DateTime<Utc>,
     pub description: Option<String>,
     pub repository_ids: Vec<Uuid>,
+}
+
+impl fmt::Debug for ApiTokenCreated {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiTokenCreated")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("token", &"[REDACTED]")
+            .field("token_prefix", &self.token_prefix)
+            .finish_non_exhaustive()
+    }
 }

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -1,5 +1,7 @@
 //! User model.
 
+use std::fmt;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
@@ -40,7 +42,7 @@ pub struct User {
 }
 
 /// API token entity
-#[derive(Debug, Clone, FromRow, Serialize)]
+#[derive(Clone, FromRow, Serialize)]
 pub struct ApiToken {
     pub id: Uuid,
     pub user_id: Uuid,
@@ -54,4 +56,18 @@ pub struct ApiToken {
     pub created_at: DateTime<Utc>,
     pub created_by_user_id: Option<Uuid>,
     pub description: Option<String>,
+}
+
+impl fmt::Debug for ApiToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiToken")
+            .field("id", &self.id)
+            .field("user_id", &self.user_id)
+            .field("name", &self.name)
+            .field("token_hash", &"[REDACTED]")
+            .field("token_prefix", &self.token_prefix)
+            .field("scopes", &self.scopes)
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
 }

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -4,6 +4,8 @@
 //! stored in the database, including encrypted credential storage and
 //! SSO session management for CSRF protection during auth flows.
 
+use std::fmt;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, PgPool};
@@ -32,7 +34,7 @@ pub struct OidcConfigRow {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Clone, FromRow)]
 pub struct LdapConfigRow {
     pub id: Uuid,
     pub name: String,
@@ -55,7 +57,21 @@ pub struct LdapConfigRow {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, FromRow)]
+impl fmt::Debug for LdapConfigRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LdapConfigRow")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("server_url", &self.server_url)
+            .field("bind_dn", &self.bind_dn)
+            .field("bind_password_encrypted", &self.bind_password_encrypted.as_ref().map(|_| "[REDACTED]"))
+            .field("user_base_dn", &self.user_base_dn)
+            .field("is_enabled", &self.is_enabled)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, FromRow)]
 pub struct SamlConfigRow {
     pub id: Uuid,
     pub name: String,
@@ -72,6 +88,20 @@ pub struct SamlConfigRow {
     pub is_enabled: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for SamlConfigRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SamlConfigRow")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("entity_id", &self.entity_id)
+            .field("sso_url", &self.sso_url)
+            .field("certificate", &"[REDACTED]")
+            .field("sp_entity_id", &self.sp_entity_id)
+            .field("is_enabled", &self.is_enabled)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug, Clone, FromRow)]

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -3,6 +3,7 @@
 //! Provides authentication against LDAP/Active Directory servers.
 //! Uses a simple bind-based authentication approach.
 
+use std::fmt;
 use std::sync::Arc;
 
 use reqwest::Client;
@@ -15,7 +16,7 @@ use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
 
 /// LDAP configuration parsed from environment
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LdapConfig {
     /// LDAP server URL (e.g., ldap://ldap.example.com:389)
     pub url: String,
@@ -39,6 +40,24 @@ pub struct LdapConfig {
     pub admin_group_dn: Option<String>,
     /// Use STARTTLS
     pub use_starttls: bool,
+}
+
+impl fmt::Debug for LdapConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LdapConfig")
+            .field("url", &self.url)
+            .field("base_dn", &self.base_dn)
+            .field("user_filter", &self.user_filter)
+            .field("bind_dn", &self.bind_dn)
+            .field("bind_password", &self.bind_password.as_ref().map(|_| "[REDACTED]"))
+            .field("username_attr", &self.username_attr)
+            .field("email_attr", &self.email_attr)
+            .field("display_name_attr", &self.display_name_attr)
+            .field("groups_attr", &self.groups_attr)
+            .field("admin_group_dn", &self.admin_group_dn)
+            .field("use_starttls", &self.use_starttls)
+            .finish()
+    }
 }
 
 impl LdapConfig {

--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -4,6 +4,7 @@
 //! Okta, Azure AD, ADFS, Shibboleth, etc.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use quick_xml::escape::unescape;
@@ -19,7 +20,7 @@ use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
 
 /// SAML configuration
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SamlConfig {
     /// SAML IdP metadata URL
     pub idp_metadata_url: Option<String>,
@@ -47,6 +48,26 @@ pub struct SamlConfig {
     pub sign_requests: bool,
     /// Require signed assertions
     pub require_signed_assertions: bool,
+}
+
+impl fmt::Debug for SamlConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SamlConfig")
+            .field("idp_metadata_url", &self.idp_metadata_url)
+            .field("idp_sso_url", &self.idp_sso_url)
+            .field("idp_issuer", &self.idp_issuer)
+            .field("idp_certificate", &self.idp_certificate.as_ref().map(|_| "[REDACTED]"))
+            .field("sp_entity_id", &self.sp_entity_id)
+            .field("acs_url", &self.acs_url)
+            .field("username_attr", &self.username_attr)
+            .field("email_attr", &self.email_attr)
+            .field("display_name_attr", &self.display_name_attr)
+            .field("groups_attr", &self.groups_attr)
+            .field("admin_group", &self.admin_group)
+            .field("sign_requests", &self.sign_requests)
+            .field("require_signed_assertions", &self.require_signed_assertions)
+            .finish()
+    }
 }
 
 impl SamlConfig {


### PR DESCRIPTION
## Summary

- Replace `#[derive(Debug)]` with custom `Debug` implementations on structs containing sensitive data
- Sensitive fields now show `[REDACTED]` instead of actual values when logged
- Affected structs: LdapConfig, SamlConfig, LdapConfigRow, SamlConfigRow, ApiToken, ApiTokenCreated

## Structs fixed

| Struct | Sensitive field | Location |
|--------|----------------|----------|
| LdapConfig | bind_password | ldap_service.rs |
| SamlConfig | idp_certificate | saml_service.rs |
| LdapConfigRow | bind_password_encrypted | auth_config_service.rs |
| SamlConfigRow | certificate | auth_config_service.rs |
| ApiToken (2 copies) | token_hash | models/api_token.rs, models/user.rs |
| ApiTokenCreated | token | models/api_token.rs |

## Test plan

- [x] `cargo check --workspace` passes
- [ ] `cargo test --workspace --lib` passes
- [ ] Verify logging output no longer contains sensitive data