### PR TITLE
docs: update clippy command to match CI (--all-targets -D warnings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ tests/
 ```bash
 # Backend lint and unit tests
 cargo fmt --check
-cargo clippy --workspace
+cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --lib
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in contributing! Here's how to get started.
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/artifact-keeper.git`
 3. Create a feature branch: `git checkout -b feature/your-feature`
 4. Make your changes
-5. Run checks: `cargo fmt --check && cargo clippy --workspace && cargo test --workspace --lib`
+5. Run checks: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --lib`
 6. Commit and push to your fork
 7. Open a Pull Request against `main`
 


### PR DESCRIPTION
## Summary
CI runs `cargo clippy --workspace --all-targets -- -D warnings` but CONTRIBUTING.md and CLAUDE.md documented the shorter form without --all-targets or -D warnings, which misses integration test files and allows warnings through. Align the docs with what CI actually enforces.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [X] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [X] N/A - no API changes
