### PR TITLE
Fix large generic artifact uploads by removing the 512MB body limit

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -134,7 +134,7 @@ pub fn router() -> Router<SharedState> {
         // Label routes nested under repository
         .merge(super::repository_labels::repo_labels_router())
         // Allow up to 512MB uploads (matches format-specific handlers)
-        .layer(DefaultBodyLimit::max(512 * 1024 * 1024))
+        .layer(DefaultBodyLimit::disable())
 }
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]


### PR DESCRIPTION
The generic repository artifact upload routes in backend/src/api/handlers/repositories.rs are hard-limited to 512 MB via DefaultBodyLimit::max(512 * 1024 * 1024). This causes large uploads, such as 8 GB ISOs, to fail during multipart parsing with a 400 validation error. The top-level API router already disables Axum’s default body limit for large artifact uploads, so the repository router should not reintroduce a restrictive 512 MB cap for generic artifact uploads.