### PR TITLE
fix: scanner storage backend resolution, Maven SNAPSHOT hard-delete

### DIFF
--- a/.sqlx/query-762e014a2441492256a70ca910a1e865d11a76990e0c3211747ca100d410a8fe.json
+++ b/.sqlx/query-762e014a2441492256a70ca910a1e865d11a76990e0c3211747ca100d410a8fe.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM artifacts WHERE repository_id = $1 AND path = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "762e014a2441492256a70ca910a1e865d11a76990e0c3211747ca100d410a8fe"
+}

--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -390,6 +390,8 @@ pub async fn delete_backup(
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SystemSettings {
+    pub storage_backend: String,
+    pub storage_path: String,
     pub allow_anonymous_download: bool,
     pub max_upload_size_bytes: i64,
     pub retention_days: i32,
@@ -431,6 +433,8 @@ pub async fn get_settings(State(state): State<SharedState>) -> Result<Json<Syste
     .map_err(|e| AppError::Database(e.to_string()))?;
 
     let mut result = SystemSettings {
+        storage_backend: state.config.storage_backend.clone(),
+        storage_path: state.config.storage_path.clone(),
         allow_anonymous_download: false,
         max_upload_size_bytes: 100 * 1024 * 1024, // 100MB default
         retention_days: 365,
@@ -905,6 +909,8 @@ mod tests {
     #[test]
     fn test_system_settings_defaults() {
         let settings = SystemSettings {
+            storage_backend: "filesystem".to_string(),
+            storage_path: "/data/artifacts".to_string(),
             allow_anonymous_download: false,
             max_upload_size_bytes: 100 * 1024 * 1024,
             retention_days: 365,
@@ -918,11 +924,14 @@ mod tests {
         assert_eq!(settings.audit_retention_days, 90);
         assert_eq!(settings.backup_retention_count, 10);
         assert_eq!(settings.edge_stale_threshold_minutes, 5);
+        assert_eq!(settings.storage_backend, "filesystem");
     }
 
     #[test]
     fn test_system_settings_serialization_roundtrip() {
         let settings = SystemSettings {
+            storage_backend: "s3".to_string(),
+            storage_path: "/data/artifacts".to_string(),
             allow_anonymous_download: true,
             max_upload_size_bytes: 500_000_000,
             retention_days: 30,

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -576,9 +576,10 @@ async fn upload(
         if !coords.version.contains("SNAPSHOT") {
             return Err((StatusCode::CONFLICT, "Artifact already exists").into_response());
         }
-        // Soft-delete old SNAPSHOT version
+        // Hard-delete old SNAPSHOT version so the UNIQUE(repository_id, path)
+        // constraint allows re-insert. Safe because SNAPSHOTs are mutable by design.
         let _ = sqlx::query!(
-            "UPDATE artifacts SET is_deleted = true WHERE repository_id = $1 AND path = $2",
+            "DELETE FROM artifacts WHERE repository_id = $1 AND path = $2",
             repo.id,
             path,
         )


### PR DESCRIPTION
## Summary

- Scanner service now receives the shared storage backend and resolves per-repo storage correctly for S3/Azure/GCS instead of always assuming filesystem
- Maven SNAPSHOT uploads hard-delete the previous version so the UNIQUE(repository_id, path) constraint allows re-insert (SNAPSHOTs are mutable by design)
- Admin settings endpoint exposes storage_backend and storage_path fields

## Test plan

- [ ] Scanner works with S3 storage backend
- [ ] Maven SNAPSHOT re-upload succeeds without constraint violation
- [ ] Admin settings API returns storage_backend and storage_path