### PR TITLE
Bump trivy CI scanner to 0.69.3, pick up zlib fix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -287,7 +287,7 @@ jobs:
       # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
       - name: Install Trivy
         run: |
-          CONTAINER_ID=$(docker create ghcr.io/aquasecurity/trivy:0.69.1)
+          CONTAINER_ID=$(docker create ghcr.io/aquasecurity/trivy:0.69.3)
           docker cp "$CONTAINER_ID:/usr/local/bin/trivy" /usr/local/bin/trivy
           docker rm "$CONTAINER_ID"
           trivy --version

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -36,7 +36,7 @@ jobs:
       # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
       - name: Install Trivy
         run: |
-          CONTAINER_ID=$(docker create ghcr.io/aquasecurity/trivy:0.69.1)
+          CONTAINER_ID=$(docker create ghcr.io/aquasecurity/trivy:0.69.3)
           docker cp "$CONTAINER_ID:/usr/local/bin/trivy" /usr/local/bin/trivy
           docker rm "$CONTAINER_ID"
           trivy --version


### PR DESCRIPTION
## Summary

- Bumps the trivy container image used in CI from 0.69.1 to 0.69.3, aligning with the version already pinned in `Dockerfile.backend.alpine` and `Dockerfile.backend`.
- The 0.69.3 image is built on Alpine 3.23, which ships zlib 1.3.2-r0, fixing CVE-2026-22184 (critical) and CVE-2026-27171 (medium).
- No code changes. Only version pins in two workflow files: `docker-publish.yml` and `scheduled-container-scan.yml`.