### PR TITLE
Fix CI pipeline: SonarCloud token guard and Docker Compose download verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
           path: lcov.info
 
       - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -205,11 +206,32 @@ jobs:
 
       - name: Install Docker Compose
         run: |
+          # Skip install if docker compose is already available
+          if docker compose version >/dev/null 2>&1; then
+            echo "Docker Compose already available:"
+            docker compose version
+            exit 0
+          fi
+
           DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          COMPOSE_VERSION="v2.32.4"
+          COMPOSE_BINARY="$DOCKER_CONFIG/cli-plugins/docker-compose"
           mkdir -p "$DOCKER_CONFIG/cli-plugins"
-          curl -SL "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64" \
-            -o "$DOCKER_CONFIG/cli-plugins/docker-compose"
-          chmod +x "$DOCKER_CONFIG/cli-plugins/docker-compose"
+
+          echo "Downloading Docker Compose ${COMPOSE_VERSION}..."
+          curl -fSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+            -o "$COMPOSE_BINARY"
+
+          # Verify download succeeded (curl -f returns non-zero on HTTP errors,
+          # but also check file size as a safeguard)
+          FILESIZE=$(stat -c%s "$COMPOSE_BINARY" 2>/dev/null || stat -f%z "$COMPOSE_BINARY" 2>/dev/null || echo "0")
+          if [ "$FILESIZE" -lt 1000000 ]; then
+            echo "ERROR: Downloaded file is ${FILESIZE} bytes (expected >60MB). Download likely failed."
+            rm -f "$COMPOSE_BINARY"
+            exit 1
+          fi
+
+          chmod +x "$COMPOSE_BINARY"
           docker compose version
 
       - name: Login to Docker Hub


### PR DESCRIPTION
## Summary

Fixes two CI infrastructure failures affecting PRs #334 and #337:

- **SonarCloud scan fails on fork PRs**: The `SONAR_TOKEN` secret is not available to workflows triggered by fork PRs (GitHub security model). Added an `if: env.SONAR_TOKEN != ''` guard so the scan step is skipped instead of failing. Coverage collection and artifact upload still run.

- **Docker Compose download silently fails on ARC runners**: The `curl -SL` command was saving HTTP error pages (190 bytes) as the binary without failing. Changed to `curl -fSL` so HTTP errors (404, rate limits, redirects to HTML) cause a non-zero exit. Also added a file size check as a safeguard (compose binary is ~60MB) and an early exit if `docker compose` is already available on the runner.

## Test plan

- [ ] Verify CI passes on this PR itself (the SonarCloud step should be skipped gracefully)
- [ ] Re-run CI on PR #337 after merge to confirm smoke E2E tests recover