### PR TITLE
fix: add no_proxy to backend for container-to-container traffic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,24 @@ JWT_EXPIRATION_SECS=86400
 # DTRACK_NO_PROXY=localhost,127.0.0.1
 
 # -----------------------------------------------------------------------------
+# Corporate proxy (host-level)
+# -----------------------------------------------------------------------------
+# If your host has HTTP_PROXY / HTTPS_PROXY set, Docker and Podman will
+# propagate them into containers. This can cause the backend's health checks
+# and API calls to route through the proxy instead of reaching services on
+# the compose network directly.
+#
+# The compose files already set no_proxy for internal service names, but if
+# you need to customize the proxy behavior, set these in your .env:
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://proxy.example.com:8080
+# NO_PROXY=localhost,127.0.0.1,.internal.com,10.,172.,192.
+#
+# The backend appends internal service hostnames (db, meilisearch, trivy,
+# openscap, dependency-track-apiserver) to NO_PROXY automatically via the
+# compose file. You do not need to add them here.
+
+# -----------------------------------------------------------------------------
 # Network security (backend)
 # -----------------------------------------------------------------------------
 # Allow HTTP (non-TLS) connections for remote repository proxying, Artifactory

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -182,6 +182,9 @@ services:
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
       DEPENDENCY_TRACK_ENABLED: "true"
       ALLOW_HTTP_INTEGRATIONS: "1"
+      # Prevent host proxy settings from intercepting container-to-container
+      # traffic on the compose network. See docker-compose.yml for details.
+      no_proxy: "${NO_PROXY:-},localhost,127.0.0.1,db,postgres,meilisearch,trivy,openscap,dependency-track-apiserver"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
       OTEL_SERVICE_NAME: artifact-keeper
       HOST: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,13 @@ services:
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
       DEPENDENCY_TRACK_ENABLED: ${DEPENDENCY_TRACK_ENABLED:-true}
       ALLOW_HTTP_INTEGRATIONS: "1"
+      # Prevent host proxy settings (HTTP_PROXY/HTTPS_PROXY) from intercepting
+      # container-to-container traffic. Docker and Podman propagate proxy vars
+      # from the host, which causes health checks and API calls to route through
+      # corporate proxies instead of the compose network. We append internal
+      # service names so they always resolve directly.
+      # ref: https://github.com/artifact-keeper/artifact-keeper/issues/395
+      no_proxy: "${NO_PROXY:-},localhost,127.0.0.1,db,postgres,meilisearch,trivy,openscap,dependency-track-apiserver"
       HOST: 0.0.0.0
       PORT: 8080
     volumes:


### PR DESCRIPTION
## Summary
- Add `no_proxy` environment variable to the backend service in both `docker-compose.yml` and `docker-compose.local-dev.yml`
- Appends internal service hostnames (db, postgres, meilisearch, trivy, openscap, dependency-track-apiserver) so health checks and API calls resolve directly on the compose network instead of routing through corporate proxies
- Document proxy configuration in `.env.example`

## Context

When users behind corporate proxies set `HTTP_PROXY`/`HTTPS_PROXY` on the host, Docker and Podman propagate these into containers. The Rust HTTP client respects these vars, causing all health check requests to route through the proxy. The proxy can't resolve container hostnames, returning 503 for every internal service.

The `NO_PROXY` users typically set on their hosts includes IP ranges and domain suffixes, but not bare container hostnames like `trivy` or `meilisearch`, so the proxy intercepts them.

## Test plan
- [ ] `docker compose up -d` with `HTTP_PROXY` set on host, verify backend health checks pass
- [ ] `docker compose up -d` without proxy vars, verify no regression
- [ ] Verify `.env.example` documents the proxy behavior

Closes #395