### PR TITLE
fix: use ci-mirror namespace for GHCR image mirrors

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -19,15 +19,15 @@ jobs:
       matrix:
         include:
           - image: postgres:16-alpine
-            target: ghcr.io/artifact-keeper/mirror/postgres:16-alpine
+            target: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
           - image: alpine:3.19
-            target: ghcr.io/artifact-keeper/mirror/alpine:3.19
+            target: ghcr.io/artifact-keeper/ci-mirror/alpine:3.19
           - image: python:3.12-slim
-            target: ghcr.io/artifact-keeper/mirror/python:3.12-slim
+            target: ghcr.io/artifact-keeper/ci-mirror/python:3.12-slim
           - image: node:20-slim
-            target: ghcr.io/artifact-keeper/mirror/node:20-slim
+            target: ghcr.io/artifact-keeper/ci-mirror/node:20-slim
           - image: rust:1.75-slim
-            target: ghcr.io/artifact-keeper/mirror/rust:1.75-slim
+            target: ghcr.io/artifact-keeper/ci-mirror/rust:1.75-slim
 
     steps:
       - name: Log in to GHCR

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -29,7 +29,7 @@ services:
   # ==========================================================================
 
   postgres:
-    image: postgres:16-alpine
+    image: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
     container_name: e2e-test-db
     environment:
       POSTGRES_USER: registry
@@ -85,7 +85,7 @@ services:
 
   # Bootstrap: create test repositories after backend is healthy
   setup:
-    image: alpine:3.19
+    image: ghcr.io/artifact-keeper/ci-mirror/alpine:3.19
     container_name: e2e-test-setup
     depends_on:
       backend:
@@ -104,7 +104,7 @@ services:
 
   # PKI service: uses pre-generated files from .pki/ if available (CI), otherwise generates them (local)
   pki:
-    image: alpine:3.19
+    image: ghcr.io/artifact-keeper/ci-mirror/alpine:3.19
     container_name: e2e-test-pki
     command: >
       sh -c "
@@ -141,7 +141,7 @@ services:
   # ==========================================================================
 
   pypi-test:
-    image: python:3.12-slim
+    image: ghcr.io/artifact-keeper/ci-mirror/python:3.12-slim
     container_name: e2e-test-pypi
     depends_on:
       setup:
@@ -161,7 +161,7 @@ services:
     profiles: ["pypi", "smoke", "all"]
 
   npm-test:
-    image: node:20-slim
+    image: ghcr.io/artifact-keeper/ci-mirror/node:20-slim
     container_name: e2e-test-npm
     depends_on:
       setup:
@@ -181,7 +181,7 @@ services:
     profiles: ["npm", "smoke", "all"]
 
   cargo-test:
-    image: rust:1.75-slim
+    image: ghcr.io/artifact-keeper/ci-mirror/rust:1.75-slim
     container_name: e2e-test-cargo
     depends_on:
       setup:
@@ -390,7 +390,7 @@ services:
   # ==========================================================================
 
   proxy-virtual-test:
-    image: node:20-slim
+    image: ghcr.io/artifact-keeper/ci-mirror/node:20-slim
     container_name: e2e-test-proxy-virtual
     depends_on:
       setup:


### PR DESCRIPTION
## Summary

- Switches GHCR mirror images from `mirror/` to `ci-mirror/` namespace
- The original `mirror/` packages were created private and unlinked, making them inaccessible to GITHUB_TOKEN and impossible to overwrite without `delete:packages` scope
- New `ci-mirror/` packages are created with `org.opencontainers.image.source` label, auto-linking them to the repo (verified: all 5 are public and linked)
- Fixes smoke E2E failures on main caused by Docker Hub rate limits on unauthenticated pulls

## Test plan

- [ ] Mirror workflow creates all 5 packages successfully (verified)
- [ ] All packages are public and linked to repo (verified)
- [ ] Smoke E2E pulls from GHCR ci-mirror without auth issues
- [ ] All CI checks pass