### PR TITLE
fix: keep scripts/openscap-wrapper.py in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,14 @@ credentials/
 *.pem
 *.key
 test-results/
-scripts/
+scripts/e2e*/
+scripts/native-tests/
+scripts/stress/
+scripts/failure/
+scripts/migration-e2e/
+scripts/sso-e2e/
+scripts/mesh-e2e/
+scripts/devops-agent*
 site/
 CLAUDE.md
 HOUSEKEEPING.md


### PR DESCRIPTION
## Summary

The blanket `scripts/` exclusion in `.dockerignore` (from PR #558) broke the OpenSCAP Docker build which needs `scripts/openscap-wrapper.py`. Changed to exclude only test/dev script subdirectories instead.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes