### PR TITLE
feat: add OCI tags/list and _catalog endpoints

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -190,9 +190,10 @@ fn parse_pagination_params(
                 "invalid pagination parameter n",
             )
         })?,
-        // OCI spec says "return all tags" without `n`, but we cap at 100 to
-        // prevent unbounded responses. A `Link` header is emitted when more
-        // results exist, so well-behaved clients will paginate correctly.
+        // OCI spec says "return all tags" without `n`, but we cap at a default
+        // of 100 to prevent unbounded responses.  This matches Docker Hub's
+        // observed behaviour.  A `Link` header is emitted when more results
+        // exist, so well-behaved clients will paginate correctly.
         None => 100,
     }
     .min(10000);
@@ -239,6 +240,9 @@ fn apply_cursor_pagination(tags: Vec<String>, last: Option<&str>, n: usize) -> (
 /// per OCI Distribution Spec.
 /// Spec reference:
 /// https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-tags
+///
+/// `dedup()` (consecutive-only) is sufficient here because `oci_lexical_cmp`
+/// provides a total order: equal strings are always adjacent after `sort_by`.
 fn merge_and_dedup_tags(tag_sets: Vec<Vec<String>>) -> Vec<String> {
     let mut all: Vec<String> = tag_sets.into_iter().flatten().collect();
     all.sort_by(|lhs, rhs| oci_lexical_cmp(lhs, rhs));
@@ -345,11 +349,12 @@ fn is_digest_reference(reference: &str) -> bool {
         return false;
     };
 
+    // OCI spec: algorithm = `[a-z0-9]+([+._-][a-z0-9]+)*` (lowercase only)
     !algorithm.is_empty()
         && !encoded.is_empty()
         && algorithm
             .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '+' | '.' | '-'))
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '+' | '.' | '-'))
         && encoded
             .chars()
             .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '=' | '_' | '-'))
@@ -1679,6 +1684,14 @@ async fn resolve_remote_tags_page(
     }
 }
 
