### PR TITLE
fix: Windows dev binary as workflow artifact, not release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,8 +516,6 @@ jobs:
     runs-on: windows-latest
     needs: [lint-rust, test-backend-unit]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -549,19 +547,10 @@ jobs:
           sha256sum artifact-keeper-windows-amd64.exe > artifact-keeper-windows-amd64.exe.sha256
           echo "Built: $(ls -lh artifact-keeper-windows-amd64.exe | awk '{print $5}')"
 
-      - name: Upload dev binary to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          # Create or update the windows-dev release
-          if gh release view windows-dev > /dev/null 2>&1; then
-            gh release delete-asset windows-dev artifact-keeper-windows-amd64.exe --yes || true
-            gh release delete-asset windows-dev artifact-keeper-windows-amd64.exe.sha256 --yes || true
-            gh release upload windows-dev dist/artifact-keeper-windows-amd64.exe dist/artifact-keeper-windows-amd64.exe.sha256 --clobber
-          else
-            gh release create windows-dev dist/artifact-keeper-windows-amd64.exe dist/artifact-keeper-windows-amd64.exe.sha256 \
-              --title "Windows Dev Build" \
-              --notes "Rolling dev build of the Windows binary from main. Updated on every push to main. Not for production use." \
-              --prerelease
-          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-keeper-windows-amd64
+          path: |
+            dist/artifact-keeper-windows-amd64.exe
+            dist/artifact-keeper-windows-amd64.exe.sha256


### PR DESCRIPTION
## Summary

Fixes the Windows dev build job added in #524. The `.exe` is now uploaded as a **workflow artifact** (downloadable from the Actions run page) instead of creating a GitHub Release. Releases stay tag-only.

Also removes the `contents: write` permission that was only needed for the release approach.

The dev `.exe` will appear under the CI run's Artifacts section, same location as other CI artifacts like Docker images.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests
- N/A: CI workflow change only

## API Changes
- [x] N/A - no API changes