### PR TITLE
fix: CI Complete fails when smoke-e2e is skipped due to no backend changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,11 +451,14 @@ jobs:
             fi
           done
 
-          # Smoke E2E
-          if [[ "${{ needs.smoke-e2e.result }}" == "success" ]]; then
+          # Smoke E2E (skipped when backend image build is skipped due to no changes)
+          smoke_result="${{ needs.smoke-e2e.result }}"
+          if [[ "$smoke_result" == "success" ]]; then
             echo "✅ smoke-e2e" >> $GITHUB_STEP_SUMMARY
+          elif [[ "$smoke_result" == "skipped" ]]; then
+            echo "⏭️ smoke-e2e (no backend changes)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "❌ smoke-e2e: ${{ needs.smoke-e2e.result }}" >> $GITHUB_STEP_SUMMARY
+            echo "❌ smoke-e2e: $smoke_result" >> $GITHUB_STEP_SUMMARY
             tier1_pass=false
           fi
 


### PR DESCRIPTION
## Summary

The CI Complete job treats skipped smoke-e2e as a failure, which causes the entire pipeline to show as failed on pushes that only change CI workflows, docs, or non-backend files.

The smoke-e2e job depends on build-backend-image, which is skipped by the detect-changes filter when no backend code changed. This is correct behavior, but CI Complete was not handling the skipped state.

This fix matches the pattern already used for integration tests and container builds: treat `skipped` as acceptable, report it as "no backend changes" in the summary.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests
- N/A: CI workflow change only

## API Changes
- [x] N/A - no API changes