### PR TITLE
fix: detect fork PRs in SonarCloud gate workflow

### DIFF
--- a/.github/workflows/sonarcloud-gate.yml
+++ b/.github/workflows/sonarcloud-gate.yml
@@ -39,9 +39,21 @@ jobs:
         id: pr
         env:
           PR_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           PR_NUMBER=$(echo "$PR_JSON" | \
             python3 -c "import sys,json; prs=json.load(sys.stdin); print(prs[0]['number'] if prs else '')")
+
+          # For fork PRs, workflow_run.pull_requests is empty. Fall back to
+          # searching by HEAD SHA via the GitHub API.
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "pull_requests array empty, searching by HEAD SHA..."
+            PR_NUMBER=$(gh api "repos/${GH_REPO}/pulls?state=open&sort=updated&direction=desc&per_page=30" \
+              --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" 2>/dev/null | head -1)
+          fi
+
           # Validate PR number is numeric to prevent injection
           if [[ -z "$PR_NUMBER" ]]; then
             echo "No PR associated with this workflow run. Skipping."


### PR DESCRIPTION
## Summary
- GitHub does not populate `workflow_run.pull_requests` for PRs from forks, causing the SonarCloud Quality Gate check to skip entirely and block merging (it's a required status check)
- Falls back to searching open PRs by HEAD SHA via the GitHub API when the array is empty
- Fixes PR #377 being blocked by a missing SonarCloud status

## Test plan
- [ ] Merge this PR first, then re-run CI on PR #377 to trigger the sonarcloud-gate workflow
- [ ] Verify SonarCloud Quality Gate status appears on PR #377