### PR TITLE
fix: wire correlation ID middleware and fix Maven SNAPSHOT handling

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -685,6 +685,47 @@ fn make_file_entry(
     entry
 }
 
+/// Update an existing artifact record to point to a new file (used when a
+/// primary upload replaces a secondary, or a SNAPSHOT re-upload updates the
+/// primary). Cleans up any soft-deleted artifact at the target path first.
+#[allow(clippy::too_many_arguments)]
+async fn update_artifact_record(
+    db: &sqlx::PgPool,
+    repo_id: uuid::Uuid,
+    artifact_id: uuid::Uuid,
+    path: &str,
+    size_bytes: i64,
+    checksum_sha256: &str,
+    content_type: &str,
+    storage_key: &str,
+) -> Result<(), Response> {
+    super::cleanup_soft_deleted_artifact(db, repo_id, path).await;
+    sqlx::query(
+        r#"
+        UPDATE artifacts
+        SET path = $1, size_bytes = $2, checksum_sha256 = $3,
+            content_type = $4, storage_key = $5, updated_at = NOW()
+        WHERE id = $6
+        "#,
+    )
+    .bind(path)
+    .bind(size_bytes)
+    .bind(checksum_sha256)
+    .bind(content_type)
+    .bind(storage_key)
+    .bind(artifact_id)
+    .execute(db)
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+            .into_response()
+    })?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // PUT /maven/{repo_key}/*path — Upload artifact
 // ---------------------------------------------------------------------------
