### PR TITLE
fix: exclude revoked tokens from service account token listing

### DIFF
--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -227,7 +227,7 @@ impl TokenService {
                    created_by_user_id, description, repo_selector,
                    revoked_at, last_used_ip, last_used_user_agent
             FROM api_tokens
-            WHERE user_id = $1
+            WHERE user_id = $1 AND revoked_at IS NULL
             ORDER BY created_at DESC
             "#,
         )


### PR DESCRIPTION
## Summary

Fixes #592

The `list_tokens` query was missing an `AND revoked_at IS NULL` filter, causing revoked API tokens to still appear in service account token listings. Other token queries in the same file already had this filter (e.g., `revoke_all_tokens`), so this aligns the listing query with the existing pattern.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Query-only change, no new unit tests needed. All 7086 existing unit tests pass.

## API Changes
- [x] N/A - no API changes