### PR TITLE
fix: add missing sccache step to Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,8 @@ jobs:
         with:
           key: x86_64-pc-windows-msvc
 
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:


### PR DESCRIPTION
## Summary

The Windows Dev Build job has been failing on main because the global `RUSTC_WRAPPER: sccache` env var requires sccache to be installed, but the Windows job was missing the `mozilla-actions/sccache-action` step. Every other job in the workflow has this step.

Error:
```
error: could not execute process `sccache ... rustc.exe -vV` (never executed)
Caused by: program not found
```

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes