### PR TITLE
docs: add Sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,21 @@ flowchart TD
 | **site.yml** | Push to `site/**` | Build and deploy docs to GitHub Pages |
 | **ami-build.yml** | On release published | Bake AWS AMI with Packer |
 
+## Sponsors
+
+Thank you to our sponsors for supporting ongoing development of Artifact Keeper.
+
+### Backers
+
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/dragonpaw"><img src="https://github.com/dragonpaw.png" width="60" /><br /><sub><b>Ash A.</b></sub></a></td>
+    <td align="center"><a href="https://github.com/injectedfusion"><img src="https://github.com/injectedfusion.png" width="60" /><br /><sub><b>Gabriel Rodriguez</b></sub></a></td>
+  </tr>
+</table>
+
+[Become a sponsor](https://github.com/sponsors/artifact-keeper) to support the project and get your name listed here.
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary

Adds a Sponsors section to the README recognizing our Backer-tier GitHub Sponsors:

- **Ash A.** (@dragonpaw)
- **Gabriel Rodriguez** (@injectedfusion)

Includes avatars, profile links, and a call-to-action for new sponsors.

## Test Checklist
- [x] N/A - documentation only

## API Changes
- [x] N/A