### PR TITLE
Set ARGOCD_NAMESPACE for mesh-e2e on ARC runners

### DIFF
--- a/.github/workflows/mesh-e2e.yml
+++ b/.github/workflows/mesh-e2e.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Sync mesh applications
         if: ${{ !inputs.skip_deploy }}
+        env:
+          ARGOCD_NAMESPACE: argocd
         run: |
           argocd login --core
 
@@ -59,6 +61,8 @@ jobs:
           done
 
       - name: Wait for healthy
+        env:
+          ARGOCD_NAMESPACE: argocd
         run: |
           argocd login --core
 


### PR DESCRIPTION
## Summary
- Set `ARGOCD_NAMESPACE=argocd` env var for ArgoCD sync and wait steps
- ARC runner pods run in `arc-runners` namespace, but `argocd login --core` defaults to the pod's namespace for finding ArgoCD server resources