### PR TITLE
Fix ArgoCD CLI install path on ARC runners

### DIFF
--- a/.github/workflows/mesh-e2e.yml
+++ b/.github/workflows/mesh-e2e.yml
@@ -40,9 +40,11 @@ jobs:
 
       - name: Install ArgoCD CLI
         run: |
-          curl -sSL -o /usr/local/bin/argocd \
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL -o "$HOME/.local/bin/argocd" \
             https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-          chmod +x /usr/local/bin/argocd
+          chmod +x "$HOME/.local/bin/argocd"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync mesh applications
         if: ${{ !inputs.skip_deploy }}


### PR DESCRIPTION
## Summary
- Install ArgoCD CLI to `$HOME/.local/bin` instead of `/usr/local/bin`
- ARC runner containers don't allow writes to `/usr/local/bin` (curl exit code 23)
- Add `$HOME/.local/bin` to `GITHUB_PATH` so subsequent steps find the binary