### PR TITLE
fix: kill gpg-agent before cleanup in E2E PKI container

### DIFF
--- a/scripts/pki/generate-gpg.sh
+++ b/scripts/pki/generate-gpg.sh
@@ -12,7 +12,7 @@ mkdir -p "$OUTPUT_DIR"
 
 # Create a temporary GNUPGHOME to avoid polluting user's keyring
 export GNUPGHOME="$(mktemp -d)"
-trap 'rm -rf "$GNUPGHOME"' EXIT
+trap 'gpgconf --kill gpg-agent 2>/dev/null; rm -rf "$GNUPGHOME"' EXIT
 
 echo "==> Generating GPG key pair..."
 


### PR DESCRIPTION
## Summary

- Kill gpg-agent before `rm -rf $GNUPGHOME` in the EXIT trap of `scripts/pki/generate-gpg.sh`
- The gpg-agent creates socket files (`S.gpg-agent.ssh`) that may already be removed by the agent when the trap fires, causing `rm` to fail under `set -e`
- This exit(1) cascades through docker compose: the PKI container fails its healthcheck, all test containers that depend on it see "dependency failed to start", and the entire E2E suite silently skips without running any tests

## Root cause

The nightly E2E failure (#398) was not a test failure. Zero tests actually ran. The PKI init container exited with code 1 due to a race condition in GPG agent socket cleanup.

## Test plan

- [ ] Re-run nightly E2E workflow manually after merge
- [ ] Verify PKI container exits cleanly (code 0)
- [ ] Verify test containers actually execute and produce output

Closes #398