### PR TITLE
test: add E2E tests for Maven SNAPSHOT re-upload and S3 scanner

### DIFF
--- a/scripts/native-tests/test-maven.sh
+++ b/scripts/native-tests/test-maven.sh
@@ -149,5 +149,145 @@ EOF
 
 mvn dependency:resolve -q
 
+echo "==> Release artifact test PASSED"
+
+# -------------------------------------------------------------------------
+# SNAPSHOT re-upload test
+# -------------------------------------------------------------------------
 echo ""
-echo "Maven native client test PASSED"
+echo "==> Testing SNAPSHOT re-upload..."
+SNAP_VERSION="1.0.0-SNAPSHOT"
+
+cd "$WORK_DIR"
+rm -rf snapshot-project
+mkdir -p snapshot-project/src/main/java/com/test
+cd snapshot-project
+
+cat > pom.xml << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.test</groupId>
+    <artifactId>snapshot-test</artifactId>
+    <version>$SNAP_VERSION</version>
+    <packaging>jar</packaging>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>test-registry</id>
+            <url>$REGISTRY_URL</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>
+EOF
+
+cat > src/main/java/com/test/SnapshotClass.java << EOF
+package com.test;
+
+public class SnapshotClass {
+    public static String version() { return "v1"; }
+}
+EOF
+
+echo "==> First SNAPSHOT deploy..."
+mvn clean package -q
+mvn deploy -q -DaltDeploymentRepository=test-registry::default::$REGISTRY_URL
+
+sleep 1
+
+# Verify first upload
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$REGISTRY_URL/com/test/snapshot-test/$SNAP_VERSION/snapshot-test-$SNAP_VERSION.jar")
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: Expected HTTP 200 for first SNAPSHOT upload, got $HTTP_CODE"
+  exit 1
+fi
+echo "==> First SNAPSHOT upload verified (HTTP $HTTP_CODE)"
+
+# Get checksum of first upload
+FIRST_SHA=$(curl -s "$REGISTRY_URL/com/test/snapshot-test/$SNAP_VERSION/snapshot-test-$SNAP_VERSION.jar.sha1")
+
+# Modify source and re-deploy
+echo "==> Modifying source and re-deploying SNAPSHOT..."
+cat > src/main/java/com/test/SnapshotClass.java << EOF
+package com.test;
+
+public class SnapshotClass {
+    public static String version() { return "v2-updated"; }
+}
+EOF
+
+mvn clean package -q
+mvn deploy -q -DaltDeploymentRepository=test-registry::default::$REGISTRY_URL
+
+sleep 1
+
+# Verify re-upload succeeded (not 409 Conflict or 500)
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$REGISTRY_URL/com/test/snapshot-test/$SNAP_VERSION/snapshot-test-$SNAP_VERSION.jar")
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: Expected HTTP 200 after SNAPSHOT re-upload, got $HTTP_CODE"
+  exit 1
+fi
+
+# Verify content actually changed
+SECOND_SHA=$(curl -s "$REGISTRY_URL/com/test/snapshot-test/$SNAP_VERSION/snapshot-test-$SNAP_VERSION.jar.sha1")
+
+if [ "$FIRST_SHA" = "$SECOND_SHA" ]; then
+  echo "FAIL: SNAPSHOT content did not change after re-upload (same SHA1)"
+  exit 1
+fi
+
+echo "==> SNAPSHOT re-upload verified: content updated (SHA1 changed)"
+
+# Verify release artifact re-upload is still rejected
+echo "==> Verifying release re-upload is rejected..."
+cd "$WORK_DIR"
+cd snapshot-project
+
+cat > pom.xml << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.test</groupId>
+    <artifactId>test-artifact-native</artifactId>
+    <version>$TEST_VERSION</version>
+    <packaging>jar</packaging>
+
+    <distributionManagement>
+        <repository>
+            <id>test-registry</id>
+            <url>$REGISTRY_URL</url>
+        </repository>
+    </distributionManagement>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>
+EOF
+
+mvn clean package -q
+if mvn deploy -q -DaltDeploymentRepository=test-registry::default::$REGISTRY_URL 2>/dev/null; then
+  echo "FAIL: Release re-upload should have been rejected (409 Conflict)"
+  exit 1
+fi
+
+echo "==> Release re-upload correctly rejected (409 Conflict)"
+
+echo ""
+echo "Maven native client test PASSED (release + SNAPSHOT)"


### PR DESCRIPTION
## Summary

- Add SNAPSHOT re-upload E2E test to `test-maven.sh`: deploys a SNAPSHOT, modifies source, re-deploys, verifies content changed via SHA1 comparison, and confirms release re-upload is still rejected with 409
- Add S3 scanner resolution E2E test to `test-s3-redirect.sh`: triggers a security scan on an S3-backed artifact and verifies the scanner does not fall back to the local filesystem (the bug fixed in #301)

Closes #303

## Test plan

- [x] Both scripts pass `bash -n` syntax validation
- [ ] Maven SNAPSHOT test passes against running backend
- [ ] S3 scanner test passes against backend with S3 storage configured