### PR TITLE
fix: download trivy and grype directly from GitHub releases

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -115,11 +115,18 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Download scanner CLIs ----------
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7 AS scanners
-ARG TRIVY_VERSION=v0.69.1
-ARG GRYPE_VERSION=v0.109.0
+ARG TRIVY_VERSION=0.69.1
+ARG GRYPE_VERSION=0.109.0
+ARG TARGETARCH
 RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 tar gzip && \
-    curl --proto '=https' --tlsv1.2 -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin "${TRIVY_VERSION}" && \
-    curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin "${GRYPE_VERSION}" && \
+    mkdir -p /opt/bin && \
+    ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
+    curl --proto '=https' --tlsv1.2 -sSfL \
+      "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz" \
+      | tar -xz -C /opt/bin trivy && \
+    curl --proto '=https' --tlsv1.2 -sSfL \
+      "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${TARGETARCH:-amd64}.tar.gz" \
+      | tar -xz -C /opt/bin grype && \
     microdnf clean all
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -35,11 +35,18 @@ RUN cargo build --release --features vendored-openssl --bin artifact-keeper
 
 # ---------- Stage 4: Download scanner CLIs ----------
 FROM alpine:3.21 AS scanners
-ARG TRIVY_VERSION=v0.69.1
-ARG GRYPE_VERSION=v0.109.0
+ARG TRIVY_VERSION=0.69.1
+ARG GRYPE_VERSION=0.109.0
+ARG TARGETARCH
 RUN apk add --no-cache curl tar gzip && \
-    curl --proto '=https' --tlsv1.2 -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /opt/bin "${TRIVY_VERSION}" && \
-    curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /opt/bin "${GRYPE_VERSION}" && \
+    mkdir -p /opt/bin && \
+    ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
+    curl --proto '=https' --tlsv1.2 -sSfL \
+      "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz" \
+      | tar -xz -C /opt/bin trivy && \
+    curl --proto '=https' --tlsv1.2 -sSfL \
+      "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${TARGETARCH:-amd64}.tar.gz" \
+      | tar -xz -C /opt/bin grype && \
     rm -rf /var/cache/apk/*
 
 # ---------- Stage 5: Alpine runtime ----------


### PR DESCRIPTION
## Summary
- The upstream install scripts for trivy and grype (`aquasecurity/trivy/main/contrib/install.sh`, `anchore/grype/main/install.sh`) are returning 404, breaking Docker image builds
- Switches both `Dockerfile.backend` and `Dockerfile.backend.alpine` to download release tarballs directly from GitHub Releases
- Adds `TARGETARCH` support for correct multi-arch downloads

## Test plan
- [ ] CI Docker build passes (no more `/opt/bin/trivy: not found`)
- [ ] Re-run E2E workflow after merge