### PR TITLE
fix: create /shared in Dockerfile so dtrack-init runs as non-root

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -134,8 +134,6 @@ services:
   dtrack-init:
     image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
     container_name: artifact-keeper-dev-dtrack-init
-    # See docker-compose.yml dtrack-init for explanation of user: "0:0"
-    user: "0:0"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,11 +106,6 @@ services:
   dtrack-init:
     image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
     container_name: artifact-keeper-dtrack-init
-    # The backend image runs as UID 1001 (non-root), but this init container
-    # needs to write to the shared_config volume which is owned by root.
-    # Running as root is safe here: it's a short-lived container that exits
-    # after writing the API key file.
-    user: "0:0"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -73,11 +73,13 @@ RUN echo 'artifact:x:1001:0:Artifact Keeper:/home/artifact:/sbin/nologin' >> /mn
              /mnt/rootfs/data/backups \
              /mnt/rootfs/data/plugins \
              /mnt/rootfs/scan-workspace \
+             /mnt/rootfs/shared \
              /mnt/rootfs/home/artifact/.cache/grype \
              /mnt/rootfs/home/artifact/.cache/trivy \
              /mnt/rootfs/usr/local/bin && \
     chown -R 1001:0 /mnt/rootfs/data /mnt/rootfs/scan-workspace \
-                     /mnt/rootfs/home/artifact /mnt/rootfs/app
+                     /mnt/rootfs/home/artifact /mnt/rootfs/app \
+                     /mnt/rootfs/shared
 
 # ---------- STIG hardening (applicable subset for ubi-micro) ----------
 # Derived from DISA STIG controls applied in registry.access.redhat.com/ubi9/ubi-stig

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -53,8 +53,8 @@ RUN addgroup -g 1001 artifact && \
 
 # Application directories
 RUN mkdir -p /app /data/storage /data/backups /data/plugins \
-    /scan-workspace /home/artifact/.cache/grype /home/artifact/.cache/trivy && \
-    chown -R 1001:1001 /data /scan-workspace /home/artifact /app
+    /scan-workspace /shared /home/artifact/.cache/grype /home/artifact/.cache/trivy && \
+    chown -R 1001:1001 /data /scan-workspace /home/artifact /app /shared
 
 # Disable core dumps (CIS 1.5.1)
 RUN mkdir -p /etc/security/limits.d && \


### PR DESCRIPTION
## Summary

Replaces the `user: "0:0"` workaround from #486 with the proper fix: create `/shared` with UID 1001 ownership in both Dockerfiles.

The root cause was PR #160 (UBI 9 Micro migration, Feb 14) which switched to a rootfs builder pattern but never added `/shared` to the rootfs. Docker volumes mounted at `/shared` were root-owned, so the non-root init container couldn't write the Dependency-Track API key.

Changes:
- Add `/shared` to `mkdir` and `chown` in `Dockerfile.backend` (rootfs builder)
- Add `/shared` to `mkdir` and `chown` in `Dockerfile.backend.alpine`
- Remove `user: "0:0"` and associated comments from both compose files

Closes #476

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes