### PR TITLE
docs: add comments explaining Caddy proxy env var overrides

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,6 +274,13 @@ services:
         condition: service_started
     environment:
       SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
+      # Clear any proxy env vars inherited from the Docker daemon config.
+      # When the daemon is configured with an HTTP proxy (common in
+      # enterprise networks), those vars are injected into all containers.
+      # Caddy (a Go app) honours them and would try to route reverse-proxy
+      # traffic to sibling containers through the external proxy, which
+      # breaks inter-container communication.
+      # See: https://docs.docker.com/engine/daemon/proxy/
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       http_proxy: ""


### PR DESCRIPTION
## Summary

Follow-up to #445. Adds inline comments to the Caddy service in
`docker-compose.yml` explaining why the proxy environment variables are
cleared and linking to the Docker daemon proxy documentation.

## Test Checklist
- [x] N/A - comment-only change

## API Changes
- [x] N/A - no API changes