### PR TITLE
fix: validate project UUID to prevent SSRF

### DIFF
--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -750,6 +750,10 @@ impl DependencyTrackService {
         project_uuid: &str,
         days: u32,
     ) -> Result<Vec<DtProjectMetrics>> {
+        // Validate project_uuid is a proper UUID to prevent SSRF via path manipulation
+        uuid::Uuid::parse_str(project_uuid).map_err(|_| {
+            AppError::Validation(format!("Invalid project UUID: {}", project_uuid))
+        })?;
         let url = format!(
             "{}/api/v1/metrics/project/{}/days/{}",
             self.config.base_url, project_uuid, days


### PR DESCRIPTION
## Summary

- Validate `project_uuid` parameter as a proper UUID before constructing the Dependency-Track API URL
- Prevents path manipulation that could redirect requests to arbitrary hosts via crafted UUID values

## Alerts resolved

| Alert # | Rule | File | Line |
|---------|------|------|------|
| 113 | rust/request-forgery | dependency_track_service.rs | 760 |

## Test plan

- [x] `cargo check --workspace` passes
- [ ] DT project metrics endpoint still works with valid UUIDs
- [ ] Invalid UUIDs return 400 validation error