### PR TITLE
fix: proxy checksum files from upstream for Maven remote repos

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -316,15 +316,36 @@ async fn download(
             }
         }
 
-        // Otherwise compute from the artifact
-        return serve_computed_checksum(
+        // Otherwise try to compute from a locally-stored artifact
+        if let Ok(response) = serve_computed_checksum(
             &state,
             repo.id,
             &repo.storage_location(),
             base_path,
             checksum_type,
         )
-        .await;
+        .await
+        {
+            return Ok(response);
+        }
+
+        // Fallback: proxy the checksum file from upstream for remote repos
+        if repo.repo_type == RepositoryType::Remote {
+            if let (Some(ref upstream_url), Some(ref proxy)) =
+                (&repo.upstream_url, &state.proxy_service)
+            {
+                let (content, _content_type) =
+                    proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &path)
+                        .await?;
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "text/plain")
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+        }
+
+        return Err(AppError::NotFound("File not found".to_string()).into_response());
     }
 
     // 4. Serve the artifact file


### PR DESCRIPTION
## Summary

The Maven download handler proxied `.jar` files from upstream for remote repositories but returned 404 for checksum requests (`.md5`, `.sha1`, `.sha256`). This caused Maven/Gradle clients to emit integrity warnings like `Could not validate integrity of download from ...`.

The checksum code path (section 3 of the `download()` handler) only checked local storage and the artifacts DB table, which are empty for remote proxy repos since artifacts are served via the proxy cache, not stored as local artifacts. After failing local lookups, the handler now falls back to fetching the checksum file directly from the upstream Maven repository using the same `proxy_helpers::proxy_fetch()` used for regular artifact downloads.

Closes #532

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes