### PR TITLE
Fix SonarCloud gate not rescanning when analysis revision is empty

### DIFF
--- a/.github/workflows/sonarcloud-gate.yml
+++ b/.github/workflows/sonarcloud-gate.yml
@@ -111,8 +111,8 @@ jobs:
             echo "Analysis revision: $ANALYSIS_REVISION"
             echo "Current HEAD SHA:  $HEAD_SHA"
 
-            if [[ -n "$ANALYSIS_REVISION" && "$ANALYSIS_REVISION" != "$HEAD_SHA" ]]; then
-              echo "Analysis is stale (from a different commit). Will rescan."
+            if [[ -z "$ANALYSIS_REVISION" || "$ANALYSIS_REVISION" != "$HEAD_SHA" ]]; then
+              echo "Analysis is stale or missing revision (from a different commit). Will rescan."
               GATE_STATUS="NONE"
             fi
           fi


### PR DESCRIPTION
## Summary

Follow-up to #468. The SonarCloud `project_analyses/search` API returns an empty revision for fork PR analyses. The previous condition required a non-empty revision to detect staleness (`-n "$ANALYSIS_REVISION" && != HEAD`), so empty revisions fell through without triggering a rescan.

Fix: invert to rescan unless the revision positively matches the current HEAD SHA (`-z "$ANALYSIS_REVISION" || != HEAD`).

Confirmed in the gate workflow logs for PR #465: `Analysis revision:` was empty while `Current HEAD SHA: 3ef2781...`.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes