### PR TITLE
fix: paginated Meilisearch reindex to avoid OOM on large registries

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -774,31 +774,12 @@ pub async fn trigger_reindex(
         .as_ref()
         .ok_or_else(|| AppError::Internal("Meilisearch is not configured".to_string()))?;
 
-    // Count artifacts and repositories before reindex so we can report counts
-    let artifact_stats = sqlx::query!(
-        r#"
-        SELECT
-            COUNT(*) as "count!",
-            COALESCE(SUM(size_bytes), 0)::BIGINT as "size!"
-        FROM artifacts
-        WHERE is_deleted = false
-        "#
-    )
-    .fetch_one(&state.db)
-    .await
-    .map_err(|e| AppError::Database(e.to_string()))?;
-
-    let repo_count = sqlx::query_scalar!("SELECT COUNT(*) as \"count!\" FROM repositories")
-        .fetch_one(&state.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
-
-    meili.full_reindex(&state.db).await?;
+    let (artifacts, repositories) = meili.full_reindex(&state.db).await?;
 
     Ok(Json(ReindexResponse {
         message: "Full reindex completed successfully".to_string(),
-        artifacts_indexed: artifact_stats.count,
-        repositories_indexed: repo_count,
+        artifacts_indexed: artifacts as i64,
+        repositories_indexed: repositories as i64,
     }))
 }
 

--- a/backend/src/api/handlers/search.rs
+++ b/backend/src/api/handlers/search.rs
@@ -631,8 +631,15 @@ pub async fn trigger_reindex(State(state): State<SharedState>) -> Result<Json<Re
     let db = state.db.clone();
     let meili = meili.clone();
     tokio::spawn(async move {
-        if let Err(e) = meili.full_reindex(&db).await {
-            tracing::error!("Search reindex failed: {}", e);
+        match meili.full_reindex(&db).await {
+            Ok((a, r)) => {
+                tracing::info!(
+                    "Search reindex complete: {} artifacts, {} repositories",
+                    a,
+                    r
+                )
+            }
+            Err(e) => tracing::error!("Search reindex failed: {}", e),
         }
     });
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -101,38 +101,51 @@ async fn main() -> Result<()> {
     let meili_service = match (&config.meilisearch_url, &config.meilisearch_api_key) {
         (Some(url), Some(api_key)) => {
             tracing::info!("Initializing Meilisearch at {}", url);
-            let service = Arc::new(MeiliService::new(url, api_key));
-            match service.configure_indexes().await {
-                Ok(()) => {
-                    tracing::info!("Meilisearch indexes configured");
-                    // Spawn background reindex if the index is empty
-                    let svc = service.clone();
-                    let pool = db_pool.clone();
-                    tokio::spawn(async move {
-                        match svc.is_index_empty().await {
-                            Ok(true) => {
-                                tracing::info!(
-                                    "Meilisearch index is empty, starting background reindex"
-                                );
-                                if let Err(e) = svc.full_reindex(&pool).await {
-                                    tracing::warn!("Background reindex failed: {}", e);
+            match MeiliService::new(url, api_key) {
+                Ok(s) => {
+                    let service = Arc::new(s);
+                    match service.configure_indexes().await {
+                        Ok(()) => {
+                            tracing::info!("Meilisearch indexes configured");
+                            let svc = service.clone();
+                            let pool = db_pool.clone();
+                            tokio::spawn(async move {
+                                match svc.is_index_empty().await {
+                                    Ok(true) => {
+                                        tracing::info!(
+                                            "Meilisearch index is empty, starting background reindex"
+                                        );
+                                        if let Err(e) = svc.full_reindex(&pool).await {
+                                            tracing::error!("Background reindex failed: {}", e);
+                                        }
+                                    }
+                                    Ok(false) => {
+                                        tracing::info!(
+                                            "Meilisearch index already populated, skipping reindex"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "Failed to check Meilisearch index status: {}",
+                                            e
+                                        );
+                                    }
                                 }
-                            }
-                            Ok(false) => {
-                                tracing::info!(
-                                    "Meilisearch index already populated, skipping reindex"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::warn!("Failed to check Meilisearch index status: {}", e);
-                            }
+                            });
+                            Some(service)
                         }
-                    });
-                    Some(service)
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to configure Meilisearch indexes, continuing without search: {}",
+                                e
+                            );
+                            None
+                        }
+                    }
                 }
                 Err(e) => {
                     tracing::warn!(
-                        "Failed to configure Meilisearch indexes, continuing without search: {}",
+                        "Failed to initialize Meilisearch client, continuing without search: {}",
                         e
                     );
                     None

--- a/backend/src/services/meili_service.rs
+++ b/backend/src/services/meili_service.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use meilisearch_sdk::client::Client;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::error::{AppError, Result};
@@ -58,9 +59,10 @@ pub struct MeiliService {
 
 impl MeiliService {
     /// Create a new MeiliService connected to the given Meilisearch instance.
-    pub fn new(url: &str, api_key: &str) -> Self {
-        let client = Client::new(url, Some(api_key)).unwrap();
-        Self { client }
+    pub fn new(url: &str, api_key: &str) -> Result<Self> {
+        let client = Client::new(url, Some(api_key))
+            .map_err(|e| AppError::Config(format!("Failed to create Meilisearch client: {}", e)))?;
+        Ok(Self { client })
     }
 
     /// Configure indexes with appropriate searchable, filterable, and sortable attributes.
@@ -268,136 +270,185 @@ impl MeiliService {
 
     /// Reindex all artifacts from the database into Meilisearch.
     ///
-    /// Joins artifacts with repositories and download statistics to build
-    /// complete search documents. Processes in batches of 1000.
-    pub async fn full_reindex_artifacts(&self, db: &PgPool) -> Result<()> {
+    /// Uses cursor-based pagination to avoid loading all rows into memory.
+    /// Artifacts inserted concurrently during a reindex may be skipped;
+    /// they are indexed individually via [`index_artifact`] on creation.
+    pub async fn full_reindex_artifacts(&self, db: &PgPool) -> Result<usize> {
         tracing::info!("Starting full artifact reindex");
 
-        let rows = sqlx::query_as::<_, ArtifactRow>(
-            r#"
-            SELECT
-                a.id,
-                a.name,
-                a.path,
-                a.version,
-                a.content_type,
-                a.size_bytes,
-                a.created_at,
-                r.id AS repository_id,
-                r.key AS repository_key,
-                r.name AS repository_name,
-                r.format::text AS format,
-                COALESCE(ds.download_count, 0) AS download_count
-            FROM artifacts a
-            INNER JOIN repositories r ON a.repository_id = r.id
-            LEFT JOIN (
-                SELECT artifact_id, COUNT(*) AS download_count
-                FROM download_statistics
-                GROUP BY artifact_id
-            ) ds ON a.id = ds.artifact_id
-            WHERE a.is_deleted = false
-            ORDER BY a.id
-            "#,
-        )
-        .fetch_all(db)
-        .await
-        .map_err(|e| AppError::Database(format!("Failed to fetch artifacts for reindex: {}", e)))?;
-
-        let total = rows.len();
-        tracing::info!("Reindexing {} artifacts", total);
-
-        let documents: Vec<ArtifactDocument> = rows
-            .into_iter()
-            .map(|row| ArtifactDocument {
-                id: row.id.to_string(),
-                name: row.name,
-                path: row.path,
-                version: row.version,
-                format: row.format,
-                repository_id: row.repository_id.to_string(),
-                repository_key: row.repository_key,
-                repository_name: row.repository_name,
-                content_type: row.content_type,
-                size_bytes: row.size_bytes,
-                download_count: row.download_count,
-                created_at: row.created_at.timestamp(),
-            })
-            .collect();
-
         let index = self.client.index(ARTIFACTS_INDEX);
+        let page_size: i64 = BATCH_SIZE as i64;
+        let mut last_id: Option<Uuid> = None;
+        let mut total = 0usize;
 
-        for chunk in documents.chunks(BATCH_SIZE) {
-            index.add_documents(chunk, Some("id")).await.map_err(|e| {
-                AppError::Internal(format!("Failed to batch index artifacts: {}", e))
+        loop {
+            let rows = sqlx::query_as::<_, ArtifactRow>(
+                r#"
+                SELECT
+                    a.id,
+                    a.name,
+                    a.path,
+                    a.version,
+                    a.content_type,
+                    a.size_bytes,
+                    a.created_at,
+                    r.id AS repository_id,
+                    r.key AS repository_key,
+                    r.name AS repository_name,
+                    r.format::text AS format
+                FROM artifacts a
+                INNER JOIN repositories r ON a.repository_id = r.id
+                WHERE a.is_deleted = false
+                  AND ($1::uuid IS NULL OR a.id > $1)
+                ORDER BY a.id
+                LIMIT $2
+                "#,
+            )
+            .bind(last_id)
+            .bind(page_size)
+            .fetch_all(db)
+            .await
+            .map_err(|e| {
+                AppError::Database(format!(
+                    "Failed to fetch artifacts for reindex (after {} documents): {}",
+                    total, e
+                ))
             })?;
+
+            if rows.is_empty() {
+                break;
+            }
+
+            let artifact_ids: Vec<Uuid> = rows.iter().map(|row| row.id).collect();
+            let download_counts: HashMap<Uuid, i64> =
+                sqlx::query_as::<_, ArtifactDownloadCountRow>(
+                    r#"
+                SELECT artifact_id, COUNT(*)::BIGINT AS download_count
+                FROM download_statistics
+                WHERE artifact_id = ANY($1)
+                GROUP BY artifact_id
+                "#,
+                )
+                .bind(&artifact_ids)
+                .fetch_all(db)
+                .await
+                .map_err(|e| {
+                    AppError::Database(format!(
+                        "Failed to fetch artifact download counts for reindex (after {} documents): {}",
+                        total, e
+                    ))
+                })?
+                .into_iter()
+                .map(|row| (row.artifact_id, row.download_count))
+                .collect();
+
+            last_id = rows.last().map(|row| row.id);
+            let documents = build_artifact_batch(rows, &download_counts);
+            let batch_len = documents.len();
+
+            index
+                .add_documents(&documents, Some("id"))
+                .await
+                .map_err(|e| {
+                    AppError::Internal(format!(
+                        "Failed to batch index artifacts (after {} documents, batch of {}): {}",
+                        total, batch_len, e
+                    ))
+                })?;
+            total += batch_len;
+
+            tracing::info!(
+                batch = documents.len(),
+                total_so_far = total,
+                "Indexed artifact batch"
+            );
         }
 
         tracing::info!("Artifact reindex complete: {} documents indexed", total);
-        Ok(())
+        Ok(total)
     }
 
     /// Reindex all repositories from the database into Meilisearch.
     ///
-    /// Processes in batches of 1000.
-    pub async fn full_reindex_repositories(&self, db: &PgPool) -> Result<()> {
+    /// Uses cursor-based pagination to avoid loading all rows into memory.
+    /// Repositories inserted concurrently during a reindex may be skipped;
+    /// they are indexed individually via [`index_repository`] on creation.
+    pub async fn full_reindex_repositories(&self, db: &PgPool) -> Result<usize> {
         tracing::info!("Starting full repository reindex");
 
-        let rows = sqlx::query_as::<_, RepositoryRow>(
-            r#"
-            SELECT
-                id,
-                name,
-                key,
-                description,
-                format::text AS format,
-                repo_type::text AS repo_type,
-                is_public,
-                created_at
-            FROM repositories
-            ORDER BY id
-            "#,
-        )
-        .fetch_all(db)
-        .await
-        .map_err(|e| {
-            AppError::Database(format!("Failed to fetch repositories for reindex: {}", e))
-        })?;
-
-        let total = rows.len();
-        tracing::info!("Reindexing {} repositories", total);
-
-        let documents: Vec<RepositoryDocument> = rows
-            .into_iter()
-            .map(|row| RepositoryDocument {
-                id: row.id.to_string(),
-                name: row.name,
-                key: row.key,
-                description: row.description,
-                format: row.format,
-                repo_type: row.repo_type,
-                is_public: row.is_public,
-                created_at: row.created_at.timestamp(),
-            })
-            .collect();
-
         let index = self.client.index(REPOSITORIES_INDEX);
+        let page_size: i64 = BATCH_SIZE as i64;
+        let mut last_id: Option<Uuid> = None;
+        let mut total = 0usize;
 
-        for chunk in documents.chunks(BATCH_SIZE) {
-            index.add_documents(chunk, Some("id")).await.map_err(|e| {
-                AppError::Internal(format!("Failed to batch index repositories: {}", e))
+        loop {
+            let rows = sqlx::query_as::<_, RepositoryRow>(
+                r#"
+                SELECT
+                    id,
+                    name,
+                    key,
+                    description,
+                    format::text AS format,
+                    repo_type::text AS repo_type,
+                    is_public,
+                    created_at
+                FROM repositories
+                WHERE ($1::uuid IS NULL OR id > $1)
+                ORDER BY id
+                LIMIT $2
+                "#,
+            )
+            .bind(last_id)
+            .bind(page_size)
+            .fetch_all(db)
+            .await
+            .map_err(|e| {
+                AppError::Database(format!(
+                    "Failed to fetch repositories for reindex (after {} documents): {}",
+                    total, e
+                ))
             })?;
+
+            if rows.is_empty() {
+                break;
+            }
+
+            last_id = rows.last().map(|row| row.id);
+            let documents = build_repository_batch(rows);
+            let batch_len = documents.len();
+
+            index
+                .add_documents(&documents, Some("id"))
+                .await
+                .map_err(|e| {
+                    AppError::Internal(format!(
+                        "Failed to batch index repositories (after {} documents, batch of {}): {}",
+                        total, batch_len, e
+                    ))
+                })?;
+            total += batch_len;
+
+            tracing::info!(
+                batch = documents.len(),
+                total_so_far = total,
+                "Indexed repository batch"
+            );
         }
 
         tracing::info!("Repository reindex complete: {} documents indexed", total);
-        Ok(())
+        Ok(total)
     }
 
     /// Run a full reindex of both artifacts and repositories.
-    pub async fn full_reindex(&self, db: &PgPool) -> Result<()> {
-        self.full_reindex_artifacts(db).await?;
-        self.full_reindex_repositories(db).await?;
+    ///
+    /// Returns the count of (artifacts, repositories) indexed.
+    pub async fn full_reindex(&self, db: &PgPool) -> Result<(usize, usize)> {
+        let artifacts = self.full_reindex_artifacts(db).await?;
+        tracing::info!("Artifact reindex phase complete, proceeding to repositories");
+        let repositories = self.full_reindex_repositories(db).await?;
         tracing::info!("Full reindex complete");
-        Ok(())
+        Ok((artifacts, repositories))
     }
 }
 
@@ -415,7 +466,6 @@ struct ArtifactRow {
     repository_key: String,
     repository_name: String,
     format: String,
-    download_count: i64,
 }
 
 /// Internal row type for repository reindex queries.
@@ -431,11 +481,124 @@ struct RepositoryRow {
     created_at: DateTime<Utc>,
 }
 
+/// Internal row type for per-artifact download count aggregation.
+#[derive(Debug, sqlx::FromRow)]
+struct ArtifactDownloadCountRow {
+    artifact_id: Uuid,
+    download_count: i64,
+}
+
+/// Build a batch of [`ArtifactDocument`]s from database rows and per-artifact download counts.
+///
+/// Artifacts with no entry in `download_counts` default to 0,
+/// matching the previous `COALESCE(ds.download_count, 0)` behavior.
+fn build_artifact_batch(
+    rows: Vec<ArtifactRow>,
+    download_counts: &HashMap<Uuid, i64>,
+) -> Vec<ArtifactDocument> {
+    rows.into_iter()
+        .map(|row| {
+            let dc = download_counts.get(&row.id).copied().unwrap_or_default();
+            artifact_document_from_row(row, dc)
+        })
+        .collect()
+}
+
+/// Build a batch of [`RepositoryDocument`]s from database rows.
+fn build_repository_batch(rows: Vec<RepositoryRow>) -> Vec<RepositoryDocument> {
+    rows.into_iter().map(repository_document_from_row).collect()
+}
+
+fn artifact_document_from_row(row: ArtifactRow, download_count: i64) -> ArtifactDocument {
+    ArtifactDocument {
+        id: row.id.to_string(),
+        name: row.name,
+        path: row.path,
+        version: row.version,
+        format: row.format,
+        repository_id: row.repository_id.to_string(),
+        repository_key: row.repository_key,
+        repository_name: row.repository_name,
+        content_type: row.content_type,
+        size_bytes: row.size_bytes,
+        download_count,
+        created_at: row.created_at.timestamp(),
+    }
+}
+
+fn repository_document_from_row(row: RepositoryRow) -> RepositoryDocument {
+    RepositoryDocument {
+        id: row.id.to_string(),
+        name: row.name,
+        key: row.key,
+        description: row.description,
+        format: row.format,
+        repo_type: row.repo_type,
+        is_public: row.is_public,
+        created_at: row.created_at.timestamp(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     #[allow(unused_imports)]
     use serde_json::json;
+
+    fn meili_service_source() -> &'static str {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/services/meili_service.rs"
+        ))
+    }
+
+    fn function_source<'a>(source: &'a str, fn_name: &str) -> &'a str {
+        let needle = format!("fn {}(", fn_name);
+        let start = source
+            .find(&needle)
+            .unwrap_or_else(|| panic!("failed to find function {fn_name}"));
+        let remainder = &source[start..];
+        // Find the next function definition or end of impl block as boundary
+        let end = remainder[1..]
+            .find("\n    pub ")
+            .or_else(|| remainder[1..].find("\n}"))
+            .map(|i| i + 1)
+            .unwrap_or(remainder.len());
+        &remainder[..end]
+    }
+
+    // -----------------------------------------------------------------------
+    // function_source helper tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_function_source_extracts_correct_boundary_for_last_method() {
+        // full_reindex is the last pub method in the impl block.
+        // function_source should not leak into structs/functions outside the impl.
+        let source = function_source(meili_service_source(), "full_reindex");
+        assert!(
+            source.contains("full_reindex_artifacts"),
+            "full_reindex body should reference full_reindex_artifacts"
+        );
+        assert!(
+            !source.contains("struct ArtifactRow"),
+            "full_reindex should not leak past the impl block into struct definitions"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Constructor tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_new_returns_result() {
+        // MeiliService::new should return Result, not panic on invalid input
+        let source = function_source(meili_service_source(), "new");
+        assert!(
+            source.contains("-> Result<Self>"),
+            "MeiliService::new should return Result<Self>"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Constants tests
@@ -446,6 +609,196 @@ mod tests {
         assert_eq!(ARTIFACTS_INDEX, "artifacts");
         assert_eq!(REPOSITORIES_INDEX, "repositories");
         assert_eq!(BATCH_SIZE, 1000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pagination page_size derived from BATCH_SIZE
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_batch_size_fits_i64_for_pagination() {
+        // full_reindex uses `BATCH_SIZE as i64` for query LIMIT params
+        let page_size: i64 = BATCH_SIZE as i64;
+        assert_eq!(page_size, 1000);
+        assert!(page_size > 0);
+    }
+
+    #[test]
+    fn test_full_reindex_artifacts_uses_cursor_pagination_without_offset() {
+        let source = function_source(meili_service_source(), "full_reindex_artifacts");
+
+        assert!(
+            source.contains("a.id > $1"),
+            "artifact reindex should paginate from the last indexed id"
+        );
+        assert!(
+            !source.contains("OFFSET"),
+            "artifact reindex should not use OFFSET pagination on a live table"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_repositories_uses_cursor_pagination_without_offset() {
+        let source = function_source(meili_service_source(), "full_reindex_repositories");
+
+        assert!(
+            source.contains("id > $1"),
+            "repository reindex should paginate from the last indexed id"
+        );
+        assert!(
+            !source.contains("OFFSET"),
+            "repository reindex should not use OFFSET pagination on a live table"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_artifacts_scopes_download_count_aggregation_to_batch() {
+        let source = function_source(meili_service_source(), "full_reindex_artifacts");
+
+        assert!(
+            source.contains("WHERE artifact_id = ANY($1)"),
+            "download counts should be aggregated only for the current artifact batch"
+        );
+        assert!(
+            !source.contains("LEFT JOIN ("),
+            "artifact reindex should not use a full-table subquery JOIN for download counts"
+        );
+    }
+
+    #[test]
+    fn test_artifact_document_from_row_zero_download_count() {
+        let now = Utc::now();
+        let row = ArtifactRow {
+            id: Uuid::new_v4(),
+            name: "no-downloads".to_string(),
+            path: "pkg/no-downloads".to_string(),
+            version: None,
+            content_type: "application/octet-stream".to_string(),
+            size_bytes: 64,
+            created_at: now,
+            repository_id: Uuid::new_v4(),
+            repository_key: "generic-local".to_string(),
+            repository_name: "Generic".to_string(),
+            format: "generic".to_string(),
+        };
+        let doc = artifact_document_from_row(row, 0);
+        assert_eq!(doc.download_count, 0);
+    }
+
+    #[test]
+    fn test_full_reindex_artifacts_errors_include_progress_context() {
+        let source = function_source(meili_service_source(), "full_reindex_artifacts");
+        assert!(
+            source.contains("after {} documents"),
+            "artifact reindex errors should include the count of documents indexed so far"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_repositories_errors_include_progress_context() {
+        let source = function_source(meili_service_source(), "full_reindex_repositories");
+        assert!(
+            source.contains("after {} documents"),
+            "repository reindex errors should include the count of documents indexed so far"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_artifacts_logs_batch_progress() {
+        let source = function_source(meili_service_source(), "full_reindex_artifacts");
+        assert!(
+            source.contains("Indexed artifact batch"),
+            "artifact reindex should log progress after each batch"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_repositories_logs_batch_progress() {
+        let source = function_source(meili_service_source(), "full_reindex_repositories");
+        assert!(
+            source.contains("Indexed repository batch"),
+            "repository reindex should log progress after each batch"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_artifacts_returns_count() {
+        let source = function_source(meili_service_source(), "full_reindex_artifacts");
+        assert!(
+            source.contains("Result<usize>"),
+            "full_reindex_artifacts should return Result<usize> with the count of indexed documents"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_repositories_returns_count() {
+        let source = function_source(meili_service_source(), "full_reindex_repositories");
+        assert!(
+            source.contains("Result<usize>"),
+            "full_reindex_repositories should return Result<usize> with the count of indexed documents"
+        );
+    }
+
+    #[test]
+    fn test_full_reindex_logs_phase_completion() {
+        let source = function_source(meili_service_source(), "full_reindex");
+        assert!(
+            source.contains("Artifact reindex phase complete"),
+            "full_reindex should log when the artifact phase completes before starting repositories"
+        );
+    }
+
+    #[test]
+    fn test_artifact_row_to_document_mapping_preserves_all_fields() {
+        let now = Utc::now();
+        let id = Uuid::new_v4();
+        let repo_id = Uuid::new_v4();
+
+        let row = ArtifactRow {
+            id,
+            name: "lib".to_string(),
+            path: "org/lib/1.0/lib-1.0.jar".to_string(),
+            version: Some("1.0".to_string()),
+            content_type: "application/java-archive".to_string(),
+            size_bytes: 4096,
+            created_at: now,
+            repository_id: repo_id,
+            repository_key: "maven-local".to_string(),
+            repository_name: "Maven Local".to_string(),
+            format: "maven".to_string(),
+        };
+
+        let doc = artifact_document_from_row(row, 5);
+
+        assert_eq!(doc.id, id.to_string());
+        assert_eq!(doc.repository_id, repo_id.to_string());
+        assert_eq!(doc.size_bytes, 4096);
+        assert_eq!(doc.download_count, 5);
+        assert_eq!(doc.created_at, now.timestamp());
+    }
+
+    #[test]
+    fn test_repository_row_to_document_mapping_preserves_all_fields() {
+        let now = Utc::now();
+        let id = Uuid::new_v4();
+
+        let row = RepositoryRow {
+            id,
+            name: "NPM Local".to_string(),
+            key: "npm-local".to_string(),
+            description: Some("Local NPM".to_string()),
+            format: "npm".to_string(),
+            repo_type: "local".to_string(),
+            is_public: false,
+            created_at: now,
+        };
+
+        let doc = repository_document_from_row(row);
+
+        assert_eq!(doc.id, id.to_string());
+        assert!(!doc.is_public);
+        assert_eq!(doc.description, Some("Local NPM".to_string()));
+        assert_eq!(doc.created_at, now.timestamp());
     }
 
     // -----------------------------------------------------------------------
@@ -712,7 +1065,6 @@ mod tests {
 
     #[test]
     fn test_artifact_row_to_document_conversion() {
-        // Mirrors the mapping in full_reindex_artifacts
         let now = Utc::now();
         let id = Uuid::new_v4();
         let repo_id = Uuid::new_v4();
@@ -729,23 +1081,9 @@ mod tests {
             repository_key: "maven-local".to_string(),
             repository_name: "Maven Local".to_string(),
             format: "maven".to_string(),
-            download_count: 7,
         };
 
-        let doc = ArtifactDocument {
-            id: row.id.to_string(),
-            name: row.name.clone(),
-            path: row.path.clone(),
-            version: row.version.clone(),
-            format: row.format.clone(),
-            repository_id: row.repository_id.to_string(),
-            repository_key: row.repository_key.clone(),
-            repository_name: row.repository_name.clone(),
-            content_type: row.content_type.clone(),
-            size_bytes: row.size_bytes,
-            download_count: row.download_count,
-            created_at: row.created_at.timestamp(),
-        };
+        let doc = artifact_document_from_row(row, 7);
 
         assert_eq!(doc.id, id.to_string());
         assert_eq!(doc.name, "my-lib");
@@ -775,21 +1113,114 @@ mod tests {
             created_at: now,
         };
 
-        let doc = RepositoryDocument {
-            id: row.id.to_string(),
-            name: row.name.clone(),
-            key: row.key.clone(),
-            description: row.description.clone(),
-            format: row.format.clone(),
-            repo_type: row.repo_type.clone(),
-            is_public: row.is_public,
-            created_at: row.created_at.timestamp(),
-        };
+        let doc = repository_document_from_row(row);
 
         assert_eq!(doc.id, id.to_string());
         assert_eq!(doc.name, "Docker Local");
         assert_eq!(doc.key, "docker-local");
         assert_eq!(doc.description, Some("Local docker repo".to_string()));
         assert!(doc.is_public);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_artifact_batch tests
+    // -----------------------------------------------------------------------
+
+    fn make_artifact_row(id: Uuid) -> ArtifactRow {
+        ArtifactRow {
+            id,
+            name: format!("artifact-{}", &id.to_string()[..8]),
+            path: format!("pkg/{id}"),
+            version: Some("1.0.0".to_string()),
+            content_type: "application/octet-stream".to_string(),
+            size_bytes: 256,
+            created_at: Utc::now(),
+            repository_id: Uuid::new_v4(),
+            repository_key: "generic-local".to_string(),
+            repository_name: "Generic".to_string(),
+            format: "generic".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_build_artifact_batch_empty() {
+        let docs = build_artifact_batch(vec![], &HashMap::new());
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn test_build_artifact_batch_mixed_downloads() {
+        let id_with = Uuid::new_v4();
+        let id_without = Uuid::new_v4();
+        let rows = vec![make_artifact_row(id_with), make_artifact_row(id_without)];
+
+        let mut counts = HashMap::new();
+        counts.insert(id_with, 42);
+
+        let docs = build_artifact_batch(rows, &counts);
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].download_count, 42);
+        assert_eq!(
+            docs[1].download_count, 0,
+            "missing download count defaults to 0"
+        );
+    }
+
+    #[test]
+    fn test_build_artifact_batch_all_have_downloads() {
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let id3 = Uuid::new_v4();
+        let rows = vec![
+            make_artifact_row(id1),
+            make_artifact_row(id2),
+            make_artifact_row(id3),
+        ];
+
+        let mut counts = HashMap::new();
+        counts.insert(id1, 10);
+        counts.insert(id2, 20);
+        counts.insert(id3, 30);
+
+        let docs = build_artifact_batch(rows, &counts);
+        assert_eq!(docs.len(), 3);
+        assert_eq!(docs[0].download_count, 10);
+        assert_eq!(docs[1].download_count, 20);
+        assert_eq!(docs[2].download_count, 30);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_repository_batch tests
+    // -----------------------------------------------------------------------
+
+    fn make_repository_row(id: Uuid) -> RepositoryRow {
+        RepositoryRow {
+            id,
+            name: format!("repo-{}", &id.to_string()[..8]),
+            key: format!("repo-{}", &id.to_string()[..8]),
+            description: None,
+            format: "generic".to_string(),
+            repo_type: "local".to_string(),
+            is_public: true,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_build_repository_batch_empty() {
+        let docs = build_repository_batch(vec![]);
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn test_build_repository_batch_multiple() {
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let rows = vec![make_repository_row(id1), make_repository_row(id2)];
+
+        let docs = build_repository_batch(rows);
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].id, id1.to_string());
+        assert_eq!(docs[1].id, id2.to_string());
     }
 }

--- a/backend/tests/meili_reindex_tests.rs
+++ b/backend/tests/meili_reindex_tests.rs
@@ -1,0 +1,320 @@
+//! Integration tests for Meilisearch reindex cursor-based pagination.
+//!
+//! These tests verify that the pagination queries correctly visit all rows
+//! across multiple batches without duplicates or gaps.
+//!
+//! Requires PostgreSQL:
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:5432/artifact_registry" \
+//!   cargo test --test meili_reindex_tests -- --ignored
+//! ```
+
+use sqlx::PgPool;
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
+
+async fn connect_db() -> PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://registry:registry@localhost:5432/artifact_registry".into()
+    });
+    PgPool::connect(&url)
+        .await
+        .expect("Failed to connect to test database")
+}
+
+fn test_prefix() -> String {
+    format!("reindex-test-{}", Uuid::new_v4().as_simple())
+}
+
+async fn create_test_repo(pool: &PgPool, key: &str) -> Uuid {
+    let row: (Uuid,) = sqlx::query_as(
+        "INSERT INTO repositories (key, name, format, repo_type, storage_path) \
+         VALUES ($1, $2, 'generic', 'local', '/tmp/test') RETURNING id",
+    )
+    .bind(key)
+    .bind(key)
+    .fetch_one(pool)
+    .await
+    .expect("failed to create test repository");
+    row.0
+}
+
+async fn insert_test_artifacts(
+    pool: &PgPool,
+    repo_id: Uuid,
+    prefix: &str,
+    count: usize,
+) -> Vec<Uuid> {
+    let mut ids = Vec::with_capacity(count);
+    for i in 0..count {
+        let row: (Uuid,) = sqlx::query_as(
+            "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $3, $4, $5, $6, 'application/octet-stream', $7) RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(format!("{prefix}/artifact-{i}"))
+        .bind(format!("{prefix}-artifact-{i}"))
+        .bind(format!("{i}.0.0"))
+        .bind((i as i64 + 1) * 100)
+        .bind(format!("{:0>64x}", i))
+        .bind(format!("{prefix}/storage-{i}"))
+        .fetch_one(pool)
+        .await
+        .expect("failed to insert test artifact");
+        ids.push(row.0);
+    }
+    ids.sort();
+    ids
+}
+
+async fn insert_test_downloads(pool: &PgPool, artifact_ids: &[Uuid], downloads_per: usize) {
+    for &artifact_id in artifact_ids {
+        for _ in 0..downloads_per {
+            sqlx::query("INSERT INTO download_statistics (artifact_id) VALUES ($1)")
+                .bind(artifact_id)
+                .execute(pool)
+                .await
+                .expect("failed to insert download statistic");
+        }
+    }
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid) {
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("failed to clean up test data");
+}
+
+// ---------------------------------------------------------------------------
+// Pagination helpers (reproduce production SQL)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, sqlx::FromRow)]
+struct IdRow {
+    id: Uuid,
+}
+
+async fn paginate_artifacts(pool: &PgPool, page_size: i64) -> Vec<Uuid> {
+    let mut collected = Vec::new();
+    let mut last_id: Option<Uuid> = None;
+
+    loop {
+        let rows = sqlx::query_as::<_, IdRow>(
+            "SELECT a.id FROM artifacts a \
+             INNER JOIN repositories r ON a.repository_id = r.id \
+             WHERE a.is_deleted = false AND ($1::uuid IS NULL OR a.id > $1) \
+             ORDER BY a.id LIMIT $2",
+        )
+        .bind(last_id)
+        .bind(page_size)
+        .fetch_all(pool)
+        .await
+        .expect("artifact pagination query failed");
+
+        if rows.is_empty() {
+            break;
+        }
+        last_id = rows.last().map(|r| r.id);
+        collected.extend(rows.into_iter().map(|r| r.id));
+    }
+    collected
+}
+
+async fn paginate_repositories(pool: &PgPool, page_size: i64) -> Vec<Uuid> {
+    let mut collected = Vec::new();
+    let mut last_id: Option<Uuid> = None;
+
+    loop {
+        let rows = sqlx::query_as::<_, IdRow>(
+            "SELECT id FROM repositories \
+             WHERE ($1::uuid IS NULL OR id > $1) \
+             ORDER BY id LIMIT $2",
+        )
+        .bind(last_id)
+        .bind(page_size)
+        .fetch_all(pool)
+        .await
+        .expect("repository pagination query failed");
+
+        if rows.is_empty() {
+            break;
+        }
+        last_id = rows.last().map(|r| r.id);
+        collected.extend(rows.into_iter().map(|r| r.id));
+    }
+    collected
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct DownloadCountRow {
+    artifact_id: Uuid,
+    download_count: i64,
+}
+
+async fn batch_download_counts(pool: &PgPool, artifact_ids: &[Uuid]) -> HashMap<Uuid, i64> {
+    sqlx::query_as::<_, DownloadCountRow>(
+        "SELECT artifact_id, COUNT(*)::BIGINT AS download_count \
+         FROM download_statistics WHERE artifact_id = ANY($1) GROUP BY artifact_id",
+    )
+    .bind(artifact_ids)
+    .fetch_all(pool)
+    .await
+    .expect("download count query failed")
+    .into_iter()
+    .map(|r| (r.artifact_id, r.download_count))
+    .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // requires PostgreSQL
+async fn test_cursor_pagination_visits_all_artifacts_across_multiple_batches() {
+    let pool = connect_db().await;
+    let prefix = test_prefix();
+    let repo_id = create_test_repo(&pool, &prefix).await;
+
+    // 7 artifacts, page_size=3 → 3 batches (3+3+1)
+    let expected_ids = insert_test_artifacts(&pool, repo_id, &prefix, 7).await;
+
+    let collected = paginate_artifacts(&pool, 3).await;
+    let our_ids: Vec<Uuid> = collected
+        .into_iter()
+        .filter(|id| expected_ids.contains(id))
+        .collect();
+
+    assert_eq!(our_ids.len(), 7, "should visit all 7 test artifacts");
+
+    let unique: HashSet<Uuid> = our_ids.iter().copied().collect();
+    assert_eq!(unique.len(), 7, "no duplicates");
+
+    let mut sorted = our_ids.clone();
+    sorted.sort();
+    assert_eq!(our_ids, sorted, "returned in UUID order");
+
+    cleanup(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_cursor_pagination_handles_empty_result() {
+    let pool = connect_db().await;
+    let prefix = test_prefix();
+    let repo_id = create_test_repo(&pool, &prefix).await;
+
+    // No artifacts — loop should terminate immediately
+    let collected = paginate_artifacts(&pool, 3).await;
+    let our_ids: Vec<Uuid> = collected
+        .into_iter()
+        .filter(|_| false) // no test artifacts to match
+        .collect();
+    assert!(our_ids.is_empty());
+
+    cleanup(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_cursor_pagination_exact_batch_boundary() {
+    let pool = connect_db().await;
+    let prefix = test_prefix();
+    let repo_id = create_test_repo(&pool, &prefix).await;
+
+    // Exactly page_size artifacts → 1 full batch + 1 empty terminator
+    let expected_ids = insert_test_artifacts(&pool, repo_id, &prefix, 3).await;
+
+    let collected = paginate_artifacts(&pool, 3).await;
+    let our_ids: Vec<Uuid> = collected
+        .into_iter()
+        .filter(|id| expected_ids.contains(id))
+        .collect();
+
+    assert_eq!(our_ids.len(), 3, "exact boundary: all 3 visited");
+
+    cleanup(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_cursor_pagination_single_artifact() {
+    let pool = connect_db().await;
+    let prefix = test_prefix();
+    let repo_id = create_test_repo(&pool, &prefix).await;
+
+    let expected_ids = insert_test_artifacts(&pool, repo_id, &prefix, 1).await;
+
+    let collected = paginate_artifacts(&pool, 3).await;
+    let our_ids: Vec<Uuid> = collected
+        .into_iter()
+        .filter(|id| expected_ids.contains(id))
+        .collect();
+
+    assert_eq!(our_ids.len(), 1);
+
+    cleanup(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_repository_cursor_pagination_visits_all_repos() {
+    let pool = connect_db().await;
+    let prefix = test_prefix();
+
+    // 5 repos, page_size=2 → 3 batches (2+2+1)
+    let mut expected_ids = Vec::new();
+    for i in 0..5 {
+        let id = create_test_repo(&pool, &format!("{prefix}-repo-{i}")).await;
+        expected_ids.push(id);
+    }
+    expected_ids.sort();
+
+    let collected = paginate_repositories(&pool, 2).await;
+    let our_ids: Vec<Uuid> = collected
+        .into_iter()
+        .filter(|id| expected_ids.contains(id))
+        .collect();
+
+    assert_eq!(our_ids.len(), 5, "all 5 repos visited");
+    let unique: HashSet<Uuid> = our_ids.iter().copied().collect();
+    assert_eq!(unique.len(), 5, "no duplicates");
+
+    for id in &expected_ids {
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(id)
+            .execute(&pool)
+            .await
+            .expect("cleanup failed");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_batch_download_counts_scoped_to_batch() {
+    let pool = connect_db().await;
+    let prefix = test_prefix();
+    let repo_id = create_test_repo(&pool, &prefix).await;
+
+    let ids = insert_test_artifacts(&pool, repo_id, &prefix, 4).await;
+    insert_test_downloads(&pool, &ids[..2], 3).await;
+
+    // Query only a subset: one with downloads (ids[0]), one without (ids[2])
+    let batch_ids = vec![ids[0], ids[2]];
+    let counts = batch_download_counts(&pool, &batch_ids).await;
+
+    assert_eq!(counts.get(&ids[0]).copied().unwrap_or(0), 3);
+    assert_eq!(
+        counts.get(&ids[2]).copied().unwrap_or(0),
+        0,
+        "no-download artifact defaults to 0 (absent from HashMap)"
+    );
+    assert!(
+        !counts.contains_key(&ids[1]),
+        "out-of-batch artifact should not appear in counts"
+    );
+
+    cleanup(&pool, repo_id).await;
+}


### PR DESCRIPTION
## Summary
Based on #435 by @inspired-geek with one fix: moved the `total` counter increment to after the `add_documents` await so error messages accurately report the count of successfully indexed documents, not including the failed batch.

Original improvements from #435:
- Convert `fetch_all` reindex to cursor-based pagination (1000 rows per batch) to prevent OOM on large registries
- Decompose download count subquery from full-table scan to batch-scoped `WHERE artifact_id = ANY($1)`
- `MeiliService::new` returns `Result` instead of panicking on malformed Meilisearch URL
- `full_reindex` returns `(artifacts_indexed, repos_indexed)` count tuple, eliminating separate COUNT queries

Closes #435.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes