### PR TITLE
fix: run dtrack-init as root to write API key to shared volume

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -134,6 +134,8 @@ services:
   dtrack-init:
     image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
     container_name: artifact-keeper-dev-dtrack-init
+    # See docker-compose.yml dtrack-init for explanation of user: "0:0"
+    user: "0:0"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,11 @@ services:
   dtrack-init:
     image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
     container_name: artifact-keeper-dtrack-init
+    # The backend image runs as UID 1001 (non-root), but this init container
+    # needs to write to the shared_config volume which is owned by root.
+    # Running as root is safe here: it's a short-lived container that exits
+    # after writing the API key file.
+    user: "0:0"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -76,6 +76,7 @@ if [ -z "$API_KEY" ]; then
 fi
 
 echo "$API_KEY" > "$API_KEY_FILE"
+chmod 644 "$API_KEY_FILE"
 echo "[dtrack-init] API key written to $API_KEY_FILE"
 
 # Enable NVD API 2.0 mirroring (NIST retired legacy feeds; DTrack 4.10.0+ supports API 2.0)


### PR DESCRIPTION
## Summary

The `dtrack-init` service fails with "Permission denied" when writing the
Dependency-Track API key to the `shared_config` volume. The backend Docker
image runs as UID 1001 (non-root `artifact` user), but Docker volumes are
created with root ownership.

Fix:
- Add `user: "0:0"` to the `dtrack-init` service in both compose files so
  the init container runs as root (safe: it's a short-lived init container
  that exits immediately after writing the key)
- Add `chmod 644` on the key file so the backend (UID 1001, volume mounted
  `:ro`) can read it

Closes #476

## Test Checklist
- [ ] Unit tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes