### PR TITLE
fix: set kubectl namespace for ArgoCD --core mode in mesh-e2e

### DIFF
--- a/.github/workflows/mesh-e2e.yml
+++ b/.github/workflows/mesh-e2e.yml
@@ -50,9 +50,10 @@ jobs:
 
       - name: Sync mesh applications
         if: ${{ !inputs.skip_deploy }}
-        env:
-          ARGOCD_NAMESPACE: argocd
         run: |
+          # Set kubectl context to argocd namespace so ArgoCD CLI
+          # can find argocd-cm configmap in --core mode
+          kubectl config set-context --current --namespace=argocd
           argocd login --core
 
           TAG="${{ inputs.image_tag || 'dev' }}"
@@ -66,9 +67,8 @@ jobs:
           done
 
       - name: Wait for healthy
-        env:
-          ARGOCD_NAMESPACE: argocd
         run: |
+          kubectl config set-context --current --namespace=argocd
           argocd login --core
 
           for app in ak-mesh-main ak-mesh-peer-1 ak-mesh-peer-2 ak-mesh-peer-3; do


### PR DESCRIPTION
## Summary
- ArgoCD CLI in `--core` mode reads `argocd-cm` configmap from the current kubectl namespace context
- ARC runner pods run in `arc-runners` namespace, so the configmap lookup fails
- Added `kubectl config set-context --current --namespace=argocd` before `argocd login --core`
- Removed `ARGOCD_NAMESPACE` env var (the context namespace is sufficient)

## Test plan
- [ ] Retag v1.1.0-rc.6 and verify mesh-e2e sync step finds argocd-cm