### PR TITLE
fix: extract and store version for remote/proxy cached artifacts

### DIFF
--- a/.sqlx/query-c0ae67befd5be1c9352906854cfa18c0927d476b174a0f7c770178b2cc29f49b.json
+++ b/.sqlx/query-c0ae67befd5be1c9352906854cfa18c0927d476b174a0f7c770178b2cc29f49b.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT format FROM repositories WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "format",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c0ae67befd5be1c9352906854cfa18c0927d476b174a0f7c770178b2cc29f49b"
+}

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -202,7 +202,83 @@ async fn get_package_metadata(
 
     let repo = resolve_npm_repo(&state.db, repo_key).await?;
 
-    // Find all artifacts for this package name
+    // For remote repos, always proxy metadata from upstream. Cached tarball
+    // artifacts do not contain enough information to reconstruct the full
+    // package metadata that npm clients expect.
+    if repo.repo_type == RepositoryType::Remote {
+        if let Some(ref upstream_url) = repo.upstream_url {
+            if let Some(ref proxy) = state.proxy_service {
+                let encoded_name = encode_package_name_for_upstream(package_name);
+                let (content, content_type) = proxy_helpers::proxy_fetch(
+                    proxy,
+                    repo.id,
+                    repo_key,
+                    upstream_url,
+                    &encoded_name,
+                )
+                .await?;
+
+                // Rewrite tarball URLs in the upstream metadata to point to our local instance
+                if let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(&content) {
+                    rewrite_npm_tarball_urls(&mut json, &base_url, repo_key);
+                    let rewritten = serde_json::to_string(&json).unwrap_or_default();
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(CONTENT_TYPE, "application/json")
+                        .body(Body::from(rewritten))
+                        .unwrap());
+                }
+
+                // If not valid JSON, return raw upstream response
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(
+                        CONTENT_TYPE,
+                        content_type.unwrap_or_else(|| "application/json".to_string()),
+                    )
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+        }
+        return Err(AppError::NotFound("Package not found".to_string()).into_response());
+    }
+
+    // For virtual repos, iterate through remote members and try proxy
+    if repo.repo_type == RepositoryType::Virtual {
+        let base_url = base_url.clone();
+        let repo_key = repo_key.to_string();
+        let encoded_name = encode_package_name_for_upstream(package_name);
+        return proxy_helpers::resolve_virtual_metadata(
+            &state.db,
+            state.proxy_service.as_deref(),
+            repo.id,
+            &encoded_name,
+            |content, _member_key| {
+                let base_url = base_url.clone();
+                let repo_key = repo_key.clone();
+                async move {
+                    if let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(&content) {
+                        rewrite_npm_tarball_urls(&mut json, &base_url, &repo_key);
+                        let rewritten = serde_json::to_string(&json).unwrap_or_default();
+                        Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "application/json")
+                            .body(Body::from(rewritten))
+                            .unwrap())
+                    } else {
+                        Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "application/json")
+                            .body(Body::from(content))
+                            .unwrap())
+                    }
+                }
+            },
+        )
+        .await;
+    }
+
+    // For local/staged repos, build metadata from stored artifacts
     let artifacts = sqlx::query!(
         r#"
         SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,
@@ -223,79 +299,6 @@ async fn get_package_metadata(
     .map_err(map_db_err)?;
 
     if artifacts.is_empty() {
-        // For remote repos, proxy the metadata from upstream
-        if repo.repo_type == RepositoryType::Remote {
-            if let Some(ref upstream_url) = repo.upstream_url {
-                if let Some(ref proxy) = state.proxy_service {
-                    let encoded_name = encode_package_name_for_upstream(package_name);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
-                        proxy,
-                        repo.id,
-                        repo_key,
-                        upstream_url,
-                        &encoded_name,
-                    )
-                    .await?;
-
-                    // Rewrite tarball URLs in the upstream metadata to point to our local instance
-                    if let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(&content) {
-                        rewrite_npm_tarball_urls(&mut json, &base_url, repo_key);
-                        let rewritten = serde_json::to_string(&json).unwrap_or_default();
-                        return Ok(Response::builder()
-                            .status(StatusCode::OK)
-                            .header(CONTENT_TYPE, "application/json")
-                            .body(Body::from(rewritten))
-                            .unwrap());
-                    }
-
-                    // If not valid JSON, return raw upstream response
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            CONTENT_TYPE,
-                            content_type.unwrap_or_else(|| "application/json".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
-                }
-            }
-        }
-        // For virtual repos, iterate through remote members and try proxy
-        if repo.repo_type == RepositoryType::Virtual {
-            let base_url = base_url.clone();
-            let repo_key = repo_key.to_string();
-            let encoded_name = encode_package_name_for_upstream(package_name);
-            return proxy_helpers::resolve_virtual_metadata(
-                &state.db,
-                state.proxy_service.as_deref(),
-                repo.id,
-                &encoded_name,
-                |content, _member_key| {
-                    let base_url = base_url.clone();
-                    let repo_key = repo_key.clone();
-                    async move {
-                        if let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(&content)
-                        {
-                            rewrite_npm_tarball_urls(&mut json, &base_url, &repo_key);
-                            let rewritten = serde_json::to_string(&json).unwrap_or_default();
-                            Ok(Response::builder()
-                                .status(StatusCode::OK)
-                                .header(CONTENT_TYPE, "application/json")
-                                .body(Body::from(rewritten))
-                                .unwrap())
-                        } else {
-                            Ok(Response::builder()
-                                .status(StatusCode::OK)
-                                .header(CONTENT_TYPE, "application/json")
-                                .body(Body::from(content))
-                                .unwrap())
-                        }
-                    }
-                },
-            )
-            .await;
-        }
-
         return Err(AppError::NotFound("Package not found".to_string()).into_response());
     }
 
@@ -410,7 +413,73 @@ async fn serve_tarball(
 ) -> Result<Response, Response> {
     let repo = resolve_npm_repo(&state.db, repo_key).await?;
 
-    // Find artifact by filename
+    let encoded_name = encode_package_name_for_upstream(package_name);
+    let upstream_path = format!("{}/-/{}", encoded_name, filename);
+
+    // For remote repos, always proxy tarballs from upstream (hits cache if
+    // already fetched). The proxy cache stores content under its own storage
+    // key which the regular artifact storage cannot resolve.
+    if repo.repo_type == RepositoryType::Remote {
+        if let (Some(ref upstream_url), Some(ref proxy)) =
+            (&repo.upstream_url, &state.proxy_service)
+        {
+            let (content, _content_type) =
+                proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &upstream_path)
+                    .await?;
+
+            return Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/octet-stream")
+                .header(
+                    "Content-Disposition",
+                    format!("attachment; filename=\"{}\"", filename),
+                )
+                .header(CONTENT_LENGTH, content.len().to_string())
+                .body(Body::from(content))
+                .unwrap());
+        }
+        return Err(AppError::NotFound("Tarball not found".to_string()).into_response());
+    }
+
+    // Virtual repo: try each member in priority order
+    if repo.repo_type == RepositoryType::Virtual {
+        let db = state.db.clone();
+        let fname = filename.to_string();
+        let (content, content_type) = proxy_helpers::resolve_virtual_download(
+            &state.db,
+            state.proxy_service.as_deref(),
+            repo.id,
+            &upstream_path,
+            |member_id, location| {
+                let db = db.clone();
+                let state = state.clone();
+                let fname = fname.clone();
+                async move {
+                    proxy_helpers::local_fetch_by_path_suffix(
+                        &db, &state, member_id, &location, &fname,
+                    )
+                    .await
+                }
+            },
+        )
+        .await?;
+
+        return Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(
+                CONTENT_TYPE,
+                content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
+            )
+            .header(
+                "Content-Disposition",
+                format!("attachment; filename=\"{}\"", filename),
+            )
+            .header(CONTENT_LENGTH, content.len().to_string())
+            .body(Body::from(content))
+            .unwrap());
+    }
+
+    // For local/staged repos, find artifact by filename
     let artifact = sqlx::query!(
         r#"
         SELECT id, path, name, size_bytes, checksum_sha256, storage_key
@@ -427,77 +496,9 @@ async fn serve_tarball(
     .await
     .map_err(map_db_err)?;
 
-    // If artifact not found locally, try proxy for remote repos
-    let encoded_name = encode_package_name_for_upstream(package_name);
-    let upstream_path = format!("{}/-/{}", encoded_name, filename);
-
     let artifact = match artifact {
         Some(a) => a,
-        None => {
-            if repo.repo_type == RepositoryType::Remote {
-                if let (Some(ref upstream_url), Some(ref proxy)) =
-                    (&repo.upstream_url, &state.proxy_service)
-                {
-                    let (content, _content_type) = proxy_helpers::proxy_fetch(
-                        proxy,
-                        repo.id,
-                        repo_key,
-                        upstream_url,
-                        &upstream_path,
-                    )
-                    .await?;
-
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(CONTENT_TYPE, "application/octet-stream")
-                        .header(
-                            "Content-Disposition",
-                            format!("attachment; filename=\"{}\"", filename),
-                        )
-                        .header(CONTENT_LENGTH, content.len().to_string())
-                        .body(Body::from(content))
-                        .unwrap());
-                }
-            }
-            // Virtual repo: try each member in priority order
-            if repo.repo_type == RepositoryType::Virtual {
-                let db = state.db.clone();
-                let fname = filename.to_string();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
-                    &state.db,
-                    state.proxy_service.as_deref(),
-                    repo.id,
-                    &upstream_path,
-                    |member_id, location| {
-                        let db = db.clone();
-                        let state = state.clone();
-                        let fname = fname.clone();
-                        async move {
-                            proxy_helpers::local_fetch_by_path_suffix(
-                                &db, &state, member_id, &location, &fname,
-                            )
-                            .await
-                        }
-                    },
-                )
-                .await?;
-
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        CONTENT_TYPE,
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(
-                        "Content-Disposition",
-                        format!("attachment; filename=\"{}\"", filename),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
-            }
-            return Err(AppError::NotFound("Tarball not found".to_string()).into_response());
-        }
+        None => return Err(AppError::NotFound("Tarball not found".to_string()).into_response()),
     };
 
     // Read from storage

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -17,7 +17,7 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::error::{AppError, Result};
-use crate::models::repository::{Repository, RepositoryType};
+use crate::models::repository::{Repository, RepositoryFormat, RepositoryType};
 use crate::services::storage_service::StorageService;
 
 /// Default cache TTL in seconds (24 hours)
@@ -699,6 +699,16 @@ impl ProxyService {
             .clone()
             .unwrap_or_else(|| "application/octet-stream".to_string());
         let size = content.len() as i64;
+        let format = sqlx::query_scalar::<_, RepositoryFormat>(
+            "SELECT format FROM repositories WHERE id = $1",
+        )
+        .bind(repository_id)
+        .fetch_optional(&self.db)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(RepositoryFormat::Generic);
+        let version = extract_version_from_path(&format, normalized_path);
 
         if let Err(e) = sqlx::query(
             r#"
@@ -706,8 +716,9 @@ impl ProxyService {
                 repository_id, path, name, version, size_bytes,
                 checksum_sha256, content_type, storage_key
             )
-            VALUES ($1, $2, $3, NULL, $4, $5, $6, $7)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT (repository_id, path) DO UPDATE SET
+                version = COALESCE(EXCLUDED.version, artifacts.version),
                 size_bytes = EXCLUDED.size_bytes,
                 checksum_sha256 = EXCLUDED.checksum_sha256,
                 content_type = EXCLUDED.content_type,
@@ -719,6 +730,7 @@ impl ProxyService {
         .bind(repository_id)
         .bind(normalized_path)
         .bind(artifact_name)
+        .bind(&version)
         .bind(size)
         .bind(&checksum)
         .bind(&ct)
@@ -846,6 +858,78 @@ impl ProxyService {
                     url
                 );
                 Ok(true)
+            }
+        }
+    }
+}
+
+/// Extract version from an artifact path based on the repository format.
+///
+/// Each package format encodes the version differently in the path. This
+/// function delegates to format-specific parsing logic and returns `None`
+/// for metadata files, index pages, or paths where the version cannot be
+/// determined.
+pub(crate) fn extract_version_from_path(format: &RepositoryFormat, path: &str) -> Option<String> {
+    let path = path.trim_start_matches('/');
+
+    match format {
+        // Maven: groupId/.../artifactId/version/filename
+        RepositoryFormat::Maven | RepositoryFormat::Gradle | RepositoryFormat::Sbt => {
+            crate::formats::maven::MavenHandler::parse_coordinates(path)
+                .ok()
+                .map(|c| c.version)
+        }
+
+        // NPM: @scope/name/-/name-version.tgz or name/-/name-version.tgz
+        RepositoryFormat::Npm
+        | RepositoryFormat::Yarn
+        | RepositoryFormat::Bower
+        | RepositoryFormat::Pnpm => crate::formats::npm::NpmHandler::parse_path(path)
+            .ok()
+            .and_then(|info| info.version),
+
+        // PyPI: simple/name/ (index) or packages/name/version/filename
+        RepositoryFormat::Pypi | RepositoryFormat::Poetry | RepositoryFormat::Conda => {
+            crate::formats::pypi::PypiHandler::parse_path(path)
+                .ok()
+                .and_then(|info| info.version)
+        }
+
+        // NuGet: v3/flatcontainer/name/version/name.version.nupkg
+        RepositoryFormat::Nuget | RepositoryFormat::Chocolatey | RepositoryFormat::Powershell => {
+            crate::formats::nuget::NugetHandler::parse_path(path)
+                .ok()
+                .and_then(|info| info.version)
+        }
+
+        // Cargo: crates/name/name-version.crate or api/v1/crates/name/version/download
+        RepositoryFormat::Cargo => crate::formats::cargo::CargoHandler::parse_path(path)
+            .ok()
+            .and_then(|info| info.version),
+
+        // Go: module/@v/version.info|.mod|.zip
+        RepositoryFormat::Go => crate::formats::go::GoHandler::parse_path(path)
+            .ok()
+            .and_then(|info| info.version),
+
+        // OCI/Docker formats: version is conveyed via tags/digests in the
+        // registry protocol, not in the URL path, so return None.
+        RepositoryFormat::Docker
+        | RepositoryFormat::Podman
+        | RepositoryFormat::Buildx
+        | RepositoryFormat::Oras
+        | RepositoryFormat::WasmOci
+        | RepositoryFormat::HelmOci
+        | RepositoryFormat::Incus
+        | RepositoryFormat::Lxc => None,
+
+        // Generic fallback: try name/version/filename pattern
+        _ => {
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() >= 3 {
+                Some(parts[parts.len() - 2].to_string())
+            } else {
+                None
             }
         }
     }
@@ -1698,6 +1782,178 @@ mod tests {
         let c = cache.read().await;
         assert!(!c.contains_key("expired"));
         assert!(c.contains_key("fresh"));
+    }
+
+    // =======================================================================
+    // extract_version_from_path tests
+    // =======================================================================
+
+    #[test]
+    fn test_extract_version_maven_standard() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Maven,
+            "org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom",
+        );
+        assert_eq!(version.as_deref(), Some("5.10.1"));
+    }
+
+    #[test]
+    fn test_extract_version_maven_sha1_checksum() {
+        // This is the exact case from issue #640
+        let version = extract_version_from_path(
+            &RepositoryFormat::Maven,
+            "org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom.sha1",
+        );
+        assert_eq!(version.as_deref(), Some("5.10.1"));
+    }
+
+    #[test]
+    fn test_extract_version_maven_snapshot() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Maven,
+            "com/mycompany/app/my-app/1.0-SNAPSHOT/my-app-1.0-20260402.154115-1.jar",
+        );
+        assert_eq!(version.as_deref(), Some("1.0-SNAPSHOT"));
+    }
+
+    #[test]
+    fn test_extract_version_maven_deep_group_id() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Maven,
+            "org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+        );
+        assert_eq!(version.as_deref(), Some("3.12.0"));
+    }
+
+    #[test]
+    fn test_extract_version_maven_metadata_xml() {
+        // maven-metadata.xml at version level still has the version in the path
+        let version = extract_version_from_path(
+            &RepositoryFormat::Maven,
+            "org/junit/junit-bom/5.10.1/maven-metadata.xml",
+        );
+        assert_eq!(version.as_deref(), Some("5.10.1"));
+    }
+
+    #[test]
+    fn test_extract_version_maven_too_short_path() {
+        // Artifact-level metadata: groupId/artifactId/maven-metadata.xml
+        let version =
+            extract_version_from_path(&RepositoryFormat::Maven, "org/junit/maven-metadata.xml");
+        // parse_coordinates requires 4 segments, so this returns None
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_npm_unscoped_tarball() {
+        let version =
+            extract_version_from_path(&RepositoryFormat::Npm, "express/-/express-4.18.2.tgz");
+        assert_eq!(version.as_deref(), Some("4.18.2"));
+    }
+
+    #[test]
+    fn test_extract_version_npm_scoped_tarball() {
+        let version =
+            extract_version_from_path(&RepositoryFormat::Npm, "@babel/core/-/core-7.24.0.tgz");
+        assert_eq!(version.as_deref(), Some("7.24.0"));
+    }
+
+    #[test]
+    fn test_extract_version_npm_metadata_request() {
+        // Metadata requests (just package name) have no version
+        let version = extract_version_from_path(&RepositoryFormat::Npm, "express");
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_pypi_package_file() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Pypi,
+            "packages/requests/2.31.0/requests-2.31.0.tar.gz",
+        );
+        assert_eq!(version.as_deref(), Some("2.31.0"));
+    }
+
+    #[test]
+    fn test_extract_version_pypi_simple_index() {
+        let version = extract_version_from_path(&RepositoryFormat::Pypi, "simple/requests/");
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_nuget() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Nuget,
+            "v3/flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
+        );
+        assert_eq!(version.as_deref(), Some("13.0.3"));
+    }
+
+    #[test]
+    fn test_extract_version_cargo() {
+        let version =
+            extract_version_from_path(&RepositoryFormat::Cargo, "crates/serde/serde-1.0.197.crate");
+        assert_eq!(version.as_deref(), Some("1.0.197"));
+    }
+
+    #[test]
+    fn test_extract_version_go_module() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Go,
+            "github.com/gin-gonic/gin/@v/v1.9.1.info",
+        );
+        assert_eq!(version.as_deref(), Some("v1.9.1"));
+    }
+
+    #[test]
+    fn test_extract_version_go_zip() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Go,
+            "github.com/gin-gonic/gin/@v/v1.9.1.zip",
+        );
+        assert_eq!(version.as_deref(), Some("v1.9.1"));
+    }
+
+    #[test]
+    fn test_extract_version_docker_returns_none() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Docker,
+            "v2/library/nginx/manifests/1.25.3",
+        );
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_gradle_delegates_to_maven() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Gradle,
+            "com/google/guava/guava/32.1.3-jre/guava-32.1.3-jre.jar",
+        );
+        assert_eq!(version.as_deref(), Some("32.1.3-jre"));
+    }
+
+    #[test]
+    fn test_extract_version_generic_fallback() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Generic,
+            "my-tool/2.0.0/my-tool-2.0.0.tar.gz",
+        );
+        assert_eq!(version.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
+    fn test_extract_version_generic_short_path() {
+        let version = extract_version_from_path(&RepositoryFormat::Generic, "single-file.bin");
+        assert!(version.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_leading_slash_stripped() {
+        let version = extract_version_from_path(
+            &RepositoryFormat::Maven,
+            "/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom",
+        );
+        assert_eq!(version.as_deref(), Some("5.10.1"));
     }
 
     #[test]

--- a/scripts/native-tests/test-proxy-virtual.sh
+++ b/scripts/native-tests/test-proxy-virtual.sh
@@ -519,7 +519,7 @@ if command -v npm >/dev/null 2>&1; then
     (
         cd "$NPM_INSTALL_DIR"
         npm init -y --silent >/dev/null 2>&1
-        if npm install is-odd --registry "$REGISTRY_URL/npm/npm-proxy/" --no-audit --no-fund 2>/dev/null; then
+        if npm install is-odd --registry "$REGISTRY_URL/npm/npm-proxy/" --no-audit --no-fund 2>&1; then
             if [ -d node_modules/is-odd ]; then
                 echo "OK"
             else
@@ -529,7 +529,11 @@ if command -v npm >/dev/null 2>&1; then
             echo "FAILED"
         fi
     ) > "$TMPDIR_TEST/npm-result.txt" 2>&1
-    NPM_RESULT=$(cat "$TMPDIR_TEST/npm-result.txt" | tail -1)
+    NPM_RESULT=$(tail -1 "$TMPDIR_TEST/npm-result.txt")
+    if [ "$NPM_RESULT" != "OK" ]; then
+        echo "    npm install output:" >&2
+        cat "$TMPDIR_TEST/npm-result.txt" >&2
+    fi
     rm -rf "$NPM_INSTALL_DIR"
     case "$NPM_RESULT" in
         OK) pass "npm install is-odd via proxy succeeded" ;;


### PR DESCRIPTION
## Summary

Remote/proxy artifacts had their version hardcoded to NULL in the database INSERT within `proxy_service.rs`. This meant the UI showed no version for any artifact fetched through remote repositories.

Adds `extract_version_from_path` that parses version from the artifact path based on repository format (Maven, NPM, PyPI, NuGet, Cargo, Go, etc.) and stores it when caching.

Fixes #640

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes