### PR TITLE
fix: use fetch_virtual_members helper in npm and pypi handlers

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -27,6 +27,7 @@ use tracing::info;
 use crate::api::handlers::proxy_helpers;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
+use crate::models::repository::RepositoryType;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -207,23 +208,7 @@ async fn get_package_metadata(
         // For virtual repos, iterate through members and try proxy for remote members
         if repo.repo_type == "virtual" {
             if let Some(ref proxy) = state.proxy_service {
-                let members = sqlx::query!(
-                    r#"SELECT r.id, r.key, r.repo_type::text as "repo_type!", r.upstream_url
-                    FROM repositories r
-                    INNER JOIN virtual_repo_members vrm ON r.id = vrm.member_repo_id
-                    WHERE vrm.virtual_repo_id = $1
-                    ORDER BY vrm.priority"#,
-                    repo.id
-                )
-                .fetch_all(&state.db)
-                .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to resolve virtual members: {}", e),
-                    )
-                        .into_response()
-                })?;
+                let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
 
                 for member in &members {
                     // Try local artifacts first
@@ -243,7 +228,7 @@ async fn get_package_metadata(
                     }
 
                     // Try proxy for remote members
-                    if member.repo_type == "remote" {
+                    if member.repo_type == RepositoryType::Remote {
                         if let Some(ref upstream_url) = member.upstream_url {
                             if let Ok((content, _ct)) = proxy_helpers::proxy_fetch(
                                 proxy,
@@ -1153,6 +1138,37 @@ mod tests {
         };
         assert_eq!(info.repo_type, "hosted");
         assert!(info.upstream_url.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Virtual member proxy filtering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_virtual_proxy_only_targets_remote_members() {
+        // get_package_metadata skips non-Remote virtual members.
+        // Verify the RepositoryType enum comparison used in that branch.
+        let remote = RepositoryType::Remote;
+        assert_eq!(remote, RepositoryType::Remote);
+        assert_ne!(remote, RepositoryType::Local);
+        assert_ne!(remote, RepositoryType::Virtual);
+        assert_ne!(remote, RepositoryType::Staging);
+    }
+
+    #[test]
+    fn test_virtual_member_filter_selects_remote_only() {
+        use crate::models::repository::RepositoryType;
+        let types = [
+            RepositoryType::Local,
+            RepositoryType::Remote,
+            RepositoryType::Virtual,
+            RepositoryType::Staging,
+        ];
+        let remote_count = types
+            .iter()
+            .filter(|t| **t == RepositoryType::Remote)
+            .count();
+        assert_eq!(remote_count, 1);
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -27,6 +27,7 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::middleware::auth::{require_auth_basic, AuthExtension};
 use crate::api::SharedState;
 use crate::formats::pypi::PypiHandler;
+use crate::models::repository::RepositoryType;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -244,27 +245,11 @@ async fn simple_project(
         // For virtual repos, iterate through members and try proxy for remote members
         if repo.repo_type == "virtual" {
             if let Some(ref proxy) = state.proxy_service {
-                let members = sqlx::query!(
-                    r#"SELECT r.id, r.key, r.repo_type::text as "repo_type!", r.upstream_url
-                    FROM repositories r
-                    INNER JOIN virtual_repo_members vrm ON r.id = vrm.member_repo_id
-                    WHERE vrm.virtual_repo_id = $1
-                    ORDER BY vrm.priority"#,
-                    repo.id
-                )
-                .fetch_all(&state.db)
-                .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to resolve virtual members: {}", e),
-                    )
-                        .into_response()
-                })?;
+                let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
 
                 for member in &members {
                     // Try proxy for remote members
-                    if member.repo_type == "remote" {
+                    if member.repo_type == RepositoryType::Remote {
                         if let Some(ref upstream_url) = member.upstream_url {
                             let upstream_path = format!("simple/{}/", normalized);
                             if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
@@ -1124,5 +1109,35 @@ mod tests {
     fn test_extract_metadata_from_sdist_invalid_data() {
         let result = extract_metadata_from_sdist(b"not a tar.gz");
         assert!(result.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Virtual member proxy filtering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_virtual_proxy_only_targets_remote_members() {
+        // simple_project skips non-Remote virtual members.
+        // Verify the RepositoryType enum comparison used in that branch.
+        let remote = RepositoryType::Remote;
+        assert_eq!(remote, RepositoryType::Remote);
+        assert_ne!(remote, RepositoryType::Local);
+        assert_ne!(remote, RepositoryType::Virtual);
+        assert_ne!(remote, RepositoryType::Staging);
+    }
+
+    #[test]
+    fn test_virtual_member_filter_selects_remote_only() {
+        let types = [
+            RepositoryType::Local,
+            RepositoryType::Remote,
+            RepositoryType::Virtual,
+            RepositoryType::Staging,
+        ];
+        let remote_count = types
+            .iter()
+            .filter(|t| **t == RepositoryType::Remote)
+            .count();
+        assert_eq!(remote_count, 1);
     }
 }


### PR DESCRIPTION
## Summary
An attempt to handle https://github.com/artifact-keeper/artifact-keeper/issues/344

Replace duplicate inline sqlx queries in get_package_metadata (npm.rs) and simple_project (pypi.rs) with calls to the shared proxy_helpers::fetch_virtual_members helper. The repo_type comparison is updated from a string literal to the RepositoryType enum.

## Test Checklist
- [X] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [X] Manually tested locally
- [X] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [X] N/A - no API changes
