### PR TITLE
Add artifact content viewing endpoint

### DIFF
--- a/backend/src/api/handlers/tree.rs
+++ b/backend/src/api/handlers/tree.rs
@@ -247,19 +247,15 @@ pub async fn get_content(
     Query(params): Query<ContentQuery>,
 ) -> Result<impl IntoResponse> {
     // Verify repository exists and check visibility
-    let repo_row: Option<(Uuid, bool, String)> = sqlx::query_as(
-        "SELECT id, is_public, storage_path FROM repositories WHERE key = $1",
-    )
-    .bind(&params.repository_key)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|e| AppError::Database(e.to_string()))?;
+    let repo_row: Option<(Uuid, bool, String)> =
+        sqlx::query_as("SELECT id, is_public, storage_path FROM repositories WHERE key = $1")
+            .bind(&params.repository_key)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
     let (repo_id, is_public, storage_path) = repo_row.ok_or_else(|| {
-        AppError::NotFound(format!(
-            "Repository '{}' not found",
-            params.repository_key
-        ))
+        AppError::NotFound(format!("Repository '{}' not found", params.repository_key))
     })?;
 
     // Private repos require authentication
@@ -298,9 +294,7 @@ pub async fn get_content(
 
     // Truncate to max_bytes if specified
     let body = match params.max_bytes {
-        Some(max) if max >= 0 && (max as usize) < content.len() => {
-            content.slice(..max as usize)
-        }
+        Some(max) if max >= 0 && (max as usize) < content.len() => content.slice(..max as usize),
         _ => content,
     };
 
@@ -322,17 +316,17 @@ pub async fn get_content(
                 header::HeaderName::from_static("x-content-size"),
                 artifact.size_bytes.to_string(),
             ),
-            (
-                header::CACHE_CONTROL,
-                "public, max-age=3600".to_string(),
-            ),
+            (header::CACHE_CONTROL, "public, max-age=3600".to_string()),
         ],
         body,
     ))
 }
 
 #[derive(OpenApi)]
-#[openapi(paths(get_tree, get_content), components(schemas(TreeResponse, TreeNodeResponse,)))]
+#[openapi(
+    paths(get_tree, get_content),
+    components(schemas(TreeResponse, TreeNodeResponse,))
+)]
 pub struct TreeApiDoc;
 
 #[cfg(test)]
@@ -694,8 +688,7 @@ mod tests {
 
     #[test]
     fn test_content_query_with_max_bytes() {
-        let json =
-            r#"{"repository_key": "npm", "path": "lodash/package.json", "max_bytes": 4096}"#;
+        let json = r#"{"repository_key": "npm", "path": "lodash/package.json", "max_bytes": 4096}"#;
         let q: ContentQuery = serde_json::from_str(json).unwrap();
         assert_eq!(q.repository_key, "npm");
         assert_eq!(q.path, "lodash/package.json");


### PR DESCRIPTION
## Summary

- New `GET /api/v1/tree/content` endpoint returns artifact bytes with Content-Type header for inline viewing (not attachment download)
- Supports `max_bytes` query parameter for truncated previews of large files
- Content type detection via stored metadata with `mime_guess` fallback
- Follows existing tree handler patterns for auth, repo visibility, and OpenAPI docs

## Test Plan

- [ ] `cargo test --workspace --lib` passes (6436 tests)
- [ ] Hit `/api/v1/tree/content?repository_key=<key>&path=<path>` and verify Content-Type header is correct
- [ ] Verify `max_bytes` truncates response while `x-content-size` reports full size
- [ ] Verify private repos return 404 for unauthenticated requests