@@ -926,30 +967,17 @@ async fn upload(
                 merged["files"] = serde_json::Value::Array(files);
 
                 // Update the artifact record to point to the JAR as primary
-                super::cleanup_soft_deleted_artifact(&state.db, repo.id, &path).await;
-                let _ = sqlx::query(
-                    r#"
-                    UPDATE artifacts
-                    SET path = $1, size_bytes = $2, checksum_sha256 = $3,
-                        content_type = $4, storage_key = $5, updated_at = NOW()
-                    WHERE id = $6
-                    "#,
+                update_artifact_record(
+                    &state.db,
+                    repo.id,
+                    existing_id,
+                    &path,
+                    size_bytes,
+                    &checksum_sha256,
+                    ct,
+                    &storage_key,
                 )
-                .bind(&path)
-                .bind(size_bytes)
-                .bind(&checksum_sha256)
-                .bind(ct)
-                .bind(&storage_key)
-                .bind(existing_id)
-                .execute(&state.db)
-                .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Database error: {}", e),
-                    )
-                        .into_response()
-                })?;
+                .await?;
 
                 let _ = sqlx::query(
                     r#"
@@ -962,7 +990,20 @@ async fn upload(
                 .bind(&merged)
                 .execute(&state.db)
                 .await;
-            } else {
+            } else if is_primary && coords.version.contains("SNAPSHOT") {
+                // SNAPSHOT re-upload: update the artifact record, then fall
+                // through to shared metadata update below.
+                update_artifact_record(
+                    &state.db,
+                    repo.id,
+                    existing_id,
+                    &path,
+                    size_bytes,
+                    &checksum_sha256,
+                    ct,
+                    &storage_key,
+                )
+                .await?;
                 // Secondary file (POM when JAR exists, or classifier like sources/javadoc).
                 // Add it to the existing artifact's metadata files array.
                 let mut updated_meta = existing_meta.unwrap_or_else(|| {

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -12,6 +12,7 @@ use super::middleware::auth::{
 use super::middleware::demo::demo_guard;
 use super::middleware::rate_limit::{rate_limit_middleware, RateLimiter};
 use super::middleware::setup::setup_guard;
+use super::middleware::tracing::correlation_id_middleware;
 use super::SharedState;
 use crate::services::auth_service::AuthService;
 
@@ -104,6 +105,11 @@ pub fn create_router(state: SharedState) -> Router {
         tracing::info!("Demo mode enabled — write operations will be blocked");
         router = router.layer(middleware::from_fn_with_state(state.clone(), demo_guard));
     }
+
+    // Correlation ID middleware (outermost layer — runs first on every request).
+    // Extracts or generates a correlation ID and sets the X-Correlation-ID
+    // response header.
+    router = router.layer(middleware::from_fn(correlation_id_middleware));
 
     router.with_state(state)
 }

--- a/backend/src/formats/maven.rs
+++ b/backend/src/formats/maven.rs
@@ -62,10 +62,12 @@ impl MavenHandler {
             .strip_suffix("-SNAPSHOT")
             .map(|base_version| format!("{}-{}", artifact_id, base_version));
 
+        let mut is_snapshot_timestamp = false;
         let remainder = if filename.starts_with(&expected_prefix) {
             &filename[expected_prefix.len()..]
         } else if let Some(ref snap) = snapshot_prefix {
             if filename.starts_with(snap) {
+                is_snapshot_timestamp = true;
                 &filename[snap.len()..]
             } else {
                 // Could be metadata file
@@ -102,6 +104,15 @@ impl MavenHandler {
             ));
         }
 
+        // For snapshot timestamps, the remainder starts with the
+        // timestamp-build suffix: -YYYYMMDD.HHMMSS-N
+        // Strip it so classifier parsing works correctly.
+        let remainder = if is_snapshot_timestamp {
+            Self::strip_snapshot_timestamp(remainder)
+        } else {
+            remainder
+        };
+
         // Check for classifier: -classifier.ext
         if let Some(rest) = remainder.strip_prefix('-') {
             if let Some(dot_pos) = rest.rfind('.') {
@@ -119,6 +130,39 @@ impl MavenHandler {
         Err(AppError::Validation(
             "Invalid Maven filename format".to_string(),
         ))
+    }
+
+    /// Strip a Maven SNAPSHOT timestamp-build suffix from a remainder string.
+    ///
+    /// Pattern: `-YYYYMMDD.HHMMSS-N` where N is one or more digits.
+    ///
+    /// Examples:
+    /// - `"-20260314.155654-1.jar"` -> `".jar"`
+    /// - `"-20260314.155654-1-sources.jar"` -> `"-sources.jar"`
+    ///
+    /// Returns the input unchanged if the pattern doesn't match.
+    fn strip_snapshot_timestamp(remainder: &str) -> &str {
+        let b = remainder.as_bytes();
+        // Minimum: -YYYYMMDD.HHMMSS-N = 18 chars
+        if b.len() < 18
+            || b[0] != b'-'
+            || !b[1..9].iter().all(u8::is_ascii_digit)
+            || b[9] != b'.'
+            || !b[10..16].iter().all(u8::is_ascii_digit)
+            || b[16] != b'-'
+        {
+            return remainder;
+        }
+        // Skip past the build number digits after the second dash
+        let end = b[17..]
+            .iter()
+            .position(|c| !c.is_ascii_digit())
+            .map_or(b.len(), |p| 17 + p);
+        if end == 17 {
+            remainder
+        } else {
+            &remainder[end..]
+        }
     }
 
     /// Check if this is a POM file
@@ -403,6 +447,7 @@ mod tests {
     #[test]
     fn test_parse_snapshot_timestamp_coordinates() {
         // SNAPSHOT version with timestamp-resolved filename (Maven deploy format)
+        // The timestamp-build suffix should NOT be treated as a classifier.
         let coords = MavenHandler::parse_coordinates(
             "com/example/test/1.0.0-SNAPSHOT/test-1.0.0-20260211.124623-1.jar",
         )
@@ -410,18 +455,43 @@ mod tests {
         assert_eq!(coords.group_id, "com.example");
         assert_eq!(coords.artifact_id, "test");
         assert_eq!(coords.version, "1.0.0-SNAPSHOT");
+        assert_eq!(coords.classifier, None);
         assert_eq!(coords.extension, "jar");
     }
 
     #[test]
     fn test_parse_snapshot_timestamp_with_classifier() {
+        // A timestamped SNAPSHOT with an actual classifier (sources/javadoc)
         let coords = MavenHandler::parse_coordinates(
             "com/example/test/1.2.3-SNAPSHOT/test-1.2.3-20260211.124623-1-sources.jar",
         )
         .unwrap();
         assert_eq!(coords.artifact_id, "test");
         assert_eq!(coords.version, "1.2.3-SNAPSHOT");
+        assert_eq!(coords.classifier, Some("sources".to_string()));
         assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_strip_snapshot_timestamp() {
+        assert_eq!(
+            MavenHandler::strip_snapshot_timestamp("-20260314.155654-1.jar"),
+            ".jar"
+        );
+        assert_eq!(
+            MavenHandler::strip_snapshot_timestamp("-20260314.155654-1-sources.jar"),
+            "-sources.jar"
+        );
+        assert_eq!(
+            MavenHandler::strip_snapshot_timestamp("-20260314.155654-12.pom"),
+            ".pom"
+        );
+        // Non-timestamp remainders returned unchanged
+        assert_eq!(
+            MavenHandler::strip_snapshot_timestamp("-sources.jar"),
+            "-sources.jar"
+        );
+        assert_eq!(MavenHandler::strip_snapshot_timestamp(".jar"), ".jar");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **X-Correlation-ID header missing**: The `correlation_id_middleware` was defined in `middleware/tracing.rs` with 13 unit tests but was never wired into the router. Added it as the outermost layer in `routes.rs` so every response now includes the header.
- **Maven SNAPSHOT 404 on JAR download**: `parse_filename` in the Maven format parser treated timestamp-build suffixes (e.g. `20260314.155654-1`) as classifiers, causing JARs to be stored as secondary files instead of primary. Added `strip_snapshot_timestamp()` to correctly handle these filenames.
- **Maven SNAPSHOT re-upload not updating primary**: When a new SNAPSHOT build was uploaded and the existing primary was also a JAR, the upload handler only appended to the files array without updating the artifact record's path and storage_key. Added a dedicated code path for SNAPSHOT primary re-uploads.

## Test plan
- [x] All 6538 unit tests pass (`cargo test --workspace --lib`)
- [x] `cargo fmt --check` and `cargo clippy --workspace` clean
- [x] K8s E2E: X-Correlation-ID header present on `/health` response
- [x] K8s E2E: Maven release deploy, download, metadata, and checksum all return 200
- [x] K8s E2E: Maven SNAPSHOT first deploy returns 200
- [x] K8s E2E: Maven SNAPSHOT re-upload updates content (SHA1 changes)
- [x] K8s E2E: Maven release re-upload correctly rejected with 409 Conflict