### PR TITLE
Revive soft-deleted artifacts when the same path is uploaded again

### DIFF
--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -230,6 +230,7 @@ impl ArtifactService {
                 content_type = EXCLUDED.content_type,
                 storage_key = EXCLUDED.storage_key,
                 uploaded_by = EXCLUDED.uploaded_by,
+                is_deleted = false,
                 updated_at = NOW()
             RETURNING
                 id, repository_id, path, name, version, size_bytes,


### PR DESCRIPTION
Fixes #491 

## Summary

This PR fixes a bug where re-uploading a previously deleted generic artifact returns success, but the artifact remains unavailable in repository listing and direct lookup.

## Problem

Artifact deletion is implemented as a soft delete by setting `is_deleted = true`.

Later, if an artifact is uploaded again to the same repository and path, the upload path uses `INSERT ... ON CONFLICT (repository_id, path) DO UPDATE`. However, the conflict update refreshes metadata such as size, checksum, content type, and storage key without restoring `is_deleted` back to `false`.

As a result, the upload request can return `200 OK`, but the artifact still does not appear in the repository because list and lookup operations only return rows where `is_deleted = false`.

## Root cause

The upload service checks for an existing artifact only among rows with `is_deleted = false`, but the database unique constraint still causes the insert to conflict with a previously deleted row.

The conflict handler updates the existing row in place, but does not revive it.

## Fix

Update the generic artifact upload conflict handler so that re-uploading an existing repository/path combination also sets:

- `is_deleted = false`

This allows previously deleted artifacts to become visible again when re-uploaded.

## Result

- Re-uploading a previously deleted artifact now restores it correctly
- Repository listing shows the artifact again
- Direct artifact lookup by path works again
- Upload success is now consistent with backend read behaviour

## Testing

Tested by:

- Uploading a generic artifact successfully
- Deleting it through the normal API/UI path
- Re-uploading the same file to the same repository/path
- Confirming the artifact appears again in:
  - Repository listing
  - Direct metadata lookup
  - UI repository view

## Notes

This issue is separate from the large-upload body limit problem. That body-limit change affects whether large uploads can be accepted at all; this fix addresses the backend state bug that occurs when re-uploading a previously deleted artifact path.