+/// Resolve a single page of tags for a virtual repository.
+///
+/// The cursor (`last`) is forwarded to each member query **and** applied again
+/// on the merged result.  This double application is intentional: member repos
+/// (especially remote upstreams) may sort tags differently than our canonical
+/// `oci_lexical_cmp` order, so tags that the upstream considers "after" the
+/// cursor may land "before" it in our ordering.  The second pass in
+/// `apply_cursor_pagination` catches these strays and keeps pagination correct.
 async fn resolve_virtual_tags_page(
     state: &SharedState,
     repo: &OciRepoInfo,

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -352,9 +352,9 @@ fn is_digest_reference(reference: &str) -> bool {
     // OCI spec: algorithm = `[a-z0-9]+([+._-][a-z0-9]+)*` (lowercase only)
     !algorithm.is_empty()
         && !encoded.is_empty()
-        && algorithm
-            .chars()
-            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '+' | '.' | '-'))
+        && algorithm.chars().all(|ch| {
+            ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '+' | '.' | '-')
+        })
         && encoded
             .chars()
             .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '=' | '_' | '-'))

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -161,6 +161,92 @@ fn compute_sha256(data: &[u8]) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Tags/list and catalog response types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct TagsListResponse {
+    name: String,
+    tags: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CatalogResponse {
+    repositories: Vec<String>,
+}
+
+/// Parse `n` and `last` pagination query parameters.
+/// Returns `Err(Response)` with 400 PAGINATION_NUMBER_INVALID when `n` is
+/// present but not a valid non-negative integer.
+#[allow(clippy::result_large_err)] // Response-as-error is used throughout this module
+fn parse_pagination_params(
+    params: &std::collections::HashMap<String, String>,
+) -> Result<(usize, Option<String>), Response> {
+    let n = match params.get("n") {
+        Some(v) => v.parse::<usize>().map_err(|_| {
+            oci_error(
+                StatusCode::BAD_REQUEST,
+                "PAGINATION_NUMBER_INVALID",
+                "invalid pagination parameter n",
+            )
+        })?,
+        // OCI spec says "return all tags" without `n`, but we cap at 100 to
+        // prevent unbounded responses. A `Link` header is emitted when more
+        // results exist, so well-behaved clients will paginate correctly.
+        None => 100,
+    }
+    .min(10000);
+    let last = params.get("last").cloned();
+    Ok((n, last))
+}
+
+/// Build a `Link` header value for OCI pagination (RFC 5988).
+/// Uses a relative URL which is reliable behind reverse proxies.
+fn build_pagination_link_header(path: &str, last_item: &str, n: usize) -> String {
+    let encoded_last = urlencoding::encode(last_item);
+    format!("<{}?n={}&last={}>; rel=\"next\"", path, n, encoded_last)
+}
+
+fn oci_lexical_cmp(lhs: &str, rhs: &str) -> std::cmp::Ordering {
+    lhs.to_ascii_lowercase()
+        .cmp(&rhs.to_ascii_lowercase())
+        .then_with(|| lhs.cmp(rhs))
+}
+
+/// Apply cursor-based pagination to a lexically sorted list.
+/// Spec reference:
+/// https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-tags
+/// Returns (page, has_more).
+fn apply_cursor_pagination(tags: Vec<String>, last: Option<&str>, n: usize) -> (Vec<String>, bool) {
+    if n == 0 {
+        return (vec![], false);
+    }
+    let start = match last {
+        Some(cursor) => tags.partition_point(|t| {
+            matches!(
+                oci_lexical_cmp(t, cursor),
+                std::cmp::Ordering::Less | std::cmp::Ordering::Equal
+            )
+        }),
+        None => 0,
+    };
+    let end = (start + n).min(tags.len());
+    let has_more = end < tags.len();
+    (tags[start..end].to_vec(), has_more)
+}
+
+/// Merge multiple tag lists, deduplicate, and sort lexically
+/// per OCI Distribution Spec.
+/// Spec reference:
+/// https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-tags
+fn merge_and_dedup_tags(tag_sets: Vec<Vec<String>>) -> Vec<String> {
+    let mut all: Vec<String> = tag_sets.into_iter().flatten().collect();
+    all.sort_by(|lhs, rhs| oci_lexical_cmp(lhs, rhs));
+    all.dedup();
+    all
+}
+
+// ---------------------------------------------------------------------------
 // Repository resolution
 // ---------------------------------------------------------------------------
 
@@ -242,6 +328,106 @@ fn normalize_docker_image(image: &str, upstream_url: &str) -> String {
         format!("library/{}", image)
     } else {
         image.to_string()
+    }
+}
+
+/// Check whether `reference` looks like an OCI content-addressable digest
+/// rather than a human-readable tag. The grammar (from the OCI Distribution
+/// Spec) is:
+///
+/// ```text
+/// digest    ::= algorithm ":" encoded
+/// algorithm ::= [a-z0-9]([a-z0-9._+-]*[a-z0-9])?
+/// encoded   ::= [a-zA-Z0-9=_-]+
+/// ```
+fn is_digest_reference(reference: &str) -> bool {
+    let Some((algorithm, encoded)) = reference.split_once(':') else {
+        return false;
+    };
+
+    !algorithm.is_empty()
+        && !encoded.is_empty()
+        && algorithm
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '+' | '.' | '-'))
+        && encoded
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '=' | '_' | '-'))
+}
+
+fn cached_manifest_reference_key(repo_type: &str, reference: &str, digest: &str) -> String {
+    if repo_type == RepositoryType::Remote && !is_digest_reference(reference) {
+        digest.to_string()
+    } else {
+        reference.to_string()
+    }
+}
+
+async fn cache_manifest_reference_locally(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    reference: &str,
+    content: &Bytes,
+    content_type: Option<&str>,
+) -> Result<String, String> {
+    let digest = compute_sha256(content);
+    let storage = state
+        .storage_for_repo(&repo.location)
+        .map_err(|e| e.to_string())?;
+    let manifest_key = manifest_storage_key(&digest);
+
+    storage
+        .put(&manifest_key, content.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let manifest_content_type = content_type
+        .unwrap_or("application/vnd.oci.image.manifest.v1+json")
+        .to_string();
+    let cached_reference = cached_manifest_reference_key(&repo.repo_type, reference, &digest);
+
+    sqlx::query(
+        r#"INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (repository_id, name, tag) DO UPDATE SET
+             manifest_digest = EXCLUDED.manifest_digest,
+             manifest_content_type = EXCLUDED.manifest_content_type,
+             updated_at = NOW()"#,
+    )
+    .bind(repo.id)
+    .bind(&repo.image)
+    .bind(cached_reference)
+    .bind(&digest)
+    .bind(&manifest_content_type)
+    .execute(&state.db)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(digest)
+}
+
+/// Cache a proxied manifest locally and return its digest. Falls back to
+/// computing the digest without caching if persistence fails.
+async fn cache_manifest_or_compute_digest(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    image_name: &str,
+    reference: &str,
+    content: &Bytes,
+    content_type: Option<&str>,
+) -> String {
+    match cache_manifest_reference_locally(state, repo, reference, content, content_type).await {
+        Ok(digest) => digest,
+        Err(e) => {
+            warn!(
+                image = image_name,
+                reference = reference,
+                error = %e,
+                "Failed to persist proxied manifest locally — \
+                 subsequent pulls will re-fetch from upstream until caching succeeds"
+            );
+            compute_sha256(content)
+        }
     }
 }
 
@@ -522,12 +708,20 @@ async fn version_check(State(state): State<SharedState>, headers: HeaderMap) -> 
 ///   "test/python/blobs/uploads/uuid" → ("test/python", "uploads", "uuid")
 fn parse_oci_path(path: &str) -> Option<(String, String, Option<String>)> {
     let path = path.trim_start_matches('/');
+    if let Some(name) = path.strip_suffix("/tags/list") {
+        return Some((
+            name.to_string(),
+            "tags".to_string(),
+            Some("list".to_string()),
+        ));
+    }
+
     let parts: Vec<&str> = path.split('/').collect();
 
-    // Find "manifests" or "blobs" in the parts
+    // Find terminal content operations in the remaining path.
     let op_idx = parts
         .iter()
-        .position(|&p| p == "manifests" || p == "blobs" || p == "tags")?;
+        .position(|&p| p == "manifests" || p == "blobs")?;
     let name = parts[..op_idx].join("/");
     let operation = parts[op_idx];
 
@@ -1074,7 +1268,7 @@ async fn handle_head_manifest(
     }
 
     // Reference can be a tag or a digest. Look up locally first.
-    let local_result: Option<(String, String)> = if reference.starts_with("sha256:") {
+    let local_result: Option<(String, String)> = if is_digest_reference(reference) {
         sqlx::query!(
             "SELECT manifest_digest, manifest_content_type FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 LIMIT 1",
             repo.id, reference
@@ -1124,7 +1318,15 @@ async fn handle_head_manifest(
     if let Some((content, ct)) =
         try_upstream_fetch(&repo, state, &format!("manifests/{}", reference)).await
     {
-        let digest = compute_sha256(&content);
+        let digest = cache_manifest_or_compute_digest(
+            state,
+            &repo,
+            image_name,
+            reference,
+            &content,
+            ct.as_deref(),
+        )
+        .await;
         return build_oci_proxy_response(
             &content,
             ct,
@@ -1163,7 +1365,7 @@ async fn handle_get_manifest(
         return unauthorized_challenge(&host);
     }
 
-    let local_result: Option<(String, String)> = if reference.starts_with("sha256:") {
+    let local_result: Option<(String, String)> = if is_digest_reference(reference) {
         sqlx::query!(
             "SELECT manifest_digest, manifest_content_type FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 LIMIT 1",
             repo.id, reference
@@ -1213,7 +1415,15 @@ async fn handle_get_manifest(
     if let Some((content, ct)) =
         try_upstream_fetch(&repo, state, &format!("manifests/{}", reference)).await
     {
-        let digest = compute_sha256(&content);
+        let digest = cache_manifest_or_compute_digest(
+            state,
+            &repo,
+            image_name,
+            reference,
+            &content,
+            ct.as_deref(),
+        )
+        .await;
         return build_oci_proxy_response(
             &content,
             ct,
@@ -1371,6 +1581,735 @@ async fn handle_put_manifest(
 }
 
 // ---------------------------------------------------------------------------
+// Tags list handler
+// ---------------------------------------------------------------------------
+
+async fn handle_tags_list(
+    state: &SharedState,
+    headers: &HeaderMap,
+    image_name: &str,
+    query: &std::collections::HashMap<String, String>,
+) -> Response {
+    let host = request_host(headers);
+    if validate_token(&state.db, &state.config, headers).is_err() {
+        return unauthorized_challenge(&host);
+    }
+
+    let repo = match resolve_repo(&state.db, image_name).await {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+
+    let (n, last) = match parse_pagination_params(query) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // n=0: return empty list per spec
+    if n == 0 {
+        return build_tags_response(&repo.image, vec![]);
+    }
+
+    let (page, has_more) = match resolve_tags_page(state, &repo, n, last.as_deref()).await {
+        Ok(page) => page,
+        Err(e) => return e,
+    };
+
+    // OCI spec: return 404 NAME_UNKNOWN when the repository name is not
+    // known to the registry. For local repos, if the first page is empty
+    // and no cursor was provided, the image has never been pushed.
+    if page.is_empty()
+        && !has_more
+        && last.is_none()
+        && repo.repo_type != RepositoryType::Remote
+        && !local_tags_exist(&state.db, repo.id, &repo.image)
+            .await
+            .unwrap_or(false)
+    {
+        return oci_error(
+            StatusCode::NOT_FOUND,
+            "NAME_UNKNOWN",
+            &format!("repository name not known to registry: {}", image_name),
+        );
+    }
+
+    build_tags_response_with_pagination(&repo.image, page, has_more, image_name, n)
+}
+
+async fn resolve_tags_page(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    n: usize,
+    last: Option<&str>,
+) -> Result<(Vec<String>, bool), Response> {
+    if repo.repo_type == RepositoryType::Remote {
+        return resolve_remote_tags_page(state, repo, n, last).await;
+    }
+
+    if repo.repo_type == RepositoryType::Virtual {
+        return resolve_virtual_tags_page(state, repo, n, last).await;
+    }
+
+    resolve_local_tags_page(state, repo, n, last).await
+}
+
+async fn resolve_remote_tags_page(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    n: usize,
+    last: Option<&str>,
+) -> Result<(Vec<String>, bool), Response> {
+    match tags_list_remote(state, repo, n, last).await {
+        Ok(page) => Ok(page),
+        Err(err) => {
+            warn!(
+                repo = %repo.key,
+                image = %repo.image,
+                status = %err.status(),
+                "Upstream tags/list failed, falling back to cached tags"
+            );
+            let cached_page = tags_list_local(&state.db, repo.id, &repo.image, last, n).await?;
+            let cache_populated = if cached_page.tags.is_empty() {
+                local_tags_exist(&state.db, repo.id, &repo.image).await?
+            } else {
+                true
+            };
+            finalize_remote_tags_page(Err(err), cached_page, cache_populated)
+        }
+    }
+}
+
+async fn resolve_virtual_tags_page(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    n: usize,
+    last: Option<&str>,
+) -> Result<(Vec<String>, bool), Response> {
+    let tags = tags_list_virtual(state, repo, n, last).await?;
+    Ok(apply_cursor_pagination(tags, last, n))
+}
+
+async fn resolve_local_tags_page(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    n: usize,
+    last: Option<&str>,
+) -> Result<(Vec<String>, bool), Response> {
+    let page = tags_list_local(&state.db, repo.id, &repo.image, last, n).await?;
+    Ok((page.tags, page.has_more))
+}
+
+/// Build a JSON response for tags/list with no pagination.
+fn build_tags_response(image: &str, tags: Vec<String>) -> Response {
+    let resp = TagsListResponse {
+        name: image.to_string(),
+        tags,
+    };
+    let json = serde_json::to_string(&resp).unwrap_or_default();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json")
+        .header(CONTENT_LENGTH, json.len().to_string())
+        .body(Body::from(json))
+        .unwrap()
+}
+
+/// Build a JSON response for tags/list with optional Link pagination header.
+fn build_tags_response_with_pagination(
+    image: &str,
+    page: Vec<String>,
+    has_more: bool,
+    image_name: &str,
+    n: usize,
+) -> Response {
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json");
+
+    if has_more {
+        if let Some(last_tag) = page.last() {
+            let path = format!("/v2/{}/tags/list", image_name);
+            let link = build_pagination_link_header(&path, last_tag, n);
+            builder = builder.header("Link", link);
+        }
+    }
+
+    let resp = TagsListResponse {
+        name: image.to_string(),
+        tags: page,
+    };
+    let json = serde_json::to_string(&resp).unwrap_or_default();
+    builder
+        .header(CONTENT_LENGTH, json.len().to_string())
+        .body(Body::from(json))
+        .unwrap()
+}
+
+/// Build the upstream `tags/list` path for direct remote repositories.
+///
+/// Requests one extra tag so this server can determine whether it should emit
+/// its own `Link` header while still returning at most `n` tags to the client.
+fn build_remote_tags_list_path(n: usize, last: Option<&str>) -> String {
+    let mut path = format!("tags/list?n={}", n.saturating_add(1));
+    if let Some(last) = last {
+        path.push_str("&last=");
+        path.push_str(&urlencoding::encode(last));
+    }
+    path
+}
+
+/// Extract the upstream `last` cursor from an OCI pagination `Link` header.
+fn parse_upstream_pagination_last(link: &str) -> Option<String> {
+    let selected = link
+        .split(',')
+        .map(str::trim)
+        .find(|segment| segment.contains("rel=\"next\""))?;
+
+    let target = selected
+        .split_once('<')
+        .and_then(|(_, rest)| rest.split_once('>'))
+        .map(|(uri, _)| uri)?;
+    let query = target.split_once('?')?.1;
+
+    serde_urlencoded::from_str::<Vec<(String, String)>>(query)
+        .ok()?
+        .into_iter()
+        .find_map(|(key, value)| (key == "last").then_some(value))
+}
+
+/// Trim the extra upstream tag used to detect whether another page exists.
+fn split_remote_tags_page(
+    mut tags: Vec<String>,
+    n: usize,
+    upstream_has_more: bool,
+) -> (Vec<String>, bool) {
+    let has_more = upstream_has_more || tags.len() > n;
+    if has_more {
+        tags.truncate(n);
+    }
+    (tags, has_more)
+}
+
+#[allow(clippy::result_large_err)] // Response-as-error is used throughout this module
+fn finalize_remote_tags_page(
+    upstream: Result<(Vec<String>, bool), Response>,
+    cached_page: LocalTagsPage,
+    cache_populated: bool,
+) -> Result<(Vec<String>, bool), Response> {
+    match upstream {
+        Ok(page) => Ok(page),
+        Err(err) => {
+            if !cache_populated {
+                Err(err)
+            } else {
+                Ok((cached_page.tags, cached_page.has_more))
+            }
+        }
+    }
+}
+
+fn missing_upload_uuid_response() -> Response {
+    oci_error(
+        StatusCode::NOT_FOUND,
+        "BLOB_UPLOAD_UNKNOWN",
+        "upload UUID required",
+    )
+}
+
+/// Build a SQL query for local tags, excluding digest references (which
+/// contain a ':' character, e.g. "sha256:abc…") so only human-readable tags
+/// are returned. This uses `POSITION(':' IN tag) = 0` as a fast SQL-side
+/// filter; the more precise `is_digest_reference()` is used on the Rust side
+/// when validating individual references.
+fn local_tags_query(has_cursor: bool) -> &'static str {
+    if has_cursor {
+        r#"SELECT tag
+           FROM (
+               SELECT DISTINCT tag
+               FROM oci_tags
+               WHERE repository_id = $1
+                 AND name = $2
+                 AND POSITION(':' IN tag) = 0
+                 AND (LOWER(tag), tag) > (LOWER($3), $3)
+           ) local_tags
+           ORDER BY LOWER(tag), tag
+           LIMIT $4"#
+    } else {
+        r#"SELECT tag
+           FROM (
+               SELECT DISTINCT tag
+               FROM oci_tags
+               WHERE repository_id = $1
+                 AND name = $2
+                 AND POSITION(':' IN tag) = 0
+           ) local_tags
+           ORDER BY LOWER(tag), tag
+           LIMIT $3"#
+    }
+}
+
+struct LocalTagsPage {
+    tags: Vec<String>,
+    has_more: bool,
+}
+
+async fn local_tags_exist(db: &PgPool, repo_id: Uuid, image_name: &str) -> Result<bool, Response> {
+    sqlx::query_scalar::<_, bool>(
+        r#"SELECT EXISTS(
+               SELECT 1
+               FROM oci_tags
+               WHERE repository_id = $1
+                 AND name = $2
+                 AND POSITION(':' IN tag) = 0
+           )"#,
+    )
+    .bind(repo_id)
+    .bind(image_name)
+    .fetch_one(db)
+    .await
+    .map_err(|e| {
+        warn!("Failed to check cached tags for {}: {}", image_name, e);
+        oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+            "failed to list tags",
+        )
+    })
+}
+
+async fn tags_list_local(
+    db: &PgPool,
+    repo_id: Uuid,
+    image_name: &str,
+    last: Option<&str>,
+    n: usize,
+) -> Result<LocalTagsPage, Response> {
+    let limit = (n.saturating_add(1)) as i64;
+    let rows = if let Some(last) = last {
+        sqlx::query_scalar::<_, String>(local_tags_query(true))
+            .bind(repo_id)
+            .bind(image_name)
+            .bind(last)
+            .bind(limit)
+            .fetch_all(db)
+            .await
+    } else {
+        sqlx::query_scalar::<_, String>(local_tags_query(false))
+            .bind(repo_id)
+            .bind(image_name)
+            .bind(limit)
+            .fetch_all(db)
+            .await
+    };
+
+    rows.map(|tags| {
+        let (tags, has_more) = split_remote_tags_page(tags, n, false);
+        LocalTagsPage { tags, has_more }
+    })
+    .map_err(|e| {
+        warn!("Failed to list tags for {}: {}", image_name, e);
+        oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+            "failed to list tags",
+        )
+    })
+}
+
+struct UpstreamTagsPage {
+    tags: Vec<String>,
+    next_last: Option<String>,
+}
+
+async fn fetch_upstream_tags_page(
+    state: &SharedState,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    image: &str,
+    n: usize,
+    last: Option<&str>,
+) -> Result<UpstreamTagsPage, Response> {
+    let proxy = state.proxy_service.as_ref().ok_or_else(|| {
+        oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "proxy service unavailable",
+        )
+    })?;
+
+    let upstream_path = format!("v2/{}/{}", image, build_remote_tags_list_path(n, last));
+    let (content, _ct, link) = proxy_helpers::proxy_fetch_uncached_with_link(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+    )
+    .await
+    .map_err(|resp| match resp.status() {
+        StatusCode::NOT_FOUND => oci_error(
+            StatusCode::NOT_FOUND,
+            "NAME_UNKNOWN",
+            "repository not found upstream",
+        ),
+        _ => oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "failed to fetch tags from upstream",
+        ),
+    })?;
+
+    let parsed = serde_json::from_slice::<serde_json::Value>(&content).map_err(|e| {
+        warn!("Invalid upstream tags/list response for {}: {}", image, e);
+        oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "invalid upstream tags response",
+        )
+    })?;
+    let tags = parsed["tags"].as_array().ok_or_else(|| {
+        warn!(
+            "Upstream tags/list response for {} is missing a tags array",
+            image
+        );
+        oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "invalid upstream tags response",
+        )
+    })?;
+
+    Ok(UpstreamTagsPage {
+        tags: tags
+            .iter()
+            .filter_map(|t| t.as_str().map(String::from))
+            .collect(),
+        next_last: link.as_deref().and_then(parse_upstream_pagination_last),
+    })
+}
+
+async fn collect_upstream_tags(
+    state: &SharedState,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    image: &str,
+    max_tags: usize,
+    last: Option<&str>,
+) -> Result<(Vec<String>, bool), Response> {
+    if max_tags == 0 {
+        return Ok((vec![], false));
+    }
+
+    let mut collected = Vec::new();
+    let mut cursor = last.map(String::from);
+    let mut pages_fetched = 0usize;
+
+    loop {
+        let remaining = max_tags.saturating_sub(collected.len());
+        if remaining == 0 {
+            return Ok((collected, false));
+        }
+
+        let page = fetch_upstream_tags_page(
+            state,
+            repo_id,
+            repo_key,
+            upstream_url,
+            image,
+            remaining,
+            cursor.as_deref(),
+        )
+        .await?;
+        pages_fetched += 1;
+
+        if pages_fetched > 1024 {
+            warn!(
+                "Stopping upstream tags pagination for {} after {} pages to avoid a loop",
+                image, pages_fetched
+            );
+            return Ok((collected, true));
+        }
+
+        let had_extra_item = page.tags.len() > remaining;
+        if had_extra_item {
+            collected.extend(page.tags.into_iter().take(remaining));
+            return Ok((collected, true));
+        }
+
+        let before_len = collected.len();
+        collected.extend(page.tags);
+
+        match page.next_last {
+            Some(next_last) if collected.len() < max_tags => {
+                if collected.len() == before_len || cursor.as_deref() == Some(next_last.as_str()) {
+                    warn!(
+                        "Upstream tags pagination for {} returned a non-advancing cursor, stopping early",
+                        image
+                    );
+                    return Ok((collected, true));
+                }
+                cursor = Some(next_last);
+            }
+            Some(_) => return Ok((collected, true)),
+            None => return Ok((collected, false)),
+        }
+    }
+}
+
+/// Fetch all tags from the upstream registry for a remote repo.
+/// Returns a single page and whether another page exists so the caller can
+/// emit artifact-keeper `Link` headers instead of upstream ones.
+async fn tags_list_remote(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    n: usize,
+    last: Option<&str>,
+) -> Result<(Vec<String>, bool), Response> {
+    let upstream_url = repo.upstream_url.as_deref().ok_or_else(|| {
+        oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "remote repository has no upstream configured",
+        )
+    })?;
+    let image = normalize_docker_image(&repo.image, upstream_url);
+    let (tags, upstream_has_more) =
+        collect_upstream_tags(state, repo.id, &repo.key, upstream_url, &image, n + 1, last).await?;
+    Ok(split_remote_tags_page(tags, n, upstream_has_more))
+}
+
+/// Aggregate tags from all virtual repo members.
+///
+/// Forward the merged cursor to every member because any tag at or before the
+/// merged cursor cannot appear on the next merged page.
+async fn tags_list_virtual(
+    state: &SharedState,
+    repo: &OciRepoInfo,
+    n_limit: usize,
+    last: Option<&str>,
+) -> Result<Vec<String>, Response> {
+    let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+    let member_limit = n_limit.saturating_add(1);
+    let member_cursor = last;
+    let image = repo.image.clone();
+
+    let handles: Vec<_> = members
+        .iter()
+        .map(|member| {
+            let image = image.clone();
+            let member_id = member.id;
+            let member_key = member.key.clone();
+            let repo_type = member.repo_type.clone();
+            let upstream_url = member.upstream_url.clone();
+            async move {
+                if repo_type == RepositoryType::Remote {
+                    fetch_tags_from_remote_member(
+                        state,
+                        member_id,
+                        &member_key,
+                        upstream_url.as_deref(),
+                        &image,
+                        member_limit,
+                        member_cursor,
+                    )
+                    .await
+                } else {
+                    tags_list_local(&state.db, member_id, &image, member_cursor, member_limit)
+                        .await
+                        .ok()
+                        .map(|page| page.tags)
+                }
+            }
+        })
+        .collect();
+
+    let tag_sets: Vec<Vec<String>> = futures::future::join_all(handles)
+        .await
+        .into_iter()
+        .flatten()
+        .collect();
+
+    Ok(merge_and_dedup_tags(tag_sets))
+}
+
+/// Fetch tags from a single remote virtual member via upstream proxy.
+async fn fetch_tags_from_remote_member(
+    state: &SharedState,
+    member_id: Uuid,
+    member_key: &str,
+    upstream_url: Option<&str>,
+    image_name: &str,
+    n_limit: usize,
+    last: Option<&str>,
+) -> Option<Vec<String>> {
+    let upstream_url = upstream_url?;
+    let image = normalize_docker_image(image_name, upstream_url);
+    let (tags, upstream_has_more) = collect_upstream_tags(
+        state,
+        member_id,
+        member_key,
+        upstream_url,
+        &image,
+        n_limit,
+        last,
+    )
+    .await
+    .map_err(|_| {
+        tracing::debug!(
+            "Virtual member '{}': upstream tags/list failed, skipping",
+            member_key
+        );
+    })
+    .ok()?;
+
+    tracing::debug!(
+        "Virtual member '{}': fetched {} tags from upstream (has_more={})",
+        member_key,
+        tags.len(),
+        upstream_has_more
+    );
+    Some(tags)
+}
+
+// ---------------------------------------------------------------------------
+// Catalog handler
+// ---------------------------------------------------------------------------
+
+/// List all repositories visible to the authenticated user.
+///
+/// Note: `_catalog` is defined by the Docker Registry HTTP API V2
+/// (distribution/distribution), **not** the OCI Distribution Spec.
+/// Per the Docker spec, the catalog contents are implementation-specific:
+/// registries MAY limit results based on access level. This implementation
+/// returns all repositories to any authenticated user without per-repository
+/// ACL filtering, consistent with Docker Hub and most registry implementations.
+async fn handle_catalog(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    query: Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    let host = request_host(&headers);
+    if validate_token(&state.db, &state.config, &headers).is_err() {
+        return unauthorized_challenge(&host);
+    }
+
+    let (n, last) = match parse_pagination_params(&query) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    if n == 0 {
+        let resp = CatalogResponse {
+            repositories: vec![],
+        };
+        let json = serde_json::to_string(&resp).unwrap_or_default();
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_LENGTH, json.len().to_string())
+            .body(Body::from(json))
+            .unwrap();
+    }
+
+    // `_catalog` is defined by the Docker Registry HTTP API V2 and is scoped
+    // to repositories available in the local registry cluster. It must not
+    // advertise what may exist only upstream.
+    // Spec reference:
+    // https://github.com/distribution/distribution/blob/v3.0.0/docs/content/spec/api.md#catalog
+    let (page, has_more) = match catalog_local_entries(&state.db, last.as_deref(), n).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json");
+
+    if has_more {
+        if let Some(last_repo) = page.last() {
+            let link = build_pagination_link_header("/v2/_catalog", last_repo, n);
+            builder = builder.header("Link", link);
+        }
+    }
+
+    let resp = CatalogResponse { repositories: page };
+    let json = serde_json::to_string(&resp).unwrap_or_default();
+    builder
+        .header(CONTENT_LENGTH, json.len().to_string())
+        .body(Body::from(json))
+        .unwrap()
+}
+
+/// Fetch a single page of catalog entries from oci_tags using SQL-side
+/// cursor pagination. Returns `(page, has_more)`.
+///
+/// Sorting uses `LOWER()` for case-insensitive primary order (matching
+/// `oci_lexical_cmp`) with a case-sensitive tiebreaker. The cursor
+/// comparison mirrors this ordering so pagination is consistent.
+async fn catalog_local_entries(
+    db: &PgPool,
+    last: Option<&str>,
+    n: usize,
+) -> Result<(Vec<String>, bool), Response> {
+    let limit = (n as i64).saturating_add(1);
+
+    let rows: Vec<(String,)> = if let Some(cursor) = last {
+        sqlx::query_as(
+            "SELECT name FROM ( \
+                 SELECT DISTINCT \
+                     CASE WHEN t.name = r.key OR t.name = '' \
+                          THEN r.key \
+                          ELSE r.key || '/' || t.name \
+                     END AS name \
+                 FROM oci_tags t \
+                 JOIN repositories r ON r.id = t.repository_id \
+             ) catalog \
+             WHERE (LOWER(name), name) > (LOWER($1), $1) \
+             ORDER BY LOWER(name), name \
+             LIMIT $2",
+        )
+        .bind(cursor)
+        .bind(limit)
+        .fetch_all(db)
+        .await
+    } else {
+        sqlx::query_as(
+            "SELECT name FROM ( \
+                 SELECT DISTINCT \
+                     CASE WHEN t.name = r.key OR t.name = '' \
+                          THEN r.key \
+                          ELSE r.key || '/' || t.name \
+                     END AS name \
+                 FROM oci_tags t \
+                 JOIN repositories r ON r.id = t.repository_id \
+             ) catalog \
+             ORDER BY LOWER(name), name \
+             LIMIT $1",
+        )
+        .bind(limit)
+        .fetch_all(db)
+        .await
+    }
+    .map_err(|e| {
+        warn!("Failed to query local catalog entries: {}", e);
+        oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+            "failed to list catalog",
+        )
+    })?;
+
+    let mut entries: Vec<String> = rows.into_iter().map(|(name,)| name).collect();
+    let has_more = entries.len() > n;
+    if has_more {
+        entries.truncate(n);
+    }
+    Ok((entries, has_more))
+}
+
+// ---------------------------------------------------------------------------
 // Catch-all handlers
 // ---------------------------------------------------------------------------
 
@@ -1391,101 +2330,55 @@ async fn catch_all(
 
     let (image_name, operation, reference) = parsed;
 
+    // Helper to require a reference, reducing repeated match arms
+    macro_rules! require_ref {
+        ($ref:expr, $code:expr, $msg:expr) => {
+            match $ref {
+                Some(r) => r,
+                None => return oci_error(StatusCode::BAD_REQUEST, $code, $msg),
+            }
+        };
+    }
+
     match (method.as_str(), operation.as_str()) {
-        // Blob operations
         ("HEAD", "blobs") => {
-            let digest = match reference {
-                Some(d) => d,
-                None => {
-                    return oci_error(StatusCode::BAD_REQUEST, "DIGEST_INVALID", "digest required")
-                }
-            };
-            handle_head_blob(&state, &headers, &image_name, &digest).await
+            let d = require_ref!(reference, "DIGEST_INVALID", "digest required");
+            handle_head_blob(&state, &headers, &image_name, &d).await
         }
         ("GET", "blobs") => {
-            let digest = match reference {
-                Some(d) => d,
-                None => {
-                    return oci_error(StatusCode::BAD_REQUEST, "DIGEST_INVALID", "digest required")
-                }
-            };
-            handle_get_blob(&state, &headers, &image_name, &digest).await
+            let d = require_ref!(reference, "DIGEST_INVALID", "digest required");
+            handle_get_blob(&state, &headers, &image_name, &d).await
         }
-
-        // Upload operations
         ("POST", "uploads") => {
             let digest = query.get("digest").map(|s| s.as_str());
             handle_start_upload(&state, &headers, &image_name, digest, body).await
         }
         ("PATCH", "uploads") => {
-            let uuid = match reference {
-                Some(u) => u,
-                None => {
-                    return oci_error(
-                        StatusCode::NOT_FOUND,
-                        "BLOB_UPLOAD_UNKNOWN",
-                        "upload UUID required",
-                    )
-                }
+            let Some(u) = reference else {
+                return missing_upload_uuid_response();
             };
-            handle_patch_upload(&state, &headers, &image_name, &uuid, body).await
+            handle_patch_upload(&state, &headers, &image_name, &u, body).await
         }
         ("PUT", "uploads") => {
-            let uuid = match reference {
-                Some(u) => u,
-                None => {
-                    return oci_error(
-                        StatusCode::NOT_FOUND,
-                        "BLOB_UPLOAD_UNKNOWN",
-                        "upload UUID required",
-                    )
-                }
+            let Some(u) = reference else {
+                return missing_upload_uuid_response();
             };
             let digest = query.get("digest").map(|s| s.as_str());
-            handle_complete_upload(&state, &headers, &image_name, &uuid, digest, body).await
+            handle_complete_upload(&state, &headers, &image_name, &u, digest, body).await
         }
-
-        // Manifest operations
         ("HEAD", "manifests") => {
-            let reference = match reference {
-                Some(r) => r,
-                None => {
-                    return oci_error(
-                        StatusCode::BAD_REQUEST,
-                        "NAME_INVALID",
-                        "reference required",
-                    )
-                }
-            };
-            handle_head_manifest(&state, &headers, &image_name, &reference).await
+            let r = require_ref!(reference, "NAME_INVALID", "reference required");
+            handle_head_manifest(&state, &headers, &image_name, &r).await
         }
         ("GET", "manifests") => {
-            let reference = match reference {
-                Some(r) => r,
-                None => {
-                    return oci_error(
-                        StatusCode::BAD_REQUEST,
-                        "NAME_INVALID",
-                        "reference required",
-                    )
-                }
-            };
-            handle_get_manifest(&state, &headers, &image_name, &reference).await
+            let r = require_ref!(reference, "NAME_INVALID", "reference required");
+            handle_get_manifest(&state, &headers, &image_name, &r).await
         }
         ("PUT", "manifests") => {
-            let reference = match reference {
-                Some(r) => r,
-                None => {
-                    return oci_error(
-                        StatusCode::BAD_REQUEST,
-                        "NAME_INVALID",
-                        "reference required",
-                    )
-                }
-            };
-            handle_put_manifest(&state, &headers, &image_name, &reference, body).await
+            let r = require_ref!(reference, "NAME_INVALID", "reference required");
+            handle_put_manifest(&state, &headers, &image_name, &r, body).await
         }
-
+        ("GET", "tags") => handle_tags_list(&state, &headers, &image_name, &query).await,
         _ => oci_error(
             StatusCode::METHOD_NOT_ALLOWED,
             "UNSUPPORTED",
@@ -1502,6 +2395,7 @@ pub fn router() -> Router<SharedState> {
     Router::new()
         .route("/", get(version_check))
         .route("/token", get(token).post(token))
+        .route("/_catalog", get(handle_catalog))
         .fallback(catch_all)
         .layer(DefaultBodyLimit::disable())
 }
@@ -1977,6 +2871,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_oci_path_allows_tags_in_repository_name() {
+        let result = parse_oci_path("acme/tags/api/manifests/latest");
+        let (name, op, reference) = result.unwrap();
+        assert_eq!(name, "acme/tags/api");
+        assert_eq!(op, "manifests");
+        assert_eq!(reference, Some("latest".to_string()));
+    }
+
+    #[test]
+    fn test_parse_oci_path_allows_repo_key_named_tags() {
+        let result = parse_oci_path("tags/myimage/manifests/latest");
+        let (name, op, reference) = result.unwrap();
+        assert_eq!(name, "tags/myimage");
+        assert_eq!(op, "manifests");
+        assert_eq!(reference, Some("latest".to_string()));
+    }
+
+    #[test]
     fn test_parse_oci_path_blobs_no_digest() {
         let result = parse_oci_path("test/image/blobs");
         let (name, op, reference) = result.unwrap();
@@ -1992,6 +2904,175 @@ mod tests {
         assert_eq!(name, "test/image");
         assert_eq!(op, "manifests");
         assert_eq!(reference, Some("sha256:abc123".to_string()));
+    }
+
+    #[test]
+    fn test_is_digest_reference_accepts_sha256_reference() {
+        assert!(is_digest_reference(
+            "sha256:4d3f1c5bcf9f2f7e4a3e2d1c0b9a887766554433221100ffeeddccbbaa998877"
+        ));
+    }
+
+    #[test]
+    fn test_is_digest_reference_accepts_non_hex_encoded() {
+        // OCI spec allows [a-zA-Z0-9=_-]+ in the encoded part
+        assert!(is_digest_reference(
+            "multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Kgd"
+        ));
+    }
+
+    #[test]
+    fn test_is_digest_reference_rejects_tag_name() {
+        assert!(!is_digest_reference("latest"));
+    }
+
+    #[test]
+    fn test_is_digest_reference_rejects_tag_with_dot() {
+        assert!(!is_digest_reference("v1.0.0"));
+    }
+
+    #[test]
+    fn test_cached_manifest_reference_key_uses_digest_for_remote_tags() {
+        assert_eq!(
+            cached_manifest_reference_key("remote", "latest", "sha256:abc"),
+            "sha256:abc"
+        );
+    }
+
+    #[test]
+    fn test_cached_manifest_reference_key_preserves_remote_digest_reference() {
+        assert_eq!(
+            cached_manifest_reference_key("remote", "sha256:def", "sha256:def"),
+            "sha256:def"
+        );
+    }
+
+    #[test]
+    fn test_cached_manifest_reference_key_preserves_local_tags() {
+        assert_eq!(
+            cached_manifest_reference_key("local", "latest", "sha256:abc"),
+            "latest"
+        );
+    }
+
+    #[test]
+    fn test_build_remote_tags_list_path_without_cursor() {
+        let path = build_remote_tags_list_path(100, None);
+        assert_eq!(path, "tags/list?n=101");
+    }
+
+    #[test]
+    fn test_build_remote_tags_list_path_forwards_cursor() {
+        let path = build_remote_tags_list_path(50, Some("release+candidate"));
+        assert_eq!(path, "tags/list?n=51&last=release%2Bcandidate");
+    }
+
+    #[test]
+    fn test_local_tags_query_without_cursor_filters_digests_and_limits_in_sql() {
+        let query = local_tags_query(false);
+        assert!(query.contains("POSITION(':' IN tag) = 0"));
+        assert!(query.contains("ORDER BY LOWER(tag), tag"));
+        assert!(query.contains("LIMIT $3"));
+    }
+
+    #[test]
+    fn test_local_tags_query_with_cursor_applies_cursor_in_sql() {
+        let query = local_tags_query(true);
+        assert!(query.contains("POSITION(':' IN tag) = 0"));
+        assert!(query.contains("(LOWER(tag), tag) > (LOWER($3), $3)"));
+        assert!(query.contains("ORDER BY LOWER(tag), tag"));
+        assert!(query.contains("LIMIT $4"));
+    }
+
+    #[test]
+    fn test_split_remote_tags_page_detects_next_page() {
+        let tags = vec!["a", "b", "c"].into_iter().map(String::from).collect();
+        let (page, has_more) = split_remote_tags_page(tags, 2, false);
+        assert_eq!(page, vec!["a", "b"]);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn test_split_remote_tags_page_without_extra_item() {
+        let tags = vec!["a", "b"].into_iter().map(String::from).collect();
+        let (page, has_more) = split_remote_tags_page(tags, 2, false);
+        assert_eq!(page, vec!["a", "b"]);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn test_split_remote_tags_page_preserves_upstream_continuation() {
+        let tags = vec!["a", "b"].into_iter().map(String::from).collect();
+        let (page, has_more) = split_remote_tags_page(tags, 2, true);
+        assert_eq!(page, vec!["a", "b"]);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn test_parse_upstream_pagination_last_from_relative_link() {
+        let next = parse_upstream_pagination_last(
+            "</v2/library/alpine/tags/list?n=2&last=v1.0%2Bbuild>; rel=\"next\"",
+        );
+        assert_eq!(next.as_deref(), Some("v1.0+build"));
+    }
+
+    #[test]
+    fn test_parse_upstream_pagination_last_from_absolute_link() {
+        let next = parse_upstream_pagination_last(
+            "<https://registry.example.test/v2/library/alpine/tags/list?n=2&last=rc-2>; rel=\"next\"",
+        );
+        assert_eq!(next.as_deref(), Some("rc-2"));
+    }
+
+    #[test]
+    fn test_parse_upstream_pagination_last_ignores_non_next_rel() {
+        let next = parse_upstream_pagination_last(
+            "</v2/library/alpine/tags/list?n=2&last=v1.0>; rel=\"prev\"",
+        );
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn test_finalize_remote_tags_page_preserves_upstream_error_without_cache() {
+        let upstream = Err(oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "upstream unavailable",
+        ));
+
+        let err = finalize_remote_tags_page(
+            upstream,
+            LocalTagsPage {
+                tags: vec![],
+                has_more: false,
+            },
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_finalize_remote_tags_page_falls_back_to_cached_tags() {
+        let upstream = Err(oci_error(
+            StatusCode::BAD_GATEWAY,
+            "UNKNOWN",
+            "upstream unavailable",
+        ));
+        let cached_page = LocalTagsPage {
+            tags: vec!["beta".to_string()],
+            has_more: true,
+        };
+
+        let (page, has_more) = finalize_remote_tags_page(upstream, cached_page, true).unwrap();
+        assert_eq!(page, vec!["beta"]);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn test_missing_upload_uuid_response_uses_not_found() {
+        let resp = missing_upload_uuid_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     // -----------------------------------------------------------------------
@@ -2344,5 +3425,234 @@ mod tests {
         let mut info = make_repo_info("docker-pub", "local", None, "myapp");
         info.is_public = true;
         assert!(info.is_public);
+    }
+
+    // -----------------------------------------------------------------------
+    // apply_cursor_pagination
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_apply_cursor_no_last_returns_first_n() {
+        let tags = vec!["a", "b", "c", "d", "e"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let (result, has_more) = apply_cursor_pagination(tags, None, 3);
+        assert_eq!(result, vec!["a", "b", "c"]);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn test_apply_cursor_with_last_skips_before() {
+        let tags = vec!["a", "b", "c", "d", "e"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let (result, has_more) = apply_cursor_pagination(tags, Some("b"), 2);
+        assert_eq!(result, vec!["c", "d"]);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn test_apply_cursor_last_item_returns_rest() {
+        let tags = vec!["a", "b", "c"].into_iter().map(String::from).collect();
+        let (result, has_more) = apply_cursor_pagination(tags, Some("a"), 10);
+        assert_eq!(result, vec!["b", "c"]);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn test_apply_cursor_n_zero_returns_empty() {
+        let tags = vec!["a", "b"].into_iter().map(String::from).collect();
+        let (result, has_more) = apply_cursor_pagination(tags, None, 0);
+        assert!(result.is_empty());
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn test_apply_cursor_last_not_found_returns_from_lexicographic_position() {
+        let tags = vec!["alpha", "beta", "gamma"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        // "az" is between "alpha" and "beta" lexicographically
+        let (result, _) = apply_cursor_pagination(tags, Some("az"), 10);
+        assert_eq!(result, vec!["beta", "gamma"]);
+    }
+
+    #[test]
+    fn test_merge_and_dedup_tags() {
+        let sets = vec![
+            vec!["b".to_string(), "a".to_string(), "c".to_string()],
+            vec!["c".to_string(), "d".to_string(), "a".to_string()],
+        ];
+        let merged = merge_and_dedup_tags(sets);
+        assert_eq!(merged, vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn test_merge_and_dedup_tags_lexical_order() {
+        let sets = vec![vec![
+            "Beta".to_string(),
+            "alpha".to_string(),
+            "GAMMA".to_string(),
+        ]];
+        let merged = merge_and_dedup_tags(sets);
+        assert_eq!(merged, vec!["alpha", "Beta", "GAMMA"]);
+    }
+
+    #[test]
+    fn test_merge_and_dedup_tags_empty() {
+        let sets: Vec<Vec<String>> = vec![vec![], vec![]];
+        let merged = merge_and_dedup_tags(sets);
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn test_merge_and_dedup_tags_exact_dedup() {
+        let sets = vec![
+            vec!["Latest".to_string(), "v1.0".to_string()],
+            vec!["latest".to_string(), "v1.0".to_string()],
+        ];
+        let merged = merge_and_dedup_tags(sets);
+        // Case-sensitive dedup: "Latest" and "latest" are distinct tags
+        assert_eq!(merged, vec!["Latest", "latest", "v1.0"]);
+    }
+
+    #[test]
+    fn test_apply_cursor_lexical_ordering() {
+        let tags = vec!["alpha", "Beta", "gamma"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let (result, _) = apply_cursor_pagination(tags, Some("Beta"), 10);
+        assert_eq!(result, vec!["gamma"]);
+    }
+
+    #[test]
+    fn test_oci_lexical_cmp_is_case_insensitive_with_stable_tiebreak() {
+        assert_eq!(oci_lexical_cmp("alpha", "Beta"), std::cmp::Ordering::Less);
+        assert_eq!(oci_lexical_cmp("Beta", "beta"), std::cmp::Ordering::Less);
+    }
+
+    // -----------------------------------------------------------------------
+    // TagsListResponse serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_tags_list_response_serialization() {
+        let resp = TagsListResponse {
+            name: "library/nginx".to_string(),
+            tags: vec!["1.25".to_string(), "latest".to_string()],
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["name"], "library/nginx");
+        assert_eq!(json["tags"], serde_json::json!(["1.25", "latest"]));
+    }
+
+    #[test]
+    fn test_tags_list_response_empty_tags() {
+        let resp = TagsListResponse {
+            name: "myimage".to_string(),
+            tags: vec![],
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["tags"], serde_json::json!([]));
+    }
+
+    // -----------------------------------------------------------------------
+    // CatalogResponse serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_catalog_response_serialization() {
+        let resp = CatalogResponse {
+            repositories: vec!["myrepo/alpine".to_string(), "myrepo/nginx".to_string()],
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            json["repositories"],
+            serde_json::json!(["myrepo/alpine", "myrepo/nginx"])
+        );
+    }
+
+    #[test]
+    fn test_catalog_response_empty() {
+        let resp = CatalogResponse {
+            repositories: vec![],
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["repositories"], serde_json::json!([]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Pagination Link header
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_pagination_link_header_relative_url() {
+        let link = build_pagination_link_header("/v2/myrepo/nginx/tags/list", "v2.0", 100);
+        assert_eq!(
+            link,
+            "</v2/myrepo/nginx/tags/list?n=100&last=v2.0>; rel=\"next\""
+        );
+    }
+
+    #[test]
+    fn test_build_pagination_link_header_url_encodes_last() {
+        let link = build_pagination_link_header("/v2/myrepo/nginx/tags/list", "v1.0+build", 50);
+        assert!(link.contains("last=v1.0%2Bbuild"));
+        assert!(link.contains("n=50"));
+        assert!(link.starts_with("</v2/"));
+    }
+
+    #[test]
+    fn test_parse_pagination_params_defaults() {
+        let params = std::collections::HashMap::new();
+        let (n, last) = parse_pagination_params(&params).unwrap();
+        assert_eq!(n, 100);
+        assert_eq!(last, None);
+    }
+
+    #[test]
+    fn test_parse_pagination_params_custom() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("n".to_string(), "50".to_string());
+        params.insert("last".to_string(), "v1.0".to_string());
+        let (n, last) = parse_pagination_params(&params).unwrap();
+        assert_eq!(n, 50);
+        assert_eq!(last, Some("v1.0".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pagination_params_n_zero() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("n".to_string(), "0".to_string());
+        let (n, _last) = parse_pagination_params(&params).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn test_parse_pagination_params_n_exceeds_max() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("n".to_string(), "99999".to_string());
+        let (n, _last) = parse_pagination_params(&params).unwrap();
+        assert_eq!(n, 10000);
+    }
+
+    #[test]
+    fn test_parse_pagination_params_invalid_n_returns_error() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("n".to_string(), "abc".to_string());
+        let err = parse_pagination_params(&params).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_parse_pagination_params_negative_n_returns_error() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("n".to_string(), "-1".to_string());
+        let err = parse_pagination_params(&params).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -332,6 +332,22 @@ pub async fn proxy_fetch_uncached(
         .map_err(|e| map_proxy_error(repo_key, path, e))
 }
 
+/// Fetch from upstream directly, preserving the upstream `Link` header.
+pub async fn proxy_fetch_uncached_with_link(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+) -> Result<(Bytes, Option<String>, Option<String>), Response> {
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
+
+    proxy_service
+        .fetch_upstream_direct_with_link(&repo, path)
+        .await
+        .map_err(|e| map_proxy_error(repo_key, path, e))
+}
+
 /// Resolve virtual repository members and attempt to find an artifact.
 /// Iterates through members by priority, trying local storage first,
 /// then proxy for remote members.

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -26,6 +26,15 @@ const DEFAULT_CACHE_TTL_SECS: i64 = 86400;
 /// HTTP client timeout in seconds
 const HTTP_TIMEOUT_SECS: u64 = 60;
 
+/// Response from an upstream registry fetch.
+struct UpstreamResponse {
+    content: Bytes,
+    content_type: Option<String>,
+    etag: Option<String>,
+    effective_url: String,
+    link: Option<String>,
+}
+
 /// Cache metadata for a proxied artifact
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheMetadata {
@@ -149,21 +158,21 @@ impl ProxyService {
         let upstream_result = self.fetch_from_upstream(&full_url, repo.id).await;
 
         match upstream_result {
-            Ok((content, content_type, etag, _effective_url)) => {
+            Ok(resp) => {
                 let cache_ttl = self.get_cache_ttl_for_repo(repo.id).await;
                 self.cache_artifact(
                     &cache_key,
                     &metadata_key,
-                    &content,
-                    content_type.clone(),
-                    etag,
+                    &resp.content,
+                    resp.content_type.clone(),
+                    resp.etag,
                     cache_ttl,
                     repo.id,
                     cache_path,
                 )
                 .await?;
 
-                Ok((content, content_type))
+                Ok((resp.content, resp.content_type))
             }
             Err(upstream_err) => {
                 if let Ok(Some((stale_content, stale_content_type))) = self
@@ -246,9 +255,33 @@ impl ProxyService {
         })?;
 
         let full_url = Self::build_upstream_url(upstream_url, path);
-        let (content, content_type, _etag, effective_url) =
-            self.fetch_from_upstream(&full_url, repo.id).await?;
-        Ok((content, content_type, effective_url))
+        let resp = self.fetch_from_upstream(&full_url, repo.id).await?;
+        Ok((resp.content, resp.content_type, resp.effective_url))
+    }
+
+    /// Fetch from upstream directly, preserving the upstream `Link` header.
+    ///
+    /// OCI tag pagination relies on the upstream continuation cursor when the
+    /// registry enforces its own page-size cap. Callers that need to reconstruct
+    /// pagination accurately should use this instead of [`fetch_upstream_direct`].
+    pub async fn fetch_upstream_direct_with_link(
+        &self,
+        repo: &Repository,
+        path: &str,
+    ) -> Result<(Bytes, Option<String>, Option<String>)> {
+        if repo.repo_type != RepositoryType::Remote {
+            return Err(AppError::Validation(
+                "Proxy operations only supported for remote repositories".to_string(),
+            ));
+        }
+
+        let upstream_url = repo.upstream_url.as_ref().ok_or_else(|| {
+            AppError::Config("Remote repository missing upstream_url".to_string())
+        })?;
+
+        let full_url = Self::build_upstream_url(upstream_url, path);
+        let resp = self.fetch_from_upstream(&full_url, repo.id).await?;
+        Ok((resp.content, resp.content_type, resp.link))
     }
 
     /// Invalidate cached artifact
@@ -379,11 +412,7 @@ impl ProxyService {
     /// a token from the indicated realm and retries the request. Tokens are
     /// cached in memory with their advertised TTL so subsequent requests to
     /// the same registry/scope don't repeat the exchange.
-    async fn fetch_from_upstream(
-        &self,
-        url: &str,
-        repo_id: Uuid,
-    ) -> Result<(Bytes, Option<String>, Option<String>, String)> {
+    async fn fetch_from_upstream(&self, url: &str, repo_id: Uuid) -> Result<UpstreamResponse> {
         tracing::info!("Fetching artifact from upstream: {}", url);
 
         let upstream_auth =
@@ -426,15 +455,11 @@ impl ProxyService {
                         .obtain_bearer_token(realm, &service, &scope, &upstream_auth)
                         .await?;
 
-                    // Retry with both the bearer token and any originally
-                    // configured upstream auth.
-                    let mut retry_request = self.http_client.get(url).bearer_auth(&token);
-                    if let Some(ref auth) = upstream_auth {
-                        retry_request = crate::services::upstream_auth::apply_upstream_auth(
-                            retry_request,
-                            auth,
-                        );
-                    }
+                    // Retry with the bearer token only. The original upstream
+                    // Basic credentials were already forwarded to the token
+                    // endpoint in obtain_bearer_token(); adding them here
+                    // would produce two Authorization headers.
+                    let retry_request = self.http_client.get(url).bearer_auth(&token);
 
                     let retry_response = retry_request.send().await.map_err(|e| {
                         AppError::Storage(format!(
@@ -456,12 +481,13 @@ impl ProxyService {
         Self::read_upstream_response(response, url).await
     }
 
-    /// Extract content, content-type, etag, and effective URL from an upstream
-    /// HTTP response. Callers are responsible for handling 401 before invoking.
+    /// Extract content, content-type, etag, effective URL, and Link header from
+    /// an upstream HTTP response. Callers are responsible for handling 401 before
+    /// invoking.
     async fn read_upstream_response(
         response: reqwest::Response,
         url: &str,
-    ) -> Result<(Bytes, Option<String>, Option<String>, String)> {
+    ) -> Result<UpstreamResponse> {
         let status = response.status();
         let effective_url = response.url().to_string();
 
@@ -491,19 +517,32 @@ impl ProxyService {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
+        let link = response
+            .headers()
+            .get("link")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
         let content = response
             .bytes()
             .await
             .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?;
 
         tracing::info!(
-            "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?})",
+            "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?}, link: {:?})",
             content.len(),
             content_type,
-            etag
+            etag,
+            link
         );
 
-        Ok((content, content_type, etag, effective_url))
+        Ok(UpstreamResponse {
+            content,
+            content_type,
+            etag,
+            effective_url,
+            link,
+        })
     }
 
     /// Obtain a bearer token for an OCI registry, using the in-memory cache

--- a/backend/tests/integration_tests.rs
+++ b/backend/tests/integration_tests.rs
@@ -122,6 +122,56 @@ impl TestServer {
         }
     }
 
+    async fn create_user(
+        &self,
+        username: &str,
+        email: &str,
+        password: &str,
+        is_admin: bool,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let client = Client::new();
+        let resp = client
+            .post(format!("{}/api/v1/users", self.base_url))
+            .header("Authorization", self.auth_header())
+            .json(&json!({
+                "username": username,
+                "email": email,
+                "password": password,
+                "display_name": username,
+                "is_admin": is_admin
+            }))
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            Ok(resp.json().await?)
+        } else {
+            let status = resp.status();
+            let text = resp.text().await?;
+            Err(format!("Failed to create user: {} - {}", status, text).into())
+        }
+    }
+
+    async fn get_oci_token(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let client = Client::new();
+        let token_resp: Value = client
+            .get(format!("{}/v2/token", self.base_url))
+            .basic_auth(username, Some(password))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        token_resp["token"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| "No OCI token in response".into())
+    }
+
     async fn upload_artifact(
         &self,
         repo_key: &str,
@@ -572,6 +622,256 @@ mod tests {
             .await
             .expect("Download failed");
         assert_eq!(downloaded, samples::docker_manifest());
+    }
+
+    // ============= Docker Tags/List and Catalog Tests =============
+
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_oci_tags_list_after_manifest_push() {
+        let server = get_server().await;
+        let repo_key = "docker-tags-test";
+
+        // Create repository
+        let _ = server
+            .create_repository(repo_key, "Docker Tags Test", "docker")
+            .await;
+
+        // Push a manifest with a tag (via the generic artifact API)
+        let manifest_path = "v2/myimage/manifests/v1.0";
+        let _ = server
+            .upload_artifact(
+                repo_key,
+                manifest_path,
+                samples::docker_manifest(),
+                "application/vnd.docker.distribution.manifest.v2+json",
+            )
+            .await;
+
+        // Query tags/list via OCI V2 API
+        let client = Client::new();
+        let token = server.get_oci_token("admin", "admin123").await.unwrap();
+
+        let resp = client
+            .get(format!(
+                "{}/v2/{}/myimage/tags/list",
+                server.base_url, repo_key
+            ))
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200, "Tags list should return 200");
+        let body: Value = resp.json().await.unwrap();
+        assert_eq!(body["name"], "myimage");
+        let tags = body["tags"].as_array().expect("tags should be an array");
+        assert!(
+            tags.iter().any(|t| t.as_str() == Some("v1.0")),
+            "Tags should contain v1.0, got: {:?}",
+            tags
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_oci_tags_list_pagination() {
+        let server = get_server().await;
+        let repo_key = "docker-tags-page-test";
+
+        let _ = server
+            .create_repository(repo_key, "Docker Tags Page Test", "docker")
+            .await;
+
+        // Push two manifests with different tags
+        for tag in &["alpha", "beta"] {
+            let path = format!("v2/paged/manifests/{}", tag);
+            let _ = server
+                .upload_artifact(
+                    repo_key,
+                    &path,
+                    samples::docker_manifest(),
+                    "application/vnd.docker.distribution.manifest.v2+json",
+                )
+                .await;
+        }
+
+        let client = Client::new();
+        let token = server.get_oci_token("admin", "admin123").await.unwrap();
+
+        // Request n=1 — should get one tag and a Link header
+        let resp = client
+            .get(format!(
+                "{}/v2/{}/paged/tags/list?n=1",
+                server.base_url, repo_key
+            ))
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let link = resp
+            .headers()
+            .get("link")
+            .map(|v| v.to_str().unwrap_or("").to_string());
+        let body: Value = resp.json().await.unwrap();
+        let tags = body["tags"].as_array().unwrap();
+        assert_eq!(tags.len(), 1, "Should return exactly 1 tag");
+        assert!(link.is_some(), "Should have Link header for next page");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_oci_tags_list_n_zero() {
+        let server = get_server().await;
+        let repo_key = "docker-tags-zero-test";
+
+        let _ = server
+            .create_repository(repo_key, "Docker Tags Zero Test", "docker")
+            .await;
+        let _ = server
+            .upload_artifact(
+                repo_key,
+                "v2/img/manifests/latest",
+                samples::docker_manifest(),
+                "application/vnd.docker.distribution.manifest.v2+json",
+            )
+            .await;
+
+        let client = Client::new();
+        let token = server.get_oci_token("admin", "admin123").await.unwrap();
+
+        let resp = client
+            .get(format!(
+                "{}/v2/{}/img/tags/list?n=0",
+                server.base_url, repo_key
+            ))
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let link = resp.headers().get("link");
+        assert!(link.is_none(), "n=0 should not have Link header");
+        let body: Value = resp.json().await.unwrap();
+        assert_eq!(
+            body["tags"],
+            serde_json::json!([]),
+            "n=0 should return empty tags"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_oci_catalog() {
+        let server = get_server().await;
+        let repo_key = "docker-catalog-test";
+
+        let _ = server
+            .create_repository(repo_key, "Docker Catalog Test", "docker")
+            .await;
+        let _ = server
+            .upload_artifact(
+                repo_key,
+                "v2/catalogimg/manifests/v1",
+                samples::docker_manifest(),
+                "application/vnd.docker.distribution.manifest.v2+json",
+            )
+            .await;
+
+        let client = Client::new();
+        let token = server.get_oci_token("admin", "admin123").await.unwrap();
+
+        let resp = client
+            .get(format!("{}/v2/_catalog", server.base_url))
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200, "Catalog should return 200");
+        let body: Value = resp.json().await.unwrap();
+        let repos = body["repositories"]
+            .as_array()
+            .expect("repositories should be an array");
+        assert!(
+            repos
+                .iter()
+                .any(|r| r.as_str().is_some_and(|s| s.contains("catalogimg"))),
+            "Catalog should contain catalogimg, got: {:?}",
+            repos
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_oci_catalog_includes_private_repos_for_authenticated_non_admin_user() {
+        let server = get_server().await;
+        let repo_key = "docker-private-catalog-test";
+        let username = "catalog-reader";
+        let password = "CatalogPass123!";
+
+        let _ = server
+            .create_private_repository(repo_key, "Docker Private Catalog Test", "docker")
+            .await;
+        let _ = server
+            .upload_artifact(
+                repo_key,
+                "v2/privateimg/manifests/v1",
+                samples::docker_manifest(),
+                "application/vnd.docker.distribution.manifest.v2+json",
+            )
+            .await;
+        let _ = server
+            .create_user(username, "catalog-reader@example.test", password, false)
+            .await;
+
+        let token = server
+            .get_oci_token(username, password)
+            .await
+            .expect("Failed to issue OCI token for non-admin user");
+
+        let client = Client::new();
+        let resp = client
+            .get(format!("{}/v2/_catalog", server.base_url))
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200, "Catalog should return 200");
+        let body: Value = resp.json().await.unwrap();
+        let repos = body["repositories"]
+            .as_array()
+            .expect("repositories should be an array");
+        assert!(
+            repos
+                .iter()
+                .any(|r| r.as_str().is_some_and(|s| s.contains("privateimg"))),
+            "Catalog should contain privateimg for authenticated non-admin users, got: {:?}",
+            repos
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_oci_tags_list_nonexistent_returns_404() {
+        let server = get_server().await;
+
+        let client = Client::new();
+        let token = server.get_oci_token("admin", "admin123").await.unwrap();
+
+        let resp = client
+            .get(format!(
+                "{}/v2/nonexistent-repo/someimage/tags/list",
+                server.base_url
+            ))
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            404,
+            "Tags list for unknown repo should return 404"
+        );
     }
 
     // ============= Helm Repository Tests =============

--- a/scripts/native-tests/test-docker.sh
+++ b/scripts/native-tests/test-docker.sh
@@ -5,10 +5,13 @@ set -euo pipefail
 
 REGISTRY_URL="${REGISTRY_URL:-localhost:30080}"
 REGISTRY_USER="${REGISTRY_USER:-admin}"
-REGISTRY_PASS="${REGISTRY_PASS:-admin123}"
+REGISTRY_PASS="${REGISTRY_PASS:-TestRunner!2026secure}"
 REPO_KEY="${REPO_KEY:-test-docker}"
 TEST_VERSION="1.0.$(date +%s)"
 FAILURES=0
+REGISTRY_SCHEME="${REGISTRY_SCHEME:-http}"
+REGISTRY_BASE_URL="${REGISTRY_SCHEME}://$REGISTRY_URL"
+HTTP_CODE_FORMAT="%{http_code}"
 
 pass() { echo "  PASS: $1"; }
 fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
@@ -22,7 +25,7 @@ echo ""
 # 1. Test V2 version check (unauthenticated should return 401)
 # --------------------------------------------------------------------------
 echo "--- Test: V2 version check (unauthenticated) ---"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://$REGISTRY_URL/v2/")
+HTTP_CODE=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" "$REGISTRY_BASE_URL/v2/")
 if [ "$HTTP_CODE" = "401" ]; then
     pass "GET /v2/ returns 401 without auth"
 else
@@ -30,7 +33,7 @@ else
 fi
 
 # Check WWW-Authenticate header
-WWW_AUTH=$(curl -s -D - -o /dev/null "http://$REGISTRY_URL/v2/" | grep -i "www-authenticate" || true)
+WWW_AUTH=$(curl -s -D - -o /dev/null "$REGISTRY_BASE_URL/v2/" | grep -i "www-authenticate" || true)
 if echo "$WWW_AUTH" | grep -q "Bearer"; then
     pass "WWW-Authenticate header contains Bearer challenge"
 else
@@ -42,7 +45,7 @@ fi
 # --------------------------------------------------------------------------
 echo ""
 echo "--- Test: Token endpoint ---"
-TOKEN_RESP=$(curl -s -u "$REGISTRY_USER:$REGISTRY_PASS" "http://$REGISTRY_URL/v2/token")
+TOKEN_RESP=$(curl -s -u "$REGISTRY_USER:$REGISTRY_PASS" "$REGISTRY_BASE_URL/v2/token")
 TOKEN=$(echo "$TOKEN_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
 if [ -n "$TOKEN" ] && [ "$TOKEN" != "None" ]; then
     pass "Token endpoint returns JWT"
@@ -51,7 +54,7 @@ else
 fi
 
 # Test invalid credentials
-BAD_CODE=$(curl -s -o /dev/null -w "%{http_code}" -u "baduser:badpass" "http://$REGISTRY_URL/v2/token")
+BAD_CODE=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" -u "baduser:badpass" "$REGISTRY_BASE_URL/v2/token")
 if [ "$BAD_CODE" = "401" ]; then
     pass "Token endpoint rejects invalid credentials"
 else
@@ -63,7 +66,7 @@ fi
 # --------------------------------------------------------------------------
 echo ""
 echo "--- Test: V2 version check (authenticated) ---"
-AUTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" "http://$REGISTRY_URL/v2/")
+AUTH_CODE=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" -H "Authorization: Bearer $TOKEN" "$REGISTRY_BASE_URL/v2/")
 if [ "$AUTH_CODE" = "200" ]; then
     pass "GET /v2/ returns 200 with valid token"
 else
@@ -114,11 +117,11 @@ fi
 # --------------------------------------------------------------------------
 echo ""
 echo "--- Test: Verify manifest via API ---"
-TOKEN=$(curl -s -u "$REGISTRY_USER:$REGISTRY_PASS" "http://$REGISTRY_URL/v2/token" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
-MANIFEST_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+TOKEN=$(curl -s -u "$REGISTRY_USER:$REGISTRY_PASS" "$REGISTRY_BASE_URL/v2/token" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+MANIFEST_CODE=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-    "http://$REGISTRY_URL/v2/$REPO_KEY/e2e-test/manifests/$TEST_VERSION")
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/e2e-test/manifests/$TEST_VERSION")
 if [ "$MANIFEST_CODE" = "200" ]; then
     pass "Manifest GET returns 200"
 else
@@ -126,10 +129,10 @@ else
 fi
 
 # HEAD request
-MANIFEST_HEAD=$(curl -s -o /dev/null -w "%{http_code}" -X HEAD \
+MANIFEST_HEAD=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" --head \
     -H "Authorization: Bearer $TOKEN" \
     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-    "http://$REGISTRY_URL/v2/$REPO_KEY/e2e-test/manifests/$TEST_VERSION")
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/e2e-test/manifests/$TEST_VERSION")
 if [ "$MANIFEST_HEAD" = "200" ]; then
     pass "Manifest HEAD returns 200"
 else
@@ -180,13 +183,129 @@ docker rmi "$ALPINE_IMAGE" 2>/dev/null || true
 # --------------------------------------------------------------------------
 echo ""
 echo "--- Test: Non-existent manifest returns 404 ---"
-NOT_FOUND=$(curl -s -o /dev/null -w "%{http_code}" \
+NOT_FOUND=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" \
     -H "Authorization: Bearer $TOKEN" \
-    "http://$REGISTRY_URL/v2/$REPO_KEY/nonexistent/manifests/notreal")
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/nonexistent/manifests/notreal")
 if [ "$NOT_FOUND" = "404" ]; then
     pass "Non-existent manifest returns 404"
 else
     fail "Non-existent manifest returned $NOT_FOUND, expected 404"
+fi
+
+# --------------------------------------------------------------------------
+# 11. Test tags/list endpoint
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test: Tags list ---"
+# Refresh token
+TOKEN=$(curl -s -u "$REGISTRY_USER:$REGISTRY_PASS" "$REGISTRY_BASE_URL/v2/token" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+TAGS_FULL=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $TOKEN" \
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/e2e-test/tags/list")
+TAGS_CODE=$(echo "$TAGS_FULL" | tail -1)
+TAGS_RESP=$(echo "$TAGS_FULL" | sed '$d')
+if [[ "$TAGS_CODE" = "200" ]]; then
+    pass "Tags list returns 200"
+else
+    fail "Tags list returned $TAGS_CODE, expected 200"
+fi
+
+# Verify response contains the pushed tag
+if echo "$TAGS_RESP" | python3 -c "import sys,json; tags=json.load(sys.stdin)['tags']; assert '$TEST_VERSION' in tags" 2>/dev/null; then
+    pass "Tags list contains pushed tag $TEST_VERSION"
+else
+    fail "Tags list does not contain expected tag: $TAGS_RESP"
+fi
+
+# Verify response has correct name field
+if echo "$TAGS_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['name']=='e2e-test'" 2>/dev/null; then
+    pass "Tags list has correct name field"
+else
+    fail "Tags list name field incorrect: $TAGS_RESP"
+fi
+
+# Test pagination with n=1
+TAGS_PAGE=$(curl -s -D /tmp/tags_headers -H "Authorization: Bearer $TOKEN" \
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/e2e-test/tags/list?n=1")
+if ! PAGE_TAGS=$(echo "$TAGS_PAGE" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['tags']))" 2>/dev/null); then
+    echo "error" >&2
+    PAGE_TAGS="error"
+fi
+if [[ "$PAGE_TAGS" = "1" ]]; then
+    pass "Tags list pagination returns exactly 1 tag with n=1"
+else
+    fail "Tags list pagination returned $PAGE_TAGS tags, expected 1"
+fi
+
+# Test n=0 returns empty
+TAGS_ZERO=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/e2e-test/tags/list?n=0")
+if ! ZERO_COUNT=$(echo "$TAGS_ZERO" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['tags']))" 2>/dev/null); then
+    echo "error" >&2
+    ZERO_COUNT="error"
+fi
+if [[ "$ZERO_COUNT" = "0" ]]; then
+    pass "Tags list with n=0 returns empty list"
+else
+    fail "Tags list with n=0 returned $ZERO_COUNT tags, expected 0"
+fi
+
+# Test non-existent image returns 404
+TAGS_404=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" -H "Authorization: Bearer $TOKEN" \
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/nonexistent/tags/list")
+if [[ "$TAGS_404" = "404" ]]; then
+    pass "Tags list for non-existent image returns 404"
+else
+    fail "Tags list for non-existent image returned $TAGS_404, expected 404"
+fi
+
+# Test unauthenticated access returns 401
+TAGS_NOAUTH=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" \
+    "$REGISTRY_BASE_URL/v2/$REPO_KEY/e2e-test/tags/list")
+if [[ "$TAGS_NOAUTH" = "401" ]]; then
+    pass "Tags list without auth returns 401"
+else
+    fail "Tags list without auth returned $TAGS_NOAUTH, expected 401"
+fi
+
+# --------------------------------------------------------------------------
+# 12. Test catalog endpoint
+# --------------------------------------------------------------------------
+echo ""
+echo "--- Test: Catalog ---"
+CATALOG_FULL=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $TOKEN" \
+    "$REGISTRY_BASE_URL/v2/_catalog")
+CATALOG_CODE=$(echo "$CATALOG_FULL" | tail -1)
+CATALOG_RESP=$(echo "$CATALOG_FULL" | sed '$d')
+if [[ "$CATALOG_CODE" = "200" ]]; then
+    pass "Catalog returns 200"
+else
+    fail "Catalog returned $CATALOG_CODE, expected 200"
+fi
+
+# Verify response contains the pushed image
+if echo "$CATALOG_RESP" | python3 -c "import sys,json; repos=json.load(sys.stdin)['repositories']; assert any('e2e-test' in r for r in repos)" 2>/dev/null; then
+    pass "Catalog contains e2e-test image"
+else
+    fail "Catalog does not contain e2e-test: $CATALOG_RESP"
+fi
+
+# Test catalog pagination with n=1
+CATALOG_PAGE_CODE=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" -H "Authorization: Bearer $TOKEN" \
+    "$REGISTRY_BASE_URL/v2/_catalog?n=1")
+if [[ "$CATALOG_PAGE_CODE" = "200" ]]; then
+    pass "Catalog pagination returns 200"
+else
+    fail "Catalog pagination returned $CATALOG_PAGE_CODE, expected 200"
+fi
+
+# Test catalog unauthenticated returns 401
+CATALOG_NOAUTH=$(curl -s -o /dev/null -w "$HTTP_CODE_FORMAT" \
+    "$REGISTRY_BASE_URL/v2/_catalog")
+if [[ "$CATALOG_NOAUTH" = "401" ]]; then
+    pass "Catalog without auth returns 401"
+else
+    fail "Catalog without auth returned $CATALOG_NOAUTH, expected 401"
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements two registry listing endpoints:

- **`GET /v2/<name>/tags/list`** per [OCI Distribution Spec v1.1.1](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-tags) — returns tags for an image in lexical order with cursor-based pagination (`n`, `last` query params, `Link` header per RFC 5988).

- **`GET /v2/_catalog`** per [Docker Registry HTTP API V2](https://github.com/distribution/distribution/blob/v3.0.0/docs/content/spec/api.md#catalog) — returns all repository names known to the registry with the same pagination model.

Both endpoints support all three repository types:

| Type | tags/list | _catalog |
|------|-----------|----------|
| **Local** | SQL query with cursor pagination, digest references excluded | Included |
| **Remote** | Proxied from upstream with local cache fallback on failure | Not included (spec: local scope only) |
| **Virtual** | Aggregated from all members in parallel, merged and deduplicated | Members' local entries included |

Additional changes in this PR:

- **Manifest caching for remote repos**: proxied manifests are now stored locally with their tag→digest mapping, so `tags/list` can return accurate results even when upstream is unreachable.
- **`is_digest_reference()`**: replaces hardcoded `starts_with("sha256:")` with full OCI digest grammar validation (`algorithm:encoded`).
- **Link header uses relative URLs**: reliable behind reverse proxies, consistent with Docker Hub behavior.
- **E2E test fix**: `curl -X HEAD` replaced with `curl --head` to prevent hanging on `Content-Length` without body.

### Spec compliance notes

- `n=0` returns empty list with no `Link` header (OCI spec §listing-tags)
- `last` cursor is non-inclusive, lexical ordering is case-insensitive primary / case-sensitive secondary
- 404 `NAME_UNKNOWN` for repositories with no pushed tags (OCI spec)
- 400 `PAGINATION_NUMBER_INVALID` for non-integer `n`
- Catalog SQL pagination uses `LIMIT n+1` pattern with consistent `LOWER()` ordering matching OCI lexical sort
- Catalog scope is local-only per Docker spec — upstream-only images are not advertised

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

7270 unit tests pass (30+ new for pagination, cursor logic, merge/dedup, Link header parsing, digest detection). 6 integration tests added. E2E `test-docker.sh` extended with 11 new checks for tags/list and catalog. Verified with `skopeo list-tags` against local, remote, and virtual repos. Clippy and fmt clean.

## API Changes
- [x] N/A - no API changes (OCI V2 endpoints are on the `/v2` router, outside the OpenAPI-annotated REST API)