### PR TITLE
fix: align SSO callback redirect with frontend route

### DIFF
--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -291,7 +291,7 @@ async fn oidc_callback_inner(
     .await?;
 
     let frontend_url = format!(
-        "/auth/callback?code={}",
+        "/callback?code={}",
         urlencoding::encode(&exchange_code),
     );
 
@@ -514,7 +514,7 @@ pub async fn saml_acs(
     .await?;
 
     let frontend_url = format!(
-        "/auth/callback?code={}",
+        "/callback?code={}",
         urlencoding::encode(&exchange_code),
     );
 


### PR DESCRIPTION
## Summary

- Changed OIDC and SAML callback redirects from `/auth/callback` to `/callback` to match the actual Next.js frontend route
- The `(auth)` route group in Next.js App Router doesn't produce a URL segment, so the page serves at `/callback`, not `/auth/callback`
- Companion PR in artifact-keeper-web removes the rewrite workaround that was papering over this mismatch

## Changes

Two lines in `backend/src/api/handlers/sso.rs`:
- Line 294 (OIDC): `/auth/callback?code={}` -> `/callback?code={}`
- Line 517 (SAML): `/auth/callback?code={}` -> `/callback?code={}`

## Test plan

- [x] `cargo test --workspace --lib` passes (6912 tests)
- [ ] Manual SSO login flow: verify redirect lands on `/callback` and token exchange completes

Closes #583