### PR TITLE
Run mesh-e2e on ARC runners instead of GitHub-hosted

### DIFF
--- a/.github/workflows/mesh-e2e.yml
+++ b/.github/workflows/mesh-e2e.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   mesh-e2e:
     name: Mesh Replication E2E
-    runs-on: ubuntu-latest
+    runs-on: ak-e2e-runners
     timeout-minutes: 30
 
     steps:
@@ -37,11 +37,6 @@ jobs:
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
-
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.MESH_KUBECONFIG }}" | base64 -d > ~/.kube/config
 
       - name: Install ArgoCD CLI
         run: |


### PR DESCRIPTION
## Summary
- Switch mesh-e2e workflow from `ubuntu-latest` to `ak-e2e-runners`
- Remove `MESH_KUBECONFIG` secret setup step (no longer needed)
- ARC runner pods are inside the cluster and use the in-cluster service account which now has ArgoCD permissions (artifact-keeper-iac#19)

The cluster API server is on a private IP that GitHub-hosted runners cannot reach. ARC runners are already in the cluster and can access both kubectl and ArgoCD natively.