### PR TITLE
fix(ci): skip smoke E2E tests for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
     name: 🔥 Smoke E2E Tests
     runs-on: ak-e2e-runners
     needs: [test-backend-unit]
+    # Skip for fork PRs: Docker Hub secrets are unavailable and anonymous
+    # pulls hit rate limits. E2E runs on main after merge.
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: read
@@ -438,11 +441,14 @@ jobs:
             fi
           done
 
-          # Smoke E2E
-          if [[ "${{ needs.smoke-e2e.result }}" == "success" ]]; then
+          # Smoke E2E (skipped for fork PRs where Docker Hub secrets are unavailable)
+          smoke_result="${{ needs.smoke-e2e.result }}"
+          if [[ "$smoke_result" == "success" ]]; then
             echo "✅ smoke-e2e" >> $GITHUB_STEP_SUMMARY
+          elif [[ "$smoke_result" == "skipped" ]]; then
+            echo "⏭️ smoke-e2e (fork PR — skipped)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "❌ smoke-e2e: ${{ needs.smoke-e2e.result }}" >> $GITHUB_STEP_SUMMARY
+            echo "❌ smoke-e2e: $smoke_result" >> $GITHUB_STEP_SUMMARY
             tier1_pass=false
           fi
 


### PR DESCRIPTION
## Summary

- Skip smoke E2E for fork PRs where Docker Hub secrets (`DOCKERHUB_USERNAME`) are unavailable, causing anonymous pulls to hit rate limits
- `ci-complete` treats skipped smoke E2E as OK (same pattern as integration tests and container builds)
- Unit tests, lint, and coverage still run for all PRs
- E2E runs after merge on main where secrets are available