### PR TITLE
Add release gate integration with artifact-keeper-test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,14 @@ jobs:
       image_tag: dev
     secrets: inherit
 
+  release-gate:
+    name: Release Gate (Full Suite)
+    uses: artifact-keeper/artifact-keeper-test/.github/workflows/release-gate.yml@main
+    with:
+      backend_tag: dev
+      test_suite: all
+    secrets: inherit
+
   # ════════════════════════════════════════════════════════════════════════════
   # BUILD BINARIES
   # ════════════════════════════════════════════════════════════════════════════
@@ -44,7 +52,7 @@ jobs:
   build-binaries:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: [e2e-gate]
+    needs: [e2e-gate, release-gate]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Adds a `release-gate` job to the release workflow that calls `artifact-keeper-test/.github/workflows/release-gate.yml@main`
- Runs the full test suite (38 formats, security, stress, resilience, mesh) against the candidate build
- Build binaries now depend on both the existing E2E gate and the new release gate

## Test plan
- [ ] Trigger a manual release workflow run and verify the release-gate job appears
- [ ] Verify build-binaries waits for release-gate to pass