### PR TITLE
fix: use --param instead of deprecated --parameter in argocd CLI

### DIFF
--- a/.github/workflows/mesh-e2e.yml
+++ b/.github/workflows/mesh-e2e.yml
@@ -57,7 +57,7 @@ jobs:
           for app in ak-mesh-main ak-mesh-peer-1 ak-mesh-peer-2 ak-mesh-peer-3; do
             echo "Syncing $app with image tag ${{ inputs.image_tag || 'dev' }}..."
             argocd app sync "$app" \
-              --parameter "backend.image.tag=${{ inputs.image_tag || 'dev' }}" \
+              --param "backend.image.tag=${{ inputs.image_tag || 'dev' }}" \
               --timeout 300
           done
 


### PR DESCRIPTION
## Summary
- The argocd CLI removed the `--parameter` flag in recent versions. Updates `mesh-e2e.yml` to use `--param` instead.

## Test plan
- [ ] Re-run mesh-e2e workflow after merge to verify argocd sync works