### PR TITLE
Fix code scanning alerts #16 and #39

### DIFF
--- a/.vex/CVE-2025-68121.vex.json
+++ b/.vex/CVE-2025-68121.vex.json
@@ -1,0 +1,27 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/artifact-keeper/artifact-keeper/vex/CVE-2025-68121",
+  "author": "Artifact Keeper <security@artifactkeeper.com>",
+  "timestamp": "2026-02-27T00:00:00Z",
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-68121",
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2025-68121"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/artifactkeeper/backend",
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/stdlib@1.25.6"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "CVE-2025-68121 is a TLS session resumption vulnerability in Go's crypto/tls package (stdlib v1.25.6, fixed in v1.25.7). The affected code is in the bundled Grype scanner binary, which only makes outgoing HTTPS connections to fetch vulnerability databases. Grype v0.109.0 is the latest upstream release and has not yet been recompiled with Go 1.25.7+. The scanner runs in an isolated container environment with no inbound TLS listeners. Will be resolved when Grype releases a version compiled with Go >= 1.25.7."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Alert #39** (CodeQL `py/command-line-injection` in `openscap-wrapper.py:146`): Added defense-in-depth re-validation of `scan_path`, `profile`, and `content_file` directly within `run_oscap_scan()`, adjacent to the `subprocess.run()` call. The inputs were already validated in the HTTP handler (`do_POST`), but CodeQL couldn't trace the sanitization across function boundaries.
- **Alert #16** (CVE-2025-68121 in grype's Go stdlib): Added VEX statement at `.vex/CVE-2025-68121.vex.json`. Grype v0.109.0 is the latest upstream release, compiled with Go 1.25.6 (fix requires Go 1.25.7+). Alert dismissed as "won't fix" pending upstream update.

## Test plan

- [ ] CodeQL re-scan no longer flags `openscap-wrapper.py:146`
- [ ] VEX attestation attaches to published images via existing `docker-publish.yml` workflow