### PR TITLE
fix: pin Trivy image to 0.69.3 from GHCR

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -62,7 +62,7 @@ services:
     restart: unless-stopped
 
   trivy:
-    image: ghcr.io/aquasecurity/trivy:latest
+    image: ghcr.io/aquasecurity/trivy:0.69.3
     container_name: artifact-keeper-dev-trivy
     command: ["server", "--listen", "0.0.0.0:8090"]
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -76,7 +76,7 @@ services:
       - e2e-test-network
 
   trivy:
-    image: ghcr.io/aquasecurity/trivy:latest
+    image: ghcr.io/aquasecurity/trivy:0.69.3
     container_name: e2e-test-trivy
     command: ["server", "--listen", "0.0.0.0:8090"]
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,7 @@ services:
   # the backend calls on demand. Optional: remove this service and unset
   # TRIVY_URL on the backend if you do not need vulnerability scanning.
   trivy:
-    image: aquasec/trivy:latest
+    image: ghcr.io/aquasecurity/trivy:0.69.3
     container_name: artifact-keeper-trivy
     command: ["server", "--listen", "0.0.0.0:8090"]
     ports:


### PR DESCRIPTION
## Summary

The `trivy` service in `docker-compose.yml` referenced `aquasec/trivy:latest` on Docker Hub, but that tag does not exist, causing `docker compose up` to fail immediately. The local-dev and test compose files used `ghcr.io/aquasecurity/trivy:latest`, which is also unreliable since Trivy only publishes versioned and `canary` tags on GHCR.

Pins all three compose files to `ghcr.io/aquasecurity/trivy:0.69.3` (latest stable release).

Fixes #585

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes