### PR TITLE
fix: serve Maven secondary GAV files and resolve SNAPSHOT downloads

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -439,6 +439,34 @@ async fn serve_artifact(
             .into_response()
     })?;
 
+    // If artifact not found by exact path, try SNAPSHOT resolution
+    let artifact = match artifact {
+        Some(a) => Some(a),
+        None if path.contains("-SNAPSHOT") => {
+            if let Some(resolved) = resolve_snapshot_artifact(&state.db, repo.id, path).await {
+                let storage = state.storage_for_repo(&repo.storage_path);
+                let content = storage.get(&resolved.storage_key).await.map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Storage error: {}", e),
+                    )
+                        .into_response()
+                })?;
+
+                let ct = content_type_for_path(path);
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, ct)
+                    .header(CONTENT_LENGTH, content.len().to_string())
+                    .header("X-Checksum-SHA256", &resolved.checksum_sha256)
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+            None
+        }
+        None => None,
+    };
+
     // If artifact not found locally, try proxy for remote repos
     let artifact = match artifact {
         Some(a) => a,
@@ -498,6 +526,26 @@ async fn serve_artifact(
                     .body(Body::from(content))
                     .unwrap());
             }
+
+            // For hosted repos, fall back to serving from storage directly.
+            // This handles secondary files (POM, sources, javadoc) that were
+            // grouped under a primary artifact record by GAV grouping — their
+            // database `path` was replaced but the file still exists in storage.
+            if repo.repo_type == RepositoryType::Local || repo.repo_type == RepositoryType::Staging
+            {
+                let storage = state.storage_for_repo(&repo.storage_path);
+                let storage_key = format!("maven/{}", path);
+                if let Ok(content) = storage.get(&storage_key).await {
+                    let ct = content_type_for_path(path);
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(CONTENT_TYPE, ct)
+                        .header(CONTENT_LENGTH, content.len().to_string())
+                        .body(Body::from(content))
+                        .unwrap());
+                }
+            }
+
             return Err((StatusCode::NOT_FOUND, "File not found").into_response());
         }
     };


### PR DESCRIPTION
When mvn deploy uploads a POM followed by a JAR for the same GAV, the
GAV grouping logic updates the artifact record's path to point to the
JAR (the primary artifact), demoting the POM into the metadata files
array. This causes subsequent download requests for the POM to return
404, which makes Maven's post-deploy verification fail with "Could not
find artifact".

Fix by adding two fallbacks to serve_artifact:

1. SNAPSHOT resolution: when the requested path contains -SNAPSHOT and
   no exact DB match exists, resolve it to the latest timestamped
   version via the existing resolve_snapshot_artifact helper (previously
   only used for checksum requests).

2. Storage fallback for hosted repos: when no DB record matches, try
   serving the file directly from storage using the maven/{path} key.
   The file was stored during upload and still exists even though GAV
   grouping overwrote the DB record's path.

Fixes #361