### PR TITLE
Fix Docker login behind Caddy reverse proxy

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -4,6 +4,8 @@
 
 {$SITE_ADDRESS:localhost} {
 	bind 0.0.0.0
+	reverse_proxy /v2 backend:8080
+	reverse_proxy /v2/* backend:8080
 	reverse_proxy /api/* backend:8080
 	reverse_proxy /health backend:8080
 	reverse_proxy /livez backend:8080
@@ -13,6 +15,8 @@
 }
 
 :80 {
+	reverse_proxy /v2 backend:8080
+	reverse_proxy /v2/* backend:8080
 	reverse_proxy /api/* backend:8080
 	reverse_proxy /health backend:8080
 	reverse_proxy /livez backend:8080


### PR DESCRIPTION
## Summary
- Add `/v2` and `/v2/*` reverse proxy rules to the Caddyfile, routing OCI registry requests directly to the backend
- Without these rules, OCI requests fell through to the web frontend catch-all. Caddy's default trailing-slash handling returned a 308 redirect from `/v2/` to `/v2` before the request reached the backend, which broke Docker's token auth flow: the client never saw the `Www-Authenticate: Bearer` header and never requested a token.

## Root cause
The Docker v2 auth flow requires:
1. `GET /v2/` returns 401 with `Www-Authenticate: Bearer realm="<host>/v2/token",service="artifact-keeper"`
2. Client extracts the token URL and authenticates via `GET /v2/token` with Basic auth
3. Client retries `GET /v2/` with the Bearer token

When Caddy redirected `/v2/` to `/v2` via 308, the redirect response didn't carry the `Www-Authenticate` header, so Docker retried `/v2` without ever requesting a token.

Fixes #322