### PR TITLE
fix: add ALLOW_HTTP_INTEGRATIONS to compose files

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -181,6 +181,7 @@ services:
       MEILISEARCH_API_KEY: artifact-keeper-dev-key
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
       DEPENDENCY_TRACK_ENABLED: "true"
+      ALLOW_HTTP_INTEGRATIONS: "1"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
       OTEL_SERVICE_NAME: artifact-keeper
       HOST: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,7 @@ services:
       # Dependency-Track integration (API key auto-provisioned by dtrack-init)
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
       DEPENDENCY_TRACK_ENABLED: ${DEPENDENCY_TRACK_ENABLED:-true}
+      ALLOW_HTTP_INTEGRATIONS: "1"
       HOST: 0.0.0.0
       PORT: 8080
     volumes:


### PR DESCRIPTION
## Summary
- Adds `ALLOW_HTTP_INTEGRATIONS=1` to the backend environment in both `docker-compose.yml` and `docker-compose.local-dev.yml`
- Without this, the Dependency-Track HTTP client enforces HTTPS-only, causing DTrack API calls to silently fail since all internal compose URLs use `http://`

## Context
Reported in #395. Both compose files use `http://` for inter-service URLs (Trivy, Meilisearch, OpenSCAP, Dependency-Track) but never set this flag. The backend's `dependency_track_service.rs` creates its client with `https_only(!allow_http)`, so without the env var, DTrack integration is broken in any compose deployment.

## Test plan
- [ ] Full compose stack test with DTrack enabled (verify SBOM uploads and scanning work)
- [ ] Verify no regression on HTTPS deployments (flag only applies to DTrack and Artifactory clients)