### PR TITLE
Fix trivy-action failure from wiped GitHub repo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -279,6 +279,15 @@ jobs:
       # Trivy scans upload SARIF to GitHub Security tab for visibility.
       # exit-code: 0 means scan results are informational — unfixed base image
       # CVEs (Red Hat's responsibility) should not block image publishing.
+      # NOTE: trivy binary extracted from official GHCR image because the
+      # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
+      - name: Install Trivy
+        run: |
+          CONTAINER_ID=$(docker create ghcr.io/aquasecurity/trivy:0.69.1)
+          docker cp "$CONTAINER_ID:/usr/local/bin/trivy" /usr/local/bin/trivy
+          docker rm "$CONTAINER_ID"
+          trivy --version
+
       - name: Trivy scan - Backend
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -288,6 +297,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '0'
+          skip-setup-trivy: true
 
       - name: Trivy scan - OpenSCAP
         uses: aquasecurity/trivy-action@0.34.1
@@ -299,6 +309,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '0'
+          skip-setup-trivy: true
 
       - name: Trivy scan - Backend Alpine
         uses: aquasecurity/trivy-action@0.34.1
@@ -310,6 +321,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '0'
+          skip-setup-trivy: true
 
       - name: Upload Backend Trivy SARIF
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -32,6 +32,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # NOTE: trivy binary extracted from official GHCR image because the
+      # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
+      - name: Install Trivy
+        run: |
+          CONTAINER_ID=$(docker create ghcr.io/aquasecurity/trivy:0.69.1)
+          docker cp "$CONTAINER_ID:/usr/local/bin/trivy" /usr/local/bin/trivy
+          docker rm "$CONTAINER_ID"
+          trivy --version
+
       - name: Trivy scan - Backend
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -41,6 +50,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '0'
+          skip-setup-trivy: true
 
       - name: Trivy scan - OpenSCAP
         uses: aquasecurity/trivy-action@0.34.1
@@ -52,6 +62,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '0'
+          skip-setup-trivy: true
 
       - name: Trivy scan - Backend Alpine
         uses: aquasecurity/trivy-action@0.34.1
@@ -63,6 +74,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           exit-code: '0'
+          skip-setup-trivy: true
 
       - name: Upload Backend Trivy SARIF
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary
- Install trivy binary from `ghcr.io/aquasecurity/trivy:0.69.1` Docker image before running scans
- Pass `skip-setup-trivy: true` to trivy-action so it uses the pre-installed binary
- Fixes docker-publish Security Scan job and scheduled-container-scan workflow

The `aquasecurity/trivy` GitHub repo was wiped (no branches, tags, or releases), causing `aquasecurity/setup-trivy` to fail with "couldn't find remote ref refs/heads/main". The GHCR Docker images are still available.