### PR TITLE
fix: install rustls CryptoProvider to prevent S3 IRSA panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "rmp-serde",
  "rsa",
  "rust-s3",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -45,6 +45,9 @@ aes-gcm.workspace = true
 # S3 storage using rust-s3 crate
 rust-s3.workspace = true
 
+# TLS (explicit provider selection for rustls 0.23+)
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
 # Logging/Tracing
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -43,6 +43,14 @@ use tonic::transport::Server as TonicServer;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install a rustls CryptoProvider before any TLS operations.
+    // Required by rustls 0.23+ when multiple providers (ring, aws-lc-rs)
+    // are compiled in via transitive dependencies (rust-s3, reqwest, sqlx).
+    // Without this, IRSA/STS credential fetches panic at startup.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls CryptoProvider");
+
     // Load environment variables
     dotenvy::dotenv().ok();
 


### PR DESCRIPTION
## Summary

Fixes the backend panic at startup when using S3 storage with IRSA (IAM Roles for Service Accounts) for AWS authentication.

The `rust-s3` crate fetches STS credentials via `attohttpc`, which uses `rustls` for TLS. Since rustls 0.23+, a `CryptoProvider` must be explicitly installed when multiple providers (`ring`, `aws-lc-rs`) are compiled in via transitive dependencies. Without it, the process panics before the server starts.

The fix installs the `ring` CryptoProvider at the very start of `main()`, before any async code or TLS operations run.

Closes #343

## Test plan

- [ ] `cargo clippy --workspace` passes
- [ ] `cargo test --workspace --lib` passes (6258 tests)
- [ ] Deploy with `STORAGE_BACKEND=s3` and IRSA auth, confirm no panic
- [ ] Verify existing filesystem/MinIO storage backends still work