### PR TITLE
fix(oidc): preserve is_admin when admin_group is not configured

### DIFF
--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -502,13 +502,13 @@ impl OidcService {
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         if let Some(mut user) = existing_user {
-            // Update user info from OIDC
             let is_admin = self.is_admin_from_groups(&oidc_user.groups);
 
             sqlx::query!(
                 r#"
                 UPDATE users
-                SET email = $1, display_name = $2, is_admin = $3,
+                SET email = $1, display_name = $2,
+                    is_admin = COALESCE($3, is_admin),
                     last_login_at = NOW(), updated_at = NOW()
                 WHERE id = $4
                 "#,
@@ -523,14 +523,16 @@ impl OidcService {
 
             user.email = oidc_user.email.clone();
             user.display_name = oidc_user.display_name.clone();
-            user.is_admin = is_admin;
+            if let Some(admin) = is_admin {
+                user.is_admin = admin;
+            }
 
             return Ok(user);
         }
 
         // Create new user from OIDC
         let user_id = Uuid::new_v4();
-        let is_admin = self.is_admin_from_groups(&oidc_user.groups);
+        let is_admin = self.is_admin_from_groups(&oidc_user.groups).unwrap_or(false);
 
         // Generate unique username if conflict exists
         let username = self.generate_unique_username(&oidc_user.username).await?;
@@ -598,15 +600,12 @@ impl OidcService {
         }
     }
 
-    /// Check if user is admin based on group memberships
-    fn is_admin_from_groups(&self, groups: &[String]) -> bool {
-        if let Some(admin_group) = &self.config.admin_group {
+    fn is_admin_from_groups(&self, groups: &[String]) -> Option<bool> {
+        self.config.admin_group.as_ref().map(|admin_group| {
             groups
                 .iter()
                 .any(|g| g.to_lowercase() == admin_group.to_lowercase())
-        } else {
-            false
-        }
+        })
     }
 
     /// Extract group memberships for role mapping
@@ -618,7 +617,7 @@ impl OidcService {
     pub fn map_groups_to_roles(&self, groups: &[String]) -> Vec<String> {
         let mut roles = vec!["user".to_string()];
 
-        if self.is_admin_from_groups(groups) {
+        if self.is_admin_from_groups(groups).unwrap_or(false) {
             roles.push("admin".to_string());
         }
 


### PR DESCRIPTION
## Summary

- `is_admin_from_groups()` now returns `Option<bool>` instead of `bool`
- When `OIDC_ADMIN_GROUP` is not set, returns `None` instead of `false`
- UPDATE query uses `COALESCE($3, is_admin)` to preserve existing value when `None`
- New user creation defaults to `false` when admin group is not configured

## Problem

When `OIDC_ADMIN_GROUP` env var is not configured, every SSO login resets `is_admin` to `false` because `is_admin_from_groups()` unconditionally returns `false` when no admin group is set. This forces admins to re-enable the admin flag after each SSO login.

## Test plan

- [ ] SSO login without `OIDC_ADMIN_GROUP` set — admin flag should be preserved
- [ ] SSO login with `OIDC_ADMIN_GROUP` set and user in group — admin flag set to `true`
- [ ] SSO login with `OIDC_ADMIN_GROUP` set and user NOT in group — admin flag set to `false`
- [ ] New user creation via SSO without admin group — defaults to non-admin

Fixes #583