### PR TITLE
fix: add diagnostic logging for virtual repo member creation

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -622,13 +622,38 @@ pub async fn create_repository(
 
     // Add virtual repository members if provided
     if repo_type == RepositoryType::Virtual {
-        if let Some(ref member_inputs) = payload.member_repos {
-            for (idx, input) in member_inputs.iter().enumerate() {
-                let member_repo = service.get_by_key(&input.repo_key).await?;
-                let priority = resolve_member_priority(input.priority, idx);
-                service
-                    .add_virtual_member(repo.id, member_repo.id, priority)
-                    .await?;
+        match &payload.member_repos {
+            Some(member_inputs) if !member_inputs.is_empty() => {
+                tracing::info!(
+                    repo_key = %repo.key,
+                    member_count = member_inputs.len(),
+                    "Adding virtual repository members during creation"
+                );
+                for (idx, input) in member_inputs.iter().enumerate() {
+                    let member_repo = service.get_by_key(&input.repo_key).await?;
+                    let priority = resolve_member_priority(input.priority, idx);
+                    tracing::debug!(
+                        virtual_repo = %repo.key,
+                        member_key = %input.repo_key,
+                        priority = priority,
+                        "Adding virtual member"
+                    );
+                    service
+                        .add_virtual_member(repo.id, member_repo.id, priority)
+                        .await?;
+                }
+            }
+            Some(_empty) => {
+                tracing::debug!(
+                    repo_key = %repo.key,
+                    "Virtual repo created with empty member_repos array"
+                );
+            }
+            None => {
+                tracing::debug!(
+                    repo_key = %repo.key,
+                    "Virtual repo created without member_repos field"
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds structured tracing logs to the virtual repo member creation path in
`create_repository` to diagnose #461 (members not saved when selected in
the UI during creation).

The handler now logs:
- `info` when members are received and being added (with count)
- `debug` for each individual member addition (key + priority)
- `debug` when `member_repos` is an empty array
- `debug` when `member_repos` is absent from the request

This will show definitively whether the frontend is sending the members
or not, without requiring the user to inspect browser network requests.

Ref #461

## Test Checklist
- [x] No regressions in existing tests
- [x] N/A - logging only

## API Changes
- [x] N/A - no API changes