### PR TITLE
feat: embed git commit SHA in /health endpoint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,6 +77,8 @@ jobs:
           cache-to: type=gha,scope=backend-${{ matrix.platform }},mode=max
           sbom: true
           provenance: mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Export digest
         run: |
@@ -209,6 +211,8 @@ jobs:
           cache-to: type=gha,scope=backend-alpine-${{ matrix.platform }},mode=max
           sbom: true
           provenance: mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Export digest
         run: |

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -10,5 +10,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .file_descriptor_set_path(&descriptor_path)
         .out_dir(&out_dir)
         .compile_protos(&["proto/sbom.proto"], &["proto"])?;
+
+    let git_sha = std::env::var("GIT_SHA")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()
+                .and_then(|o| {
+                    if o.status.success() {
+                        String::from_utf8(o.stdout)
+                            .ok()
+                            .map(|s| s.trim().to_string())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| "unknown".to_string())
+        });
+    println!("cargo:rustc-env=GIT_SHA={git_sha}");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+
     Ok(())
 }

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -21,6 +21,10 @@ pub struct HealthResponse {
     pub checks: HealthChecks,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_pool: Option<DbPoolStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dirty: Option<bool>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -151,6 +155,14 @@ pub async fn health_check(State(state): State<SharedState>) -> impl IntoResponse
         size: state.db.size(),
     };
 
+    let git_sha = env!("GIT_SHA");
+    let is_prerelease = env!("CARGO_PKG_VERSION").contains('-');
+    let (commit, dirty) = if git_sha != "unknown" {
+        (Some(git_sha.to_string()), Some(is_prerelease))
+    } else {
+        (None, None)
+    };
+
     let response = HealthResponse {
         status: overall_status.to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -162,6 +174,8 @@ pub async fn health_check(State(state): State<SharedState>) -> impl IntoResponse
             meilisearch: meili_check,
         },
         db_pool: Some(pool_stats),
+        commit,
+        dirty,
     };
 
     let status_code = if overall_status == "healthy" {
@@ -436,6 +450,8 @@ mod tests {
                 meilisearch: None,
             },
             db_pool: Some(sample_pool_stats()),
+            commit: None,
+            dirty: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -447,6 +463,9 @@ mod tests {
         assert!(json.contains("\"max_connections\":20"));
         // security_scanner is None, should be skipped
         assert!(!json.contains("\"security_scanner\""));
+        // commit/dirty are None, should be skipped
+        assert!(!json.contains("\"commit\""));
+        assert!(!json.contains("\"dirty\""));
     }
 
     #[test]
@@ -462,6 +481,8 @@ mod tests {
                 meilisearch: None,
             },
             db_pool: None,
+            commit: None,
+            dirty: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -481,6 +502,8 @@ mod tests {
                 meilisearch: None,
             },
             db_pool: None,
+            commit: None,
+            dirty: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -520,6 +543,8 @@ mod tests {
                 meilisearch: None,
             },
             db_pool: None,
+            commit: None,
+            dirty: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -623,5 +648,49 @@ mod tests {
         assert!(json.contains("\"idle_connections\":15"));
         assert!(json.contains("\"active_connections\":5"));
         assert!(json.contains("\"size\":20"));
+    }
+
+    #[test]
+    fn test_health_response_with_commit_and_dirty() {
+        let response = HealthResponse {
+            status: "healthy".to_string(),
+            version: "1.1.0-rc.5".to_string(),
+            demo_mode: false,
+            checks: HealthChecks {
+                database: healthy_check(),
+                storage: healthy_check(),
+                security_scanner: None,
+                meilisearch: None,
+            },
+            db_pool: None,
+            commit: Some("abc1234def5678".to_string()),
+            dirty: Some(true),
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"commit\":\"abc1234def5678\""));
+        assert!(json.contains("\"dirty\":true"));
+    }
+
+    #[test]
+    fn test_health_response_commit_omitted_when_none() {
+        let response = HealthResponse {
+            status: "healthy".to_string(),
+            version: "1.1.0".to_string(),
+            demo_mode: false,
+            checks: HealthChecks {
+                database: healthy_check(),
+                storage: healthy_check(),
+                security_scanner: None,
+                meilisearch: None,
+            },
+            db_pool: None,
+            commit: None,
+            dirty: None,
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(!json.contains("\"commit\""));
+        assert!(!json.contains("\"dirty\""));
     }
 }

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -42,7 +42,9 @@ COPY --from=deps /root/.cargo/registry /root/.cargo/registry
 COPY Cargo.toml Cargo.lock ./
 COPY .sqlx ./.sqlx
 COPY backend ./backend
+ARG GIT_SHA=unknown
 ENV SQLX_OFFLINE=true
+ENV GIT_SHA=${GIT_SHA}
 RUN cargo build --release --bin artifact-keeper
 
 # ---------- Stage 4: Build minimal rootfs ----------

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -30,7 +30,9 @@ COPY --from=deps /usr/local/cargo/registry /usr/local/cargo/registry
 COPY Cargo.toml Cargo.lock ./
 COPY .sqlx ./.sqlx
 COPY backend ./backend
+ARG GIT_SHA=unknown
 ENV SQLX_OFFLINE=true
+ENV GIT_SHA=${GIT_SHA}
 RUN cargo build --release --features vendored-openssl --bin artifact-keeper
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------


### PR DESCRIPTION
## Summary

- Embeds the git commit SHA at compile time via `build.rs`, using `GIT_SHA` env var (Docker/CI), `git rev-parse HEAD` (local dev), or `"unknown"` as fallback
- Adds `commit` and `dirty` optional fields to the `/health` JSON response, only serialized for prerelease builds where the SHA is known
- Passes `GIT_SHA=${{ github.sha }}` as a Docker build-arg in CI for both UBI and Alpine backend images

## Test plan

- [x] `cargo test --workspace --lib health` passes (69 tests, including 2 new: `test_health_response_with_commit_and_dirty`, `test_health_response_commit_omitted_when_none`)
- [ ] Local `cargo run` then `curl localhost:8080/health` shows `commit` and `dirty` fields
- [ ] Stable version (no `-` in version) hides `commit`/`dirty` from JSON
- [ ] Docker build with `--build-arg GIT_SHA=abc123` embeds the SHA correctly

Closes #152