### PR TITLE
fix: use POSIX sh in init-pg-ssl.sh for Alpine compatibility

### DIFF
--- a/docker/init-pg-ssl.sh
+++ b/docker/init-pg-ssl.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 # Enable SSL in PostgreSQL using mounted certificates.
 # This script runs during container first-boot (as the postgres user)
 # via /docker-entrypoint-initdb.d/.
-set -euo pipefail
+set -eu
 
 CERT_SRC="/var/lib/postgresql/certs"
 
-if [[ ! -f "$CERT_SRC/server.crt" ]]; then
+if [ ! -f "$CERT_SRC/server.crt" ]; then
   echo "init-pg-ssl: no certificates found at $CERT_SRC, skipping SSL setup"
   exit 0
 fi


### PR DESCRIPTION
## Summary

`docker/init-pg-ssl.sh` used `#!/bin/bash` and bash-specific syntax (`set -euo pipefail`, `[[ ]]`), but `postgres:16-alpine` does not include bash. This caused the SSL init script to fail silently, leaving PostgreSQL without TLS and crashing the backend on connection.

This PR replaces all bashisms with POSIX sh equivalents:
- `#!/bin/bash` to `#!/bin/sh`
- `set -euo pipefail` to `set -eu` (pipefail is not POSIX)
- `[[ ! -f ... ]]` to `[ ! -f ... ]`

Also verified `docker/init-dtrack.sh` already uses POSIX sh, no changes needed there.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests
- [x] Verified with `shellcheck -s sh docker/init-pg-ssl.sh` (passes clean)

## API Changes
- [x] N/A - no API changes