### PR TITLE
fix(auth): preserve is_admin on SSO login when no admin group pattern matches

### DIFF
--- a/.sqlx/query-58004db582b2c8bf892dc4eadf55f08756e8a7955b598baf8f62f7457b6b9d93.json
+++ b/.sqlx/query-58004db582b2c8bf892dc4eadf55f08756e8a7955b598baf8f62f7457b6b9d93.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET is_admin = COALESCE($2, is_admin), updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "58004db582b2c8bf892dc4eadf55f08756e8a7955b598baf8f62f7457b6b9d93"
+}

--- a/.sqlx/query-63585afba650b4bb395d24b0ffc3668a1089a79666338e0859bc361e3f64ca48.json
+++ b/.sqlx/query-63585afba650b4bb395d24b0ffc3668a1089a79666338e0859bc361e3f64ca48.json
@@ -1,0 +1,140 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE users\n                SET\n                    username = $2,\n                    email = $3,\n                    display_name = $4,\n                    is_admin = COALESCE($5, is_admin),\n                    is_active = true,\n                    updated_at = NOW()\n                WHERE id = $1\n                RETURNING\n                    id, username, email, password_hash, display_name,\n                    auth_provider as \"auth_provider: AuthProvider\",\n                    external_id, is_admin, is_active, is_service_account, must_change_password,\n                    totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                    last_login_at, created_at, updated_at\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "63585afba650b4bb395d24b0ffc3668a1089a79666338e0859bc361e3f64ca48"
+}

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -38,8 +38,9 @@ pub struct FederatedCredentials {
 /// Result of group-to-role mapping
 #[derive(Debug, Clone, Default)]
 pub struct RoleMapping {
-    /// Whether the user should be an admin
-    pub is_admin: bool,
+    /// Whether the user should be an admin.
+    /// `None` means no admin group was found in claims — preserve existing value.
+    pub is_admin: Option<bool>,
     /// Additional role names to assign
     pub roles: Vec<String>,
 }
@@ -785,7 +786,7 @@ impl AuthService {
         for group in &normalized_groups {
             for pattern in &admin_patterns {
                 if group.contains(pattern) {
-                    mapping.is_admin = true;
+                    mapping.is_admin = Some(true);
                     mapping.roles.push("admin".to_string());
                     break;
                 }
@@ -821,9 +822,9 @@ impl AuthService {
     ///
     /// Updates the user's is_admin flag and assigns roles based on the mapping.
     pub async fn apply_role_mapping(&self, user_id: Uuid, mapping: &RoleMapping) -> Result<()> {
-        // Update is_admin flag
+        // Update is_admin flag (only if admin group mapping is configured)
         sqlx::query!(
-            "UPDATE users SET is_admin = $2, updated_at = NOW() WHERE id = $1",
+            "UPDATE users SET is_admin = COALESCE($2, is_admin), updated_at = NOW() WHERE id = $1",
             user_id,
             mapping.is_admin
         )
@@ -915,7 +916,7 @@ impl AuthService {
                     username = $2,
                     email = $3,
                     display_name = $4,
-                    is_admin = $5,
+                    is_admin = COALESCE($5, is_admin),
                     is_active = true,
                     updated_at = NOW()
                 WHERE id = $1
@@ -957,7 +958,7 @@ impl AuthService {
                 credentials.display_name,
                 provider as AuthProvider,
                 credentials.external_id,
-                role_mapping.is_admin
+                role_mapping.is_admin.unwrap_or(false)
             )
             .fetch_one(&self.db)
             .await
@@ -1479,7 +1480,7 @@ mod tests {
     #[test]
     fn test_role_mapping_default() {
         let mapping = RoleMapping::default();
-        assert!(!mapping.is_admin);
+        assert!(mapping.is_admin.is_none());
         assert!(mapping.roles.is_empty());
     }
 
@@ -1501,7 +1502,7 @@ mod tests {
         for group in &normalized_groups {
             for pattern in &admin_patterns {
                 if group.contains(pattern) {
-                    mapping.is_admin = true;
+                    mapping.is_admin = Some(true);
                     mapping.roles.push("admin".to_string());
                     break;
                 }
@@ -1533,38 +1534,38 @@ mod tests {
     #[test]
     fn test_map_groups_admin_group() {
         let mapping = test_map_groups_to_roles(&["team-admin".to_string()]);
-        assert!(mapping.is_admin);
+        assert_eq!(mapping.is_admin, Some(true));
         assert!(mapping.roles.contains(&"admin".to_string()));
     }
 
     #[test]
     fn test_map_groups_administrators_group() {
         let mapping = test_map_groups_to_roles(&["CN=Administrators,DC=corp".to_string()]);
-        assert!(mapping.is_admin);
+        assert_eq!(mapping.is_admin, Some(true));
     }
 
     #[test]
     fn test_map_groups_superusers_group() {
         let mapping = test_map_groups_to_roles(&["superusers".to_string()]);
-        assert!(mapping.is_admin);
+        assert_eq!(mapping.is_admin, Some(true));
     }
 
     #[test]
     fn test_map_groups_artifact_admins_group() {
         let mapping = test_map_groups_to_roles(&["artifact-admins".to_string()]);
-        assert!(mapping.is_admin);
+        assert_eq!(mapping.is_admin, Some(true));
     }
 
     #[test]
     fn test_map_groups_case_insensitive_admin() {
         let mapping = test_map_groups_to_roles(&["ADMIN-TEAM".to_string()]);
-        assert!(mapping.is_admin);
+        assert_eq!(mapping.is_admin, Some(true));
     }
 
     #[test]
     fn test_map_groups_developers() {
         let mapping = test_map_groups_to_roles(&["team-developers".to_string()]);
-        assert!(!mapping.is_admin);
+        assert!(mapping.is_admin.is_none());
         assert!(mapping.roles.contains(&"developer".to_string()));
         assert!(mapping.roles.contains(&"user".to_string()));
     }
@@ -1590,14 +1591,14 @@ mod tests {
     #[test]
     fn test_map_groups_no_matching_groups() {
         let mapping = test_map_groups_to_roles(&["random-group".to_string()]);
-        assert!(!mapping.is_admin);
+        assert!(mapping.is_admin.is_none());
         assert_eq!(mapping.roles, vec!["user"]);
     }
 
     #[test]
     fn test_map_groups_empty_groups() {
         let mapping = test_map_groups_to_roles(&[]);
-        assert!(!mapping.is_admin);
+        assert!(mapping.is_admin.is_none());
         assert_eq!(mapping.roles, vec!["user"]);
     }
 
@@ -1613,7 +1614,7 @@ mod tests {
     #[test]
     fn test_map_groups_admin_plus_developer() {
         let mapping = test_map_groups_to_roles(&["admin".to_string(), "developers".to_string()]);
-        assert!(mapping.is_admin);
+        assert_eq!(mapping.is_admin, Some(true));
         assert!(mapping.roles.contains(&"admin".to_string()));
         assert!(mapping.roles.contains(&"developer".to_string()));
         // user role should not be duplicated


### PR DESCRIPTION
## Summary

SSO login resets admin permissions set by administrator. Details in #608.

## Changes

### `RoleMapping.is_admin`: `bool` → `Option<bool>`

Previously defaulted to `false`, making it impossible to distinguish "user is not admin" from "no admin group info in claims". Now:
- `None` — no admin group matched in claims, preserve existing DB value
- `Some(true)` — user's group matched an admin pattern

### `sync_federated_user()` UPDATE query

```sql
-- before
UPDATE users SET ... is_admin = $5 ... WHERE id = $1

-- after
UPDATE users SET ... is_admin = COALESCE($5, is_admin) ... WHERE id = $1
```

When `is_admin` is `None`, `COALESCE` preserves the existing value in the database.

### `apply_role_mapping()` UPDATE query

Same `COALESCE` pattern applied.

### New user INSERT

Uses `.unwrap_or(false)` — new SSO users default to non-admin, which is the expected behavior.

### Tests

Updated assertions from `bool` to `Option<bool>`.

## Note

Same bug exists in `saml_service.rs` — not addressed in this PR.

Fixes #608