### PR TITLE
fix: filter revoked tokens from token listing endpoints

### DIFF
--- a/.sqlx/query-04c18ffc790e321c7af9fbde1ccf2e9742d72e74d29a0056edbae56a4527462d.json
+++ b/.sqlx/query-04c18ffc790e321c7af9fbde1ccf2e9742d72e74d29a0056edbae56a4527462d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, name, token_prefix, scopes, expires_at, last_used_at, created_at\n        FROM api_tokens\n        WHERE user_id = $1\n        ORDER BY created_at DESC\n        ",
+  "query": "\n        SELECT id, name, token_prefix, scopes, expires_at, last_used_at, created_at\n        FROM api_tokens\n        WHERE user_id = $1 AND revoked_at IS NULL\n        ORDER BY created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -54,5 +54,5 @@
       false
     ]
   },
-  "hash": "39bccdd40b46f8d0aa18676cc862192f856b2491d0a16bf66721484ddb572fe7"
+  "hash": "04c18ffc790e321c7af9fbde1ccf2e9742d72e74d29a0056edbae56a4527462d"
 }

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -42,7 +42,7 @@ async fn list_access_tokens(
         r#"
         SELECT id, name, token_prefix, scopes, expires_at, last_used_at, created_at
         FROM api_tokens
-        WHERE user_id = $1
+        WHERE user_id = $1 AND revoked_at IS NULL
         ORDER BY created_at DESC
         "#,
         auth.user_id

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -614,7 +614,7 @@ pub async fn list_user_tokens(
         r#"
         SELECT id, name, token_prefix, scopes, expires_at, last_used_at, created_at
         FROM api_tokens
-        WHERE user_id = $1
+        WHERE user_id = $1 AND revoked_at IS NULL
         ORDER BY created_at DESC
         "#,
         id


### PR DESCRIPTION
## Summary

Both `list_user_tokens` (admin endpoint) and `list_access_tokens` (profile
endpoint) returned revoked tokens in their listings. Added `AND revoked_at
IS NULL` to both queries.

Found by the E2E test `test-admin-token-revoke.sh` which verified that a
revoked token should no longer appear in the listing.

## Test Checklist
- [x] Unit tests pass (6762)
- [x] E2E test identified the bug
- [x] No regressions in existing tests

## API Changes
- [x] N/A - behavior fix, no schema change