### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ scripts/sso-e2e/sso-config-ids.env
 
 # Git worktrees
 .worktrees/
+charts/artifact-keeper/charts/*.tgz
+charts/artifact-keeper/Chart.lock

--- a/charts/artifact-keeper/.helmignore
+++ b/charts/artifact-keeper/.helmignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: artifact-keeper
+description: A universal artifact registry supporting 25+ package formats with vulnerability scanning and SBOM analysis
+type: application
+version: 0.1.0
+appVersion: "1.1.0"
+home: https://artifactkeeper.com
+sources:
+  - https://github.com/artifact-keeper/artifact-keeper
+maintainers:
+  - name: artifact-keeper
+    url: https://github.com/artifact-keeper
+keywords:
+  - artifact-registry
+  - package-manager
+  - docker-registry
+  - oci
+  - vulnerability-scanning
+  - sbom
+
+dependencies:
+  # PostgreSQL — disable and set externalPostgresql if using an existing instance
+  - name: postgresql
+    version: "16.4.1"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+
+  # Meilisearch — disable and set externalMeilisearch if using an existing instance
+  - name: meilisearch
+    version: "0.27.0"
+    repository: https://meilisearch.github.io/meilisearch-kubernetes
+    condition: meilisearch.enabled

--- a/charts/artifact-keeper/templates/NOTES.txt
+++ b/charts/artifact-keeper/templates/NOTES.txt
@@ -1,0 +1,66 @@
+
+=================================================================
+  Artifact Keeper {{ .Chart.AppVersion }} deployed!
+=================================================================
+
+{{- if .Values.ingress.enabled }}
+
+  Access via Ingress:
+    Host: {{ .Values.ingress.host }}
+    {{- if .Values.ingress.tls }}
+    URL:  https://{{ .Values.ingress.host }}
+    {{- else }}
+    URL:  http://{{ .Values.ingress.host }}
+    {{- end }}
+
+{{- else if .Values.gateway.enabled }}
+
+  Access via Gateway API:
+    Host: {{ .Values.gateway.host }}
+
+{{- else }}
+
+  Access via port-forward:
+    kubectl port-forward svc/{{ include "artifact-keeper.fullname" . }}-backend {{ .Values.backend.service.port }}:{{ .Values.backend.service.port }}
+  {{- if .Values.web.enabled }}
+    kubectl port-forward svc/{{ include "artifact-keeper.fullname" . }}-web {{ .Values.web.service.port }}:{{ .Values.web.service.port }}
+  {{- end }}
+
+{{- end }}
+
+Components:
+  - Backend API:    {{ include "artifact-keeper.fullname" . }}-backend:{{ .Values.backend.service.port }}
+  {{- if .Values.web.enabled }}
+  - Web UI:         {{ include "artifact-keeper.fullname" . }}-web:{{ .Values.web.service.port }}
+  {{- end }}
+  {{- if .Values.trivy.enabled }}
+  - Trivy:          {{ include "artifact-keeper.fullname" . }}-trivy:{{ .Values.trivy.service.port }}
+  {{- end }}
+  {{- if .Values.openscap.enabled }}
+  - OpenSCAP:       {{ include "artifact-keeper.fullname" . }}-openscap:{{ .Values.openscap.service.port }}
+  {{- end }}
+  {{- if .Values.dependencyTrack.enabled }}
+  - Dep-Track:      {{ include "artifact-keeper.fullname" . }}-dtrack:{{ .Values.dependencyTrack.service.port }}
+  {{- end }}
+
+Database:
+  {{- if .Values.postgresql.enabled }}
+  - PostgreSQL (subchart): {{ .Release.Name }}-postgresql:5432
+  {{- else }}
+  - External PostgreSQL: {{ .Values.externalPostgresql.host }}:{{ .Values.externalPostgresql.port }}
+  {{- end }}
+
+Search:
+  {{- if .Values.meilisearch.enabled }}
+  - Meilisearch (subchart): {{ .Release.Name }}-meilisearch:7700
+  {{- else }}
+  - External Meilisearch: {{ .Values.externalMeilisearch.host }}:{{ .Values.externalMeilisearch.port }}
+  {{- end }}
+
+=================================================================
+  IMPORTANT: Change the JWT secret in production!
+  {{- if eq .Values.backend.jwtSecret "change-me-in-production-please" }}
+  WARNING: You are using the default JWT secret. Set backend.jwtSecret
+           or backend.existingJwtSecret for production.
+  {{- end }}
+=================================================================

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -1,0 +1,155 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "artifact-keeper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "artifact-keeper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "artifact-keeper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "artifact-keeper.labels" -}}
+helm.sh/chart: {{ include "artifact-keeper.chart" . }}
+{{ include "artifact-keeper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "artifact-keeper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "artifact-keeper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Backend image
+*/}}
+{{- define "artifact-keeper.backend.image" -}}
+{{- printf "%s:%s" .Values.backend.image.repository (default .Chart.AppVersion .Values.backend.image.tag) }}
+{{- end }}
+
+{{/*
+Web image
+*/}}
+{{- define "artifact-keeper.web.image" -}}
+{{- printf "%s:%s" .Values.web.image.repository (default .Chart.AppVersion .Values.web.image.tag) }}
+{{- end }}
+
+{{/*
+OpenSCAP image
+*/}}
+{{- define "artifact-keeper.openscap.image" -}}
+{{- printf "%s:%s" .Values.openscap.image.repository (default .Chart.AppVersion .Values.openscap.image.tag) }}
+{{- end }}
+
+{{/*
+PostgreSQL host — subchart or external
+*/}}
+{{- define "artifact-keeper.postgresql.host" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "%s-postgresql" .Release.Name }}
+{{- else }}
+{{- .Values.externalPostgresql.host }}
+{{- end }}
+{{- end }}
+
+{{/*
+PostgreSQL port
+*/}}
+{{- define "artifact-keeper.postgresql.port" -}}
+{{- if .Values.postgresql.enabled }}
+{{- 5432 }}
+{{- else }}
+{{- .Values.externalPostgresql.port | default 5432 }}
+{{- end }}
+{{- end }}
+
+{{/*
+PostgreSQL DATABASE_URL
+*/}}
+{{- define "artifact-keeper.databaseUrl" -}}
+{{- $host := include "artifact-keeper.postgresql.host" . }}
+{{- $port := include "artifact-keeper.postgresql.port" . }}
+{{- if .Values.postgresql.enabled }}
+{{- printf "postgresql://%s:%s@%s:%s/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password $host $port .Values.postgresql.auth.database }}
+{{- else }}
+{{- printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" .Values.externalPostgresql.username .Values.externalPostgresql.password $host $port .Values.externalPostgresql.database (.Values.externalPostgresql.sslMode | default "prefer") }}
+{{- end }}
+{{- end }}
+
+{{/*
+Dependency-Track database URL (JDBC format, separate database)
+*/}}
+{{- define "artifact-keeper.dtrack.databaseUrl" -}}
+{{- $host := include "artifact-keeper.postgresql.host" . }}
+{{- $port := include "artifact-keeper.postgresql.port" . }}
+{{- printf "jdbc:postgresql://%s:%s/dependency_track" $host $port }}
+{{- end }}
+
+{{/*
+Dependency-Track PostgreSQL credentials
+*/}}
+{{- define "artifact-keeper.dtrack.dbUsername" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.username }}
+{{- else }}
+{{- .Values.externalPostgresql.username }}
+{{- end }}
+{{- end }}
+
+{{- define "artifact-keeper.dtrack.dbPassword" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.password }}
+{{- else }}
+{{- .Values.externalPostgresql.password }}
+{{- end }}
+{{- end }}
+
+{{/*
+Meilisearch URL — subchart or external
+*/}}
+{{- define "artifact-keeper.meilisearch.url" -}}
+{{- if .Values.meilisearch.enabled }}
+{{- printf "http://%s-meilisearch:7700" .Release.Name }}
+{{- else }}
+{{- printf "http://%s:%s" .Values.externalMeilisearch.host (toString (.Values.externalMeilisearch.port | default 7700)) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Meilisearch API key
+*/}}
+{{- define "artifact-keeper.meilisearch.apiKey" -}}
+{{- if .Values.meilisearch.enabled }}
+{{- .Values.meilisearch.masterKey | default "artifact-keeper-production-key" }}
+{{- else }}
+{{- .Values.externalMeilisearch.apiKey }}
+{{- end }}
+{{- end }}

--- a/charts/artifact-keeper/templates/backend-configmap.yaml
+++ b/charts/artifact-keeper/templates/backend-configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-backend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+data:
+  STORAGE_PATH: /data/storage
+  BACKUP_PATH: /data/backups
+  PLUGINS_DIR: /data/plugins
+  SCAN_WORKSPACE_PATH: /scan-workspace
+  RUST_LOG: {{ .Values.backend.rustLog | quote }}
+  ENVIRONMENT: {{ .Values.backend.environment | quote }}
+  HOST: "0.0.0.0"
+  PORT: "8080"
+  DATABASE_URL: {{ include "artifact-keeper.databaseUrl" . | quote }}
+  MEILISEARCH_URL: {{ include "artifact-keeper.meilisearch.url" . | quote }}
+  {{- if .Values.backend.corsOrigins }}
+  CORS_ORIGINS: {{ .Values.backend.corsOrigins | quote }}
+  {{- end }}
+  {{- if .Values.trivy.enabled }}
+  TRIVY_URL: {{ printf "http://%s-trivy:%d" (include "artifact-keeper.fullname" .) (int .Values.trivy.service.port) | quote }}
+  {{- end }}
+  {{- if .Values.openscap.enabled }}
+  OPENSCAP_URL: {{ printf "http://%s-openscap:%d" (include "artifact-keeper.fullname" .) (int .Values.openscap.service.port) | quote }}
+  {{- end }}
+  {{- if .Values.dependencyTrack.enabled }}
+  DEPENDENCY_TRACK_URL: {{ printf "http://%s-dtrack:%d" (include "artifact-keeper.fullname" .) (int .Values.dependencyTrack.service.port) | quote }}
+  DEPENDENCY_TRACK_ENABLED: "true"
+  {{- else }}
+  DEPENDENCY_TRACK_ENABLED: "false"
+  {{- end }}
+  {{- range $key, $value := .Values.backend.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-backend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/backend-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/backend-secret.yaml") . | sha256sum }}
+        {{- with .Values.backend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dependencyTrack.enabled }}
+      initContainers:
+        - name: wait-for-dtrack
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for Dependency-Track API key..."
+              for i in $(seq 1 60); do
+                if [ -f /shared/dtrack-api-key ] && [ -s /shared/dtrack-api-key ]; then
+                  echo "API key found"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "WARNING: Dependency-Track API key not found after 5 min, continuing anyway"
+          volumeMounts:
+            - name: shared-config
+              mountPath: /shared
+              readOnly: true
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "artifact-keeper.backend.image" . }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          {{- if .Values.dependencyTrack.enabled }}
+          command:
+            - sh
+            - -c
+            - |
+              if [ -f /shared/dtrack-api-key ] && [ -s /shared/dtrack-api-key ]; then
+                export DEPENDENCY_TRACK_API_KEY="$(cat /shared/dtrack-api-key)"
+              fi
+              exec artifact-keeper
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9090
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "artifact-keeper.fullname" . }}-backend
+            - secretRef:
+                name: {{ .Values.backend.existingJwtSecret | default (printf "%s-backend" (include "artifact-keeper.fullname" .)) }}
+          livenessProbe:
+            {{- toYaml .Values.backend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.backend.readinessProbe | nindent 12 }}
+          {{- with .Values.backend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: artifact-storage
+              mountPath: /data/storage
+            - name: backup-storage
+              mountPath: /data/backups
+            - name: plugins-storage
+              mountPath: /data/plugins
+            - name: scan-workspace
+              mountPath: /scan-workspace
+            {{- if .Values.dependencyTrack.enabled }}
+            - name: shared-config
+              mountPath: /shared
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: artifact-storage
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-artifacts
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-backups
+        - name: plugins-storage
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-plugins
+        - name: scan-workspace
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-scan-workspace
+        {{- if .Values.dependencyTrack.enabled }}
+        - name: shared-config
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-shared-config
+        {{- end }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/artifact-keeper/templates/backend-pvc.yaml
+++ b/charts/artifact-keeper/templates/backend-pvc.yaml
@@ -1,0 +1,40 @@
+{{- $fullname := include "artifact-keeper.fullname" . }}
+{{- $labels := include "artifact-keeper.labels" . }}
+{{- $sc := .Values.global.storageClass }}
+{{- range $name, $size := dict "artifacts" .Values.backend.storage.artifacts.size "backups" .Values.backend.storage.backups.size "plugins" .Values.backend.storage.plugins.size "scan-workspace" .Values.backend.storage.scanWorkspace.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullname }}-{{ $name }}
+  labels:
+    {{- $labels | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if $sc }}
+  storageClassName: {{ $sc }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $size }}
+{{- end }}
+{{- if .Values.dependencyTrack.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullname }}-shared-config
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if $sc }}
+  storageClassName: {{ $sc }}
+  {{- end }}
+  resources:
+    requests:
+      storage: 100Mi
+{{- end }}

--- a/charts/artifact-keeper/templates/backend-secret.yaml
+++ b/charts/artifact-keeper/templates/backend-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.backend.existingJwtSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-backend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+type: Opaque
+stringData:
+  JWT_SECRET: {{ .Values.backend.jwtSecret | quote }}
+  MEILISEARCH_API_KEY: {{ include "artifact-keeper.meilisearch.apiKey" . | quote }}
+  {{- if .Values.backend.adminPassword }}
+  ADMIN_PASSWORD: {{ .Values.backend.adminPassword | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/artifact-keeper/templates/backend-service.yaml
+++ b/charts/artifact-keeper/templates/backend-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-backend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.backend.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "artifact-keeper.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend

--- a/charts/artifact-keeper/templates/dtrack-deployment.yaml
+++ b/charts/artifact-keeper/templates/dtrack-deployment.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.dependencyTrack.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dependency-track
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dependency-track
+  template:
+    metadata:
+      {{- with .Values.dependencyTrack.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: dependency-track
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: apiserver
+          image: "{{ .Values.dependencyTrack.image.repository }}:{{ .Values.dependencyTrack.image.tag }}"
+          imagePullPolicy: {{ .Values.dependencyTrack.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: ALPINE_DATABASE_MODE
+              value: external
+            - name: ALPINE_DATABASE_URL
+              value: {{ include "artifact-keeper.dtrack.databaseUrl" . | quote }}
+            - name: ALPINE_DATABASE_DRIVER
+              value: org.postgresql.Driver
+            - name: ALPINE_DATABASE_USERNAME
+              value: {{ include "artifact-keeper.dtrack.dbUsername" . | quote }}
+            - name: ALPINE_DATABASE_PASSWORD
+              value: {{ include "artifact-keeper.dtrack.dbPassword" . | quote }}
+            - name: ALPINE_DATA_DIRECTORY
+              value: /data
+            - name: ALPINE_ENFORCE_AUTHENTICATION
+              value: "true"
+            - name: ALPINE_CORS_ENABLED
+              value: "true"
+            - name: ALPINE_CORS_ALLOW_ORIGIN
+              value: "*"
+          livenessProbe:
+            httpGet:
+              path: /api/version
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/version
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 10
+          {{- with .Values.dependencyTrack.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: dtrack-data
+              mountPath: /data
+      volumes:
+        - name: dtrack-data
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-dtrack-data
+      {{- with .Values.dependencyTrack.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dependencyTrack.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dependencyTrack.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dependency-track
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.dependencyTrack.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "artifact-keeper.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dependency-track
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack-data
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dependency-track
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.dependencyTrack.storage.size }}
+{{- end }}

--- a/charts/artifact-keeper/templates/dtrack-frontend.yaml
+++ b/charts/artifact-keeper/templates/dtrack-frontend.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.dependencyTrack.enabled .Values.dependencyTrack.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack-frontend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dtrack-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dtrack-frontend
+  template:
+    metadata:
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: dtrack-frontend
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: "{{ .Values.dependencyTrack.frontend.image.repository }}:{{ .Values.dependencyTrack.frontend.image.tag }}"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: API_BASE_URL
+              value: {{ printf "http://%s-dtrack:%d" (include "artifact-keeper.fullname" .) (int .Values.dependencyTrack.service.port) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack-frontend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dtrack-frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.dependencyTrack.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "artifact-keeper.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dtrack-frontend
+{{- end }}

--- a/charts/artifact-keeper/templates/dtrack-init-job.yaml
+++ b/charts/artifact-keeper/templates/dtrack-init-job.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.dependencyTrack.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack-init
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dtrack-init
+  annotations:
+    # Run after the main resources are created
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: dtrack-init
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      containers:
+        - name: dtrack-init
+          image: {{ include "artifact-keeper.backend.image" . }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+
+              DT_URL="http://{{ include "artifact-keeper.fullname" . }}-dtrack:{{ .Values.dependencyTrack.service.port }}"
+              DT_ADMIN_USER="admin"
+              DT_DEFAULT_PASS="admin"
+              DT_NEW_PASS="{{ .Values.dependencyTrack.adminPassword }}"
+              API_KEY_FILE="/shared/dtrack-api-key"
+
+              echo "[dtrack-init] Waiting for Dependency-Track at $DT_URL ..."
+              for i in $(seq 1 60); do
+                if curl -sf "$DT_URL/api/version" > /dev/null 2>&1; then
+                  break
+                fi
+                if [ "$i" -eq 60 ]; then
+                  echo "[dtrack-init] ERROR: Dependency-Track did not become ready" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+              echo "[dtrack-init] Dependency-Track is up"
+
+              # Skip if already provisioned
+              if [ -f "$API_KEY_FILE" ] && [ -s "$API_KEY_FILE" ]; then
+                echo "[dtrack-init] API key already provisioned — skipping"
+                exit 0
+              fi
+
+              # Try login with new password first
+              TOKEN=$(curl -sf -X POST "$DT_URL/api/v1/user/login" \
+                -H "Content-Type: application/x-www-form-urlencoded" \
+                -d "username=${DT_ADMIN_USER}&password=${DT_NEW_PASS}" 2>/dev/null || true)
+
+              if [ -z "$TOKEN" ] || echo "$TOKEN" | grep -qi "FORCE_PASSWORD_CHANGE"; then
+                echo "[dtrack-init] Changing default admin password..."
+                curl -sf -o /dev/null \
+                  -X POST "$DT_URL/api/v1/user/forceChangePassword" \
+                  -H "Content-Type: application/x-www-form-urlencoded" \
+                  -d "username=${DT_ADMIN_USER}&password=${DT_DEFAULT_PASS}&newPassword=${DT_NEW_PASS}&confirmPassword=${DT_NEW_PASS}" || true
+
+                TOKEN=$(curl -sf -X POST "$DT_URL/api/v1/user/login" \
+                  -H "Content-Type: application/x-www-form-urlencoded" \
+                  -d "username=${DT_ADMIN_USER}&password=${DT_NEW_PASS}" 2>/dev/null || true)
+              fi
+
+              if [ -z "$TOKEN" ]; then
+                echo "[dtrack-init] ERROR: Could not authenticate" >&2
+                exit 1
+              fi
+
+              echo "[dtrack-init] Authenticated successfully"
+
+              API_KEY=$(curl -sf "$DT_URL/api/v1/team" \
+                -H "Authorization: Bearer $TOKEN" | \
+                jq -r '.[] | select(.name == "Automation") | .apiKeys[0].key // empty')
+
+              if [ -z "$API_KEY" ]; then
+                echo "[dtrack-init] ERROR: Could not find Automation team API key" >&2
+                exit 1
+              fi
+
+              echo "$API_KEY" > "$API_KEY_FILE"
+              echo "[dtrack-init] API key written to $API_KEY_FILE"
+
+              # Enable NVD API 2.0
+              curl -sf -o /dev/null \
+                -X POST "$DT_URL/api/v1/configProperty" \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-Type: application/json" \
+                -d '{"groupName":"vuln-source","propertyName":"nvd.feeds.url","propertyValue":"https://services.nvd.nist.gov/rest/json/cves/2.0"}' || true
+
+              echo "[dtrack-init] Done"
+          volumeMounts:
+            - name: shared-config
+              mountPath: /shared
+      volumes:
+        - name: shared-config
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-shared-config
+{{- end }}

--- a/charts/artifact-keeper/templates/gateway-httproute.yaml
+++ b/charts/artifact-keeper/templates/gateway-httproute.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    - name: {{ .Values.gateway.gatewayRef.name }}
+      {{- if .Values.gateway.gatewayRef.namespace }}
+      namespace: {{ .Values.gateway.gatewayRef.namespace }}
+      {{- end }}
+      {{- if .Values.gateway.gatewayRef.sectionName }}
+      sectionName: {{ .Values.gateway.gatewayRef.sectionName }}
+      {{- end }}
+  hostnames:
+    - {{ .Values.gateway.host | quote }}
+  rules:
+    # API and system endpoints → backend
+    {{- $backendSvc := printf "%s-backend" (include "artifact-keeper.fullname" .) }}
+    {{- $backendPort := int .Values.backend.service.port }}
+    # /health, /livez, /readyz, /metrics are internal-only (probes + Prometheus)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+        - path:
+            type: PathPrefix
+            value: /swagger-ui
+        - path:
+            type: PathPrefix
+            value: /v2
+      backendRefs:
+        - name: {{ $backendSvc }}
+          port: {{ $backendPort }}
+
+    # Native package format handlers → backend
+    {{- range list "maven" "npm" "pypi" "nuget" "cargo" "gems" "go" "helm" "debian" "rpm" "alpine" "composer" "conan" "conda" "swift" "terraform" "cocoapods" "hex" "pub" "lfs" "ivy" "chef" "puppet" "ansible" "cran" "huggingface" "jetbrains" "vscode" "proto" "incus" "ext" }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /{{ . }}
+      backendRefs:
+        - name: {{ $backendSvc }}
+          port: {{ $backendPort }}
+    {{- end }}
+
+    # Default: everything else → web frontend
+    {{- if .Values.web.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "artifact-keeper.fullname" . }}-web
+          port: {{ int .Values.web.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/artifact-keeper/templates/ingress.yaml
+++ b/charts/artifact-keeper/templates/ingress.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          # API and system endpoints → backend
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "artifact-keeper.fullname" . }}-backend
+                port:
+                  number: {{ .Values.backend.service.port }}
+          # /health, /livez, /readyz, /metrics are internal-only (probes + Prometheus)
+          - path: /swagger-ui
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "artifact-keeper.fullname" . }}-backend
+                port:
+                  number: {{ .Values.backend.service.port }}
+          # OCI / Docker registry
+          - path: /v2
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "artifact-keeper.fullname" . }}-backend
+                port:
+                  number: {{ .Values.backend.service.port }}
+          # Native package format handlers
+          {{- $backendSvc := printf "%s-backend" (include "artifact-keeper.fullname" .) }}
+          {{- $backendPort := int .Values.backend.service.port }}
+          {{- range list "maven" "npm" "pypi" "nuget" "cargo" "gems" "go" "helm" "debian" "rpm" "alpine" "composer" "conan" "conda" "swift" "terraform" "cocoapods" "hex" "pub" "lfs" "ivy" "chef" "puppet" "ansible" "cran" "huggingface" "jetbrains" "vscode" "proto" "incus" "ext" }}
+          - path: /{{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $backendSvc }}
+                port:
+                  number: {{ $backendPort }}
+          {{- end }}
+          # Default: everything else → web frontend
+          {{- if .Values.web.enabled }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "artifact-keeper.fullname" . }}-web
+                port:
+                  number: {{ .Values.web.service.port }}
+          {{- end }}
+{{- end }}

--- a/charts/artifact-keeper/templates/openscap-deployment.yaml
+++ b/charts/artifact-keeper/templates/openscap-deployment.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.openscap.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-openscap
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openscap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: openscap
+  template:
+    metadata:
+      {{- with .Values.openscap.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: openscap
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: openscap
+          image: {{ include "artifact-keeper.openscap.image" . }}
+          imagePullPolicy: {{ .Values.openscap.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8091
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.openscap.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: scan-workspace
+              mountPath: /scan-workspace
+              readOnly: true
+      volumes:
+        - name: scan-workspace
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-scan-workspace
+      {{- with .Values.openscap.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.openscap.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.openscap.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-openscap
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: openscap
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.openscap.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "artifact-keeper.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: openscap
+{{- end }}

--- a/charts/artifact-keeper/templates/trivy-deployment.yaml
+++ b/charts/artifact-keeper/templates/trivy-deployment.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.trivy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-trivy
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: trivy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: trivy
+  template:
+    metadata:
+      {{- with .Values.trivy.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: trivy
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: trivy
+          image: "{{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}"
+          imagePullPolicy: {{ .Values.trivy.image.pullPolicy }}
+          args: ["server", "--listen", "0.0.0.0:8090"]
+          ports:
+            - name: http
+              containerPort: 8090
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.trivy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: trivy-cache
+              mountPath: /root/.cache/trivy
+            - name: scan-workspace
+              mountPath: /scan-workspace
+              readOnly: true
+      volumes:
+        - name: trivy-cache
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-trivy-cache
+        - name: scan-workspace
+          persistentVolumeClaim:
+            claimName: {{ include "artifact-keeper.fullname" . }}-scan-workspace
+      {{- with .Values.trivy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.trivy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.trivy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-trivy
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: trivy
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.trivy.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "artifact-keeper.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: trivy
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-trivy-cache
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: trivy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.trivy.cache.size }}
+{{- end }}

--- a/charts/artifact-keeper/templates/web-deployment.yaml
+++ b/charts/artifact-keeper/templates/web-deployment.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-web
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      {{- with .Values.web.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "artifact-keeper.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: {{ include "artifact-keeper.web.image" . }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: BACKEND_URL
+              value: {{ printf "http://%s-backend:%d" (include "artifact-keeper.fullname" .) (int .Values.backend.service.port) }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/artifact-keeper/templates/web-service.yaml
+++ b/charts/artifact-keeper/templates/web-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-web
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "artifact-keeper.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+{{- end }}

--- a/charts/artifact-keeper/values-external-deps.yaml
+++ b/charts/artifact-keeper/values-external-deps.yaml
@@ -1,0 +1,60 @@
+# Example: using external PostgreSQL and Meilisearch instead of subcharts
+# Usage: helm install artifact-keeper ./charts/artifact-keeper -f ./charts/artifact-keeper/values-external-deps.yaml
+
+# Disable subcharts
+postgresql:
+  enabled: false
+meilisearch:
+  enabled: false
+
+# Point to external PostgreSQL (e.g., RDS, Cloud SQL, managed PG)
+externalPostgresql:
+  host: my-postgres.example.com
+  port: 5432
+  username: registry
+  password: ""  # prefer existingSecret
+  database: artifact_registry
+  sslMode: require
+  existingSecret: artifact-keeper-pg-credentials  # must contain POSTGRES_PASSWORD, DATABASE_URL
+
+# Point to external Meilisearch
+externalMeilisearch:
+  host: my-meilisearch.example.com
+  port: 7700
+  apiKey: ""  # prefer existingSecret
+  existingSecret: artifact-keeper-meili-credentials  # must contain MEILISEARCH_API_KEY
+
+# Production-ready settings
+backend:
+  jwtSecret: ""  # prefer existingJwtSecret
+  existingJwtSecret: artifact-keeper-jwt-secret  # must contain JWT_SECRET
+  environment: production
+  corsOrigins: "https://registry.example.com"
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  host: registry.example.com
+  tls:
+    - secretName: artifact-keeper-tls
+      hosts:
+        - registry.example.com
+
+# Or use Gateway API instead of Ingress:
+# ingress:
+#   enabled: false
+# gateway:
+#   enabled: true
+#   gatewayRef:
+#     name: main-gateway
+#   host: registry.example.com

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -1,0 +1,250 @@
+# =============================================================================
+# Artifact Keeper Helm Chart — values.yaml
+# =============================================================================
+
+# -- Global settings
+global:
+  # -- Image pull secrets for private registries
+  imagePullSecrets: []
+  # -- Storage class for all PVCs (empty = cluster default)
+  storageClass: ""
+
+# =============================================================================
+# Backend (Rust API server)
+# =============================================================================
+backend:
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-backend
+    tag: ""  # defaults to .Chart.AppVersion
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  # -- Kubernetes service
+  service:
+    type: ClusterIP
+    port: 8080
+    grpcPort: 9090
+  # -- Resource limits
+  resources: {}
+    # requests:
+    #   cpu: 250m
+    #   memory: 512Mi
+    # limits:
+    #   cpu: "1"
+    #   memory: 1Gi
+  # -- Extra environment variables (key-value pairs)
+  extraEnv: {}
+  # -- JWT secret for API authentication
+  jwtSecret: "change-me-in-production-please"
+  # -- Existing secret containing JWT_SECRET key (overrides jwtSecret)
+  existingJwtSecret: ""
+  # -- Admin password for first-boot setup (empty = auto-generated to PVC)
+  adminPassword: ""
+  # -- Log level
+  rustLog: "info,artifact_keeper=debug"
+  # -- Environment name
+  environment: production
+  # -- CORS origins (comma-separated)
+  corsOrigins: ""
+  # -- Storage volumes
+  storage:
+    artifacts:
+      size: 50Gi
+    backups:
+      size: 20Gi
+    plugins:
+      size: 5Gi
+    scanWorkspace:
+      size: 10Gi
+  # -- Pod annotations
+  podAnnotations: {}
+  # -- Node selector
+  nodeSelector: {}
+  # -- Tolerations
+  tolerations: []
+  # -- Affinity rules
+  affinity: {}
+  # -- Liveness probe
+  livenessProbe:
+    httpGet:
+      path: /livez
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 10
+  # -- Readiness probe
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+# =============================================================================
+# Web (Next.js frontend)
+# =============================================================================
+web:
+  enabled: true
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-web
+    tag: ""  # defaults to .Chart.AppVersion
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 3000
+  resources: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# Ingress (replaces Caddy reverse proxy)
+# =============================================================================
+ingress:
+  enabled: true
+  className: ""  # e.g. "nginx", "traefik"
+  annotations: {}
+    # nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  host: artifact-keeper.local
+  tls: []
+    # - secretName: artifact-keeper-tls
+    #   hosts:
+    #     - artifact-keeper.local
+
+# =============================================================================
+# Gateway API (new K8s standard, alternative to Ingress)
+# Use this instead of ingress when your cluster has a Gateway API controller
+# (e.g. Envoy Gateway, Istio, Cilium, Kong, etc.)
+# =============================================================================
+gateway:
+  enabled: false
+  # -- Reference to the parent Gateway resource
+  gatewayRef:
+    name: ""       # e.g. "main-gateway"
+    namespace: ""  # leave empty for same namespace
+    sectionName: "" # optional listener name
+  host: artifact-keeper.local
+  annotations: {}
+
+# =============================================================================
+# Trivy (vulnerability scanner)
+# =============================================================================
+trivy:
+  enabled: true
+  image:
+    repository: aquasec/trivy
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    port: 8090
+  resources: {}
+  cache:
+    size: 10Gi
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# OpenSCAP (compliance scanner)
+# =============================================================================
+openscap:
+  enabled: true
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-openscap
+    tag: ""  # defaults to .Chart.AppVersion
+    pullPolicy: IfNotPresent
+  service:
+    port: 8091
+  resources: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# Dependency-Track (SBOM analysis — optional)
+# =============================================================================
+dependencyTrack:
+  enabled: true
+  image:
+    repository: dependencytrack/apiserver
+    tag: "4.11.4"
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  # -- Admin password (changed from default on first boot)
+  adminPassword: "ArtifactKeeper2026!"
+  # -- Existing secret with ADMIN_PASSWORD key
+  existingAdminSecret: ""
+  resources: {}
+  storage:
+    size: 10Gi
+  # -- Optional frontend for direct DTrack access
+  frontend:
+    enabled: false
+    image:
+      repository: dependencytrack/frontend
+      tag: "4.11.4"
+    service:
+      port: 8080
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
+# PostgreSQL (Bitnami subchart)
+# Set enabled=false and configure externalPostgresql for an existing instance
+# =============================================================================
+postgresql:
+  enabled: true
+  auth:
+    username: registry
+    password: registry
+    database: artifact_registry
+  primary:
+    persistence:
+      size: 20Gi
+    initdb:
+      scripts:
+        init-db.sql: |
+          CREATE DATABASE dependency_track;
+          GRANT ALL PRIVILEGES ON DATABASE dependency_track TO registry;
+
+# -- External PostgreSQL (used when postgresql.enabled=false)
+externalPostgresql:
+  host: ""
+  port: 5432
+  username: registry
+  password: registry
+  database: artifact_registry
+  sslMode: prefer
+  # -- Existing secret with keys: POSTGRES_PASSWORD, DATABASE_URL
+  existingSecret: ""
+
+# =============================================================================
+# Meilisearch (subchart)
+# Set enabled=false and configure externalMeilisearch for an existing instance
+# =============================================================================
+meilisearch:
+  enabled: true
+  environment:
+    MEILI_ENV: production
+  auth:
+    existingMasterKeySecret: ""
+  masterKey: "artifact-keeper-production-key"
+  persistence:
+    enabled: true
+    size: 10Gi
+
+# -- External Meilisearch (used when meilisearch.enabled=false)
+externalMeilisearch:
+  host: ""
+  port: 7700
+  apiKey: ""
+  # -- Existing secret with key: MEILISEARCH_API_KEY
+  existingSecret: ""


### PR DESCRIPTION
## Summary
- Adds a production-ready Helm chart at `charts/artifact-keeper/` for deploying all services on Kubernetes
- PostgreSQL and Meilisearch are configurable as **subchart dependencies** (default) or **external resources** (RDS, Cloud SQL, managed Meilisearch, etc.)
- Supports both traditional **Ingress** and the new **Gateway API** (HTTPRoute) for traffic routing
- Internal endpoints (`/livez`, `/readyz`, `/metrics`) excluded from public exposure — only available to K8s probes and Prometheus scraping
- All optional components (Trivy, OpenSCAP, Dependency-Track) are toggleable via values
- Includes `values-external-deps.yaml` as a reference for production deployments
- Secrets support `existingSecret` pattern for integration with Vault/external-secrets-operator

## Components
| Component | Subchart/Built-in | External Support |
|-----------|-------------------|------------------|
| PostgreSQL | Bitnami subchart | `externalPostgresql.*` |
| Meilisearch | Official subchart | `externalMeilisearch.*` |
| Trivy | Deployment | `trivy.enabled=false` to disable |
| OpenSCAP | Deployment | `openscap.enabled=false` to disable |
| Dependency-Track | Deployment + init Job | `dependencyTrack.enabled=false` to disable |

## Install examples
```bash
# Default (all-in-one with subcharts)
helm dependency update charts/artifact-keeper/
helm install artifact-keeper ./charts/artifact-keeper

# External dependencies
helm install artifact-keeper ./charts/artifact-keeper \
  -f charts/artifact-keeper/values-external-deps.yaml

# Gateway API instead of Ingress
helm install artifact-keeper ./charts/artifact-keeper \
  --set ingress.enabled=false \
  --set gateway.enabled=true \
  --set gateway.gatewayRef.name=my-gateway
```

## Test plan
- [x] `helm lint --strict` passes
- [x] `helm template` renders all 36 manifests (default scenario)
- [x] External deps scenario: no PG/Meili subcharts, correct DATABASE_URL/MEILISEARCH_URL
- [x] Gateway API scenario: HTTPRoute instead of Ingress
- [x] Minimal scenario: scanners disabled, only backend + web + deps
- [ ] Deploy to a test cluster and verify all pods come up healthy