### PR TITLE
fix: use X-Forwarded-Proto/Host in OCI v2 auth challenge

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -1439,10 +1439,7 @@ mod tests {
             HeaderValue::from_static("registry.example.com:30443"),
         );
         headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
-        assert_eq!(
-            request_host(&headers),
-            "https://registry.example.com:30443"
-        );
+        assert_eq!(request_host(&headers), "https://registry.example.com:30443");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `request_host()` in the OCI v2 handler always used `http://` when constructing the `WWW-Authenticate` realm URL, ignoring reverse proxy headers
- When behind a TLS-terminating proxy (Caddy, Nginx, Next.js), Docker received `realm="http://host:port/v2/token"` but the port only speaks TLS, so Docker could never reach the token endpoint
- Now checks `X-Forwarded-Proto` for the scheme and `X-Forwarded-Host` for the host, matching the pattern already used by the Git LFS, NuGet, Cargo, and npm handlers

Fixes #315