### PR TITLE
fix: delegate PyPI virtual repo downloads to format-specific fetch logic

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use regex::Regex;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::api::handlers::error_helpers::{map_db_err, map_storage_err};
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
@@ -412,7 +412,7 @@ async fn serve_file(
                 for member in &members {
                     // Try local storage first (works for hosted repos and
                     // cached remote artifacts)
-                    if let Ok((content, _ct)) = proxy_helpers::local_fetch_by_path_suffix(
+                    match proxy_helpers::local_fetch_by_path_suffix(
                         &state.db,
                         state,
                         member.id,
@@ -421,7 +421,16 @@ async fn serve_file(
                     )
                     .await
                     {
-                        return Ok(build_file_response(filename, content));
+                        Ok((content, _ct)) => {
+                            return Ok(build_file_response(filename, content));
+                        }
+                        Err(e) => {
+                            debug!(
+                                member_key = %member.key,
+                                error = %e.status(),
+                                "local fetch failed for virtual member"
+                            );
+                        }
                     }
 
                     // If member is a remote PyPI repo, use the format-specific
@@ -431,7 +440,7 @@ async fn serve_file(
                         if let (Some(ref upstream_url), Some(ref proxy)) =
                             (&member.upstream_url, &state.proxy_service)
                         {
-                            if let Ok(content) = fetch_from_pypi_remote(
+                            match fetch_from_pypi_remote(
                                 proxy,
                                 member.id,
                                 &member.key,
@@ -441,7 +450,16 @@ async fn serve_file(
                             )
                             .await
                             {
-                                return Ok(build_file_response(filename, content));
+                                Ok(content) => {
+                                    return Ok(build_file_response(filename, content));
+                                }
+                                Err(e) => {
+                                    debug!(
+                                        member_key = %member.key,
+                                        error = %e.status(),
+                                        "remote PyPI fetch failed for virtual member"
+                                    );
+                                }
                             }
                         }
                     }
@@ -465,7 +483,9 @@ async fn serve_file(
         .await
         .map_err(map_storage_err)?;
 
-    // Record download
+    // Record download statistics for locally-stored artifacts only.
+    // Proxied and virtual-repo fetches go through build_file_response()
+    // which intentionally skips stats since the artifact is not ours.
     let _ = sqlx::query!(
         "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
         artifact.id
@@ -473,17 +493,9 @@ async fn serve_file(
     .execute(&state.db)
     .await;
 
-    let content_type = if filename.ends_with(".whl") {
-        "application/zip"
-    } else if filename.ends_with(".tar.gz") {
-        "application/gzip"
-    } else {
-        "application/octet-stream"
-    };
-
     Ok(Response::builder()
         .status(StatusCode::OK)
-        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_TYPE, pypi_content_type(filename))
         .header(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
@@ -518,29 +530,23 @@ async fn fetch_from_pypi_remote(
     let index_html = String::from_utf8_lossy(&index_bytes);
     let file_url = find_upstream_url_for_file(&index_html, filename);
 
-    let (fetch_base, fetch_path) = if let Some(ref url) = file_url {
-        // Absolute URL from the index (e.g.
-        // https://files.pythonhosted.org/packages/.../file.whl).
-        // Split into scheme+host base and path so proxy_fetch can
-        // cache it under the repo key.
-        match url
-            .find("://")
-            .and_then(|i| url[i + 3..].find('/').map(|j| i + 3 + j))
-        {
-            Some(pos) => (url[..pos].to_string(), url[pos + 1..].to_string()),
-            None => (
-                upstream_url.to_string(),
-                format!("simple/{}/{}", normalized, filename),
-            ),
-        }
-    } else {
-        // No absolute URL found (the upstream may be another AK instance
-        // that uses relative paths). Fall back to the
-        // simple/{project}/{filename} convention.
+    let fallback = || {
         (
             upstream_url.to_string(),
             format!("simple/{}/{}", normalized, filename),
         )
+    };
+
+    let (fetch_base, fetch_path) = match file_url.as_deref().and_then(split_url_base_and_path) {
+        // Absolute URL from the index (e.g.
+        // https://files.pythonhosted.org/packages/.../file.whl).
+        // Split into scheme+host base and path so proxy_fetch can
+        // cache it under the repo key.
+        Some(pair) => pair,
+        // No absolute URL found, or the URL had no path component.
+        // The upstream may be another AK instance that uses relative
+        // paths. Fall back to the simple/{project}/{filename} convention.
+        None => fallback(),
     };
 
     let (content, _content_type) =
@@ -550,14 +556,12 @@ async fn fetch_from_pypi_remote(
 }
 
 /// Build the HTTP response for serving a PyPI file download.
+///
+/// Used for proxied and virtual-repo fetches. Download statistics are not
+/// recorded here because the artifact is not stored locally; stats are only
+/// tracked for artifacts served from our own storage (see `serve_file`).
 fn build_file_response(filename: &str, content: Bytes) -> Response {
-    let content_type = if filename.ends_with(".whl") {
-        "application/zip"
-    } else if filename.ends_with(".tar.gz") {
-        "application/gzip"
-    } else {
-        "application/octet-stream"
-    };
+    let content_type = pypi_content_type(filename);
 
     Response::builder()
         .status(StatusCode::OK)
@@ -834,14 +838,7 @@ async fn upload(
             .insert("summary".to_string(), serde_json::Value::String(s.clone()));
     }
 
-    // Infer content type
-    let content_type = if filename.ends_with(".whl") {
-        "application/zip"
-    } else if filename.ends_with(".tar.gz") {
-        "application/gzip"
-    } else {
-        "application/octet-stream"
-    };
+    let content_type = pypi_content_type(&filename);
 
     let artifact_path = format!("{}/{}/{}", normalized, pkg_version, filename);
     let size_bytes = content.len() as i64;
@@ -924,11 +921,38 @@ async fn upload(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Determine the Content-Type for a PyPI filename based on its extension.
+fn pypi_content_type(filename: &str) -> &'static str {
+    if filename.ends_with(".whl") || filename.ends_with(".zip") {
+        "application/zip"
+    } else if filename.ends_with(".tar.gz") {
+        "application/gzip"
+    } else if filename.ends_with(".tar.bz2") {
+        "application/x-bzip2"
+    } else {
+        "application/octet-stream"
+    }
+}
+
 fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+}
+
+/// Split a URL into its base (scheme + host) and path components.
+///
+/// For example, `https://files.pythonhosted.org/packages/ab/cd/file.whl` splits
+/// into `("https://files.pythonhosted.org", "packages/ab/cd/file.whl")`.
+/// Returns `None` if the URL has no `://` scheme separator or no path after the
+/// host.
+fn split_url_base_and_path(url: &str) -> Option<(String, String)> {
+    let scheme_end = url.find("://")?;
+    let after_scheme = &url[scheme_end + 3..];
+    let slash_pos = after_scheme.find('/')?;
+    let split = scheme_end + 3 + slash_pos;
+    Some((url[..split].to_string(), url[split + 1..].to_string()))
 }
 
 /// Look up the original download URL for a given filename in upstream simple
@@ -1620,9 +1644,16 @@ mod tests {
     }
 
     #[test]
-    fn test_build_file_response_unknown_extension() {
+    fn test_build_file_response_zip_extension() {
         let content = Bytes::from_static(b"some data");
         let resp = build_file_response("package-1.0.zip", content);
+        assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "application/zip");
+    }
+
+    #[test]
+    fn test_build_file_response_unknown_extension() {
+        let content = Bytes::from_static(b"some data");
+        let resp = build_file_response("package-1.0.egg", content);
         assert_eq!(
             resp.headers().get(CONTENT_TYPE).unwrap(),
             "application/octet-stream"
@@ -1648,5 +1679,94 @@ mod tests {
             resp.headers().get(CONTENT_LENGTH).unwrap(),
             &data.len().to_string()
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // pypi_content_type
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pypi_content_type_whl() {
+        assert_eq!(
+            pypi_content_type("numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.whl"),
+            "application/zip"
+        );
+    }
+
+    #[test]
+    fn test_pypi_content_type_tar_gz() {
+        assert_eq!(pypi_content_type("six-1.16.0.tar.gz"), "application/gzip");
+    }
+
+    #[test]
+    fn test_pypi_content_type_tar_bz2() {
+        assert_eq!(
+            pypi_content_type("package-1.0.tar.bz2"),
+            "application/x-bzip2"
+        );
+    }
+
+    #[test]
+    fn test_pypi_content_type_zip() {
+        assert_eq!(pypi_content_type("package-1.0.zip"), "application/zip");
+    }
+
+    #[test]
+    fn test_pypi_content_type_unknown() {
+        assert_eq!(
+            pypi_content_type("package-1.0.egg"),
+            "application/octet-stream"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // split_url_base_and_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_split_url_normal() {
+        let result =
+            split_url_base_and_path("https://files.pythonhosted.org/packages/ab/cd/file.whl");
+        assert_eq!(
+            result,
+            Some((
+                "https://files.pythonhosted.org".to_string(),
+                "packages/ab/cd/file.whl".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_split_url_with_port() {
+        let result = split_url_base_and_path("http://localhost:8080/api/v1/packages");
+        assert_eq!(
+            result,
+            Some((
+                "http://localhost:8080".to_string(),
+                "api/v1/packages".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_split_url_without_path() {
+        // URL with host only and no trailing slash has no path component
+        let result = split_url_base_and_path("https://example.com");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_split_url_with_single_path_segment() {
+        let result = split_url_base_and_path("https://example.com/file.whl");
+        assert_eq!(
+            result,
+            Some(("https://example.com".to_string(), "file.whl".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_split_url_no_scheme() {
+        let result = split_url_base_and_path("not-a-url");
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary

PyPI virtual repositories failed to download artifacts from remote members because the download
path used the generic `resolve_virtual_download` proxy helper. That helper constructs an upstream
URL by appending the filename to the member's upstream URL (e.g. `https://pypi.org/simple/six/six-1.16.0.tar.gz`),
which does not work for external PyPI registries. Real PyPI hosts files on a separate domain
(`files.pythonhosted.org`) with deep paths that can only be discovered by parsing the simple index page.

The remote repo download path already handled this correctly via `find_upstream_url_for_file`, but
the virtual repo path bypassed that logic entirely.

This change:
- Extracts the remote PyPI fetch logic into a reusable `fetch_from_pypi_remote` helper that fetches
  the upstream simple index, resolves the real download URL, and downloads from there.
- Replaces the virtual repo download block to iterate members manually using `fetch_virtual_members`,
  trying local storage first, then delegating to `fetch_from_pypi_remote` for remote members.
- Extracts `build_file_response` to deduplicate the response construction across all three paths
  (local, remote, virtual).

Closes #602

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes