### PR TITLE
docs: document release/1.1.x maintenance branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,25 +152,26 @@ Branch naming conventions:
 Long-lived `release/X.Y.x` branches exist for shipping bug fixes to older release series:
 
 - **`release/1.0.x`** — maintenance branch for the 1.0 series (created from `v1.0.0-rc.5`)
-- **`main`** — continues with 1.1.x (and beyond) development
+- **`release/1.1.x`** — maintenance branch for the 1.1 series (created from `v1.1.2`)
+- **`main`** — continues with 1.2.x (and beyond) development
 
 **Bug fix workflow for maintenance branches:**
 1. Create a fix branch from the maintenance branch:
    ```bash
-   git checkout release/1.0.x && git pull
+   git checkout release/1.1.x && git pull
    git checkout -b fix/short-description
    ```
-2. Push and create a PR **targeting `release/1.0.x`** (not main):
+2. Push and create a PR **targeting `release/1.1.x`** (not main):
    ```bash
    git push -u origin fix/short-description
-   gh pr create --base release/1.0.x --fill
+   gh pr create --base release/1.1.x --fill
    ```
 3. Tag releases from the maintenance branch:
    ```bash
-   git checkout release/1.0.x && git pull
-   git tag v1.0.1 && git push origin v1.0.1
+   git checkout release/1.1.x && git pull
+   git tag v1.1.3 && git push origin v1.1.3
    ```
-4. Cherry-pick to the maintenance branch when a fix on `main` also applies to 1.0.x.
+4. Cherry-pick fixes between maintenance and `main` so both lines stay in sync. Bug fixes typically land on the maintenance branch first, then cherry-pick forward to main.
 
 **Docker image tags** (set by `docker/metadata-action` in `docker-publish.yml`):
 - Version tags **strip the `v` prefix**: git tag `v1.1.0-rc.2` → Docker tag `:1.1.0-rc.2`


### PR DESCRIPTION
## Summary

Documents the new \`release/1.1.x\` maintenance branch (created from \`v1.1.2\`) and updates the bug fix workflow examples to reference it. main now continues forward with 1.2.x development.

This is a docs-only change to keep CLAUDE.md in sync with the actual branch state.

## Test Checklist
- [x] N/A - docs only

## API Changes
- [x] N/A - no API changes