### PR TITLE
fix(ci): smoke E2E tests build from PR source instead of pulling :dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,10 +237,11 @@ jobs:
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Pull backend image
+      - name: Build backend image from PR source
         run: |
-          docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:dev
-          docker tag ghcr.io/artifact-keeper/artifact-keeper-backend:dev artifact-keeper-backend:test
+          echo "Building backend image from current branch (not pulling :dev from registry)..."
+          docker build -f docker/Dockerfile.backend -t artifact-keeper-backend:test .
+        timeout-minutes: 10
 
       - name: Start smoke E2E stack
         run: docker compose -f docker-compose.test.yml --profile smoke up -d


### PR DESCRIPTION
## Summary

The smoke E2E job was pulling `ghcr.io/artifact-keeper-backend:dev` (built from main), so PR smoke tests tested main's code, not the PR's. This caused a chicken-and-egg problem where bug fixes could not prove themselves until after merging.

Changed the "Pull backend image" step to "Build backend image from PR source" using `docker build` from the checked-out PR branch. The test compose file already expects the local tag `artifact-keeper-backend:test`.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes