### PR TITLE
fix: add supply chain attestations and reduce openscap CVEs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,8 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=backend-${{ matrix.platform }}
           cache-to: type=gha,scope=backend-${{ matrix.platform }},mode=max
+          sbom: true
+          provenance: mode=max
 
       - name: Export digest
         run: |
@@ -139,6 +141,8 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=openscap-${{ matrix.platform }}
           cache-to: type=gha,scope=openscap-${{ matrix.platform }},mode=max
+          sbom: true
+          provenance: mode=max
 
       - name: Export digest
         run: |

--- a/docker/Dockerfile.openscap
+++ b/docker/Dockerfile.openscap
@@ -6,7 +6,9 @@ RUN ARCH=$(uname -m) && \
     dnf install -y --nodocs 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo "https://mirror.stream.centos.org/9-stream/AppStream/${ARCH}/os/"
 
-# Install OpenSCAP, SCAP content, and Python into a clean rootfs
+# Install OpenSCAP, SCAP content, and Python into a clean rootfs.
+# Then remove pip/setuptools wheel packages from RPM database (not needed
+# at runtime) and strip the bundled ensurepip module to eliminate pip CVEs.
 RUN mkdir -p /mnt/rootfs && \
     dnf install --installroot /mnt/rootfs --releasever 9 \
         --setopt install_weak_deps=0 --nodocs --nogpgcheck -y \
@@ -15,6 +17,8 @@ RUN mkdir -p /mnt/rootfs && \
         openscap-scanner \
         scap-security-guide \
         python3 \
+    && rpm --root /mnt/rootfs -e --nodeps python3-pip-wheel python3-setuptools-wheel \
+    && rm -rf /mnt/rootfs/usr/lib/python3.9/ensurepip \
     && dnf --installroot /mnt/rootfs clean all \
     && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 


### PR DESCRIPTION
## Summary
- Add `sbom: true` and `provenance: mode=max` to both backend and openscap `docker/build-push-action` steps, resolving the "Missing supply chain attestation(s)" Docker Scout policy violation
- Remove `python3-pip-wheel` and `python3-setuptools-wheel` from the openscap image (unused at runtime), eliminating 2 CVEs (CVE-2023-45803 medium, CVE-2021-3572 low)

## Impact
- **OpenSCAP image**: 18 CVEs to 16 CVEs, 147 packages to 143 packages
- **Both images**: Supply chain attestation policy now satisfied (SBOM + max-mode provenance attached to every build)
- All remaining CVEs are in base image packages (glibc, zlib, brotli, etc.) with no upstream fix available from Red Hat

## Test plan
- [x] Local build of openscap image succeeds
- [x] Docker Scout scan of local build confirms 16 CVEs (down from 18)
- [x] pip-wheel and setuptools-wheel removed from RPM database
- [ ] CI docker-publish workflow runs with attestations attached