### PR TITLE
Ensured caddy ignores proxy environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,6 +274,12 @@ services:
         condition: service_started
     environment:
       SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      http_proxy: ""
+      https_proxy: ""
+      NO_PROXY: "localhost,127.0.0.1"
+      no_proxy: "localhost,127.0.0.1"
     ports:
       - "${HTTP_PORT:-30080}:80"
       - "${HTTPS_PORT:-30443}:443"


### PR DESCRIPTION
## Summary
FIx  https://github.com/orgs/artifact-keeper/discussions/444

Should ease the [quickstart](https://artifactkeeper.com/docs/getting-started/quickstart/#quick-start)

(Apologies in advance for my own clumsiness I am more stupid than evil, I meant only to provide a very small help)

## Test Checklist
- [ X ] No regressions in existing tests

## API Changes
- [ X ] N/A - no API changes
