### PR TITLE
fix: handle re-upload of generic artifacts after soft-delete

### DIFF
--- a/.sqlx/query-05ffc53ac0c7649ec607a90f7f71ee7cef00141e4c78234fbb411a9d12b27562.json
+++ b/.sqlx/query-05ffc53ac0c7649ec607a90f7f71ee7cef00141e4c78234fbb411a9d12b27562.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO artifacts (\n                repository_id, path, name, version, size_bytes,\n                checksum_sha256, content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n            ON CONFLICT (repository_id, path) DO UPDATE SET\n                version = EXCLUDED.version,\n                size_bytes = EXCLUDED.size_bytes,\n                checksum_sha256 = EXCLUDED.checksum_sha256,\n                content_type = EXCLUDED.content_type,\n                storage_key = EXCLUDED.storage_key,\n                uploaded_by = EXCLUDED.uploaded_by,\n                updated_at = NOW()\n            RETURNING\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                created_at, updated_at\n            ",
+  "query": "\n            INSERT INTO artifacts (\n                repository_id, path, name, version, size_bytes,\n                checksum_sha256, content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n            ON CONFLICT (repository_id, path) DO UPDATE SET\n                name = EXCLUDED.name,\n                version = EXCLUDED.version,\n                size_bytes = EXCLUDED.size_bytes,\n                checksum_sha256 = EXCLUDED.checksum_sha256,\n                content_type = EXCLUDED.content_type,\n                storage_key = EXCLUDED.storage_key,\n                uploaded_by = EXCLUDED.uploaded_by,\n                is_deleted = false,\n                updated_at = NOW()\n            RETURNING\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                created_at, updated_at\n            ",
   "describe": {
     "columns": [
       {
@@ -110,5 +110,5 @@
       false
     ]
   },
-  "hash": "4d4db34df7b47ef39285c486ec848d435b68d835bb27247257e16692449bf169"
+  "hash": "05ffc53ac0c7649ec607a90f7f71ee7cef00141e4c78234fbb411a9d12b27562"
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1076,6 +1076,10 @@ pub async fn upload_artifact(
                 .to_string()
         });
 
+    // Clean up any soft-deleted artifact at the same path so the
+    // UNIQUE(repository_id, path) constraint doesn't block re-upload.
+    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &path).await;
+
     let artifact = artifact_service
         .upload(
             repo.id,

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -224,12 +224,14 @@ impl ArtifactService {
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (repository_id, path) DO UPDATE SET
+                name = EXCLUDED.name,
                 version = EXCLUDED.version,
                 size_bytes = EXCLUDED.size_bytes,
                 checksum_sha256 = EXCLUDED.checksum_sha256,
                 content_type = EXCLUDED.content_type,
                 storage_key = EXCLUDED.storage_key,
                 uploaded_by = EXCLUDED.uploaded_by,
+                is_deleted = false,
                 updated_at = NOW()
             RETURNING
                 id, repository_id, path, name, version, size_bytes,


### PR DESCRIPTION
## Summary

Fixes a bug where re-uploading a generic artifact to the same path after soft-delete returned 200 but the artifact did not appear in listings (#491).

The generic upload handler was the only format handler missing the `cleanup_soft_deleted_artifact` call before INSERT. Without it, the soft-deleted row blocked the INSERT via the UNIQUE(repository_id, path) constraint, causing the ON CONFLICT upsert to fire. The upsert updated the row's content but left `is_deleted = true`, so the artifact was invisible in all queries that filter on `is_deleted = false`.

Two changes:

1. Added `cleanup_soft_deleted_artifact` call in `upload_artifact` (repositories.rs), matching the pattern used by all 35+ format-specific handlers.
2. Added `is_deleted = false` and `name = EXCLUDED.name` to the ON CONFLICT clause in `artifact_service.upload` as defense-in-depth. If any future caller skips the cleanup step, the upsert now reactivates the row instead of silently leaving it deleted.

Closes #491

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes