### PR TITLE
chore: add VEX attestation for CVE-2026-24051

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -425,6 +425,23 @@ jobs:
           push-to-registry: true
         continue-on-error: true
 
+      - name: Checkout (for VEX files)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .vex
+
+      - name: Attach VEX attestations
+        run: |
+          for vex in .vex/*.vex.json; do
+            [ -f "$vex" ] || continue
+            echo "Attaching VEX: $vex"
+            docker scout attestation add \
+              --file "$vex" \
+              --predicate-type https://openvex.dev/ns/v0.2.0 \
+              ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@${{ steps.inspect.outputs.digest }}
+          done
+        continue-on-error: true
+
   merge-openscap:
     name: OpenSCAP Multi-Arch Manifest
     runs-on: ubuntu-latest

--- a/.vex/CVE-2026-24051.vex.json
+++ b/.vex/CVE-2026-24051.vex.json
@@ -1,0 +1,30 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/artifact-keeper/artifact-keeper/vex/CVE-2026-24051",
+  "author": "Artifact Keeper <security@artifactkeeper.com>",
+  "timestamp": "2026-02-26T10:00:00Z",
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-24051",
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-24051"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/artifactkeeper/backend",
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/go.opentelemetry.io/otel/sdk@1.38.0"
+            },
+            {
+              "@id": "pkg:golang/go.opentelemetry.io/otel/sdk@1.39.0"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-24051 is a PATH hijacking vulnerability in the OpenTelemetry Go SDK HostID detector that only affects macOS/Darwin systems (it exploits the ioreg command). Our Docker images run exclusively on Linux where the vulnerable code path is never executed. The affected packages are transitive dependencies of the bundled Trivy and Grype scanner binaries."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.vex/CVE-2026-24051.vex.json` documenting that CVE-2026-24051 (OpenTelemetry Go SDK PATH hijacking) does not affect our Linux-based Docker images. The vulnerable code path only executes on macOS/Darwin via the `ioreg` command.
- Updates the Docker publish workflow to attach VEX attestations to the backend image using `docker scout attestation add` after the existing provenance attestation step.
- The OpenSCAP image is not affected (it does not bundle Trivy or Grype).

## How it works

The `.vex/` directory holds OpenVEX documents. During the `merge-backend` job, the workflow checks out the `.vex/` directory (sparse checkout) and loops over all `*.vex.json` files, attaching each as an in-toto attestation to the multi-arch manifest digest. Docker Scout reads these attestations to suppress false-positive CVE findings.

Future CVEs that don't apply to our images can be handled by adding another `.vex.json` file to the directory, no workflow changes needed.

## Test plan

- [ ] Verify CI passes (workflow syntax is valid)
- [ ] On next push to main, confirm the VEX attestation step runs (it uses `continue-on-error: true` so it won't block publishing if Docker Scout CLI isn't available)