### PR TITLE
feat: configurable PostgreSQL connection pool via env vars (#678)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,24 @@
 # -----------------------------------------------------------------------------
 DATABASE_URL=postgres://registry:registry@localhost:5432/artifact_registry
 
+# Connection pool tuning. Defaults are suitable for most deployments. Adjust
+# when running against a database with a restricted connection budget
+# (shared RDS, PgBouncer), or when scaling horizontally.
+#
+# DATABASE_MAX_CONNECTIONS: maximum open connections in the pool. Default 20.
+# DATABASE_MIN_CONNECTIONS: minimum idle connections kept warm. Default 5.
+# DATABASE_ACQUIRE_TIMEOUT_SECS: timeout waiting for a connection. Default 30.
+# DATABASE_IDLE_TIMEOUT_SECS: close connections idle longer than this.
+#                             Default 600 (10 minutes).
+# DATABASE_MAX_LIFETIME_SECS: recycle connections older than this, even if
+#                             healthy. Useful when behind TCP load balancers
+#                             with an idle disconnect. Default 1800 (30 min).
+# DATABASE_MAX_CONNECTIONS=20
+# DATABASE_MIN_CONNECTIONS=5
+# DATABASE_ACQUIRE_TIMEOUT_SECS=30
+# DATABASE_IDLE_TIMEOUT_SECS=600
+# DATABASE_MAX_LIFETIME_SECS=1800
+
 # -----------------------------------------------------------------------------
 # Server (backend)
 # -----------------------------------------------------------------------------

--- a/backend/src/api/handlers/events.rs
+++ b/backend/src/api/handlers/events.rs
@@ -111,6 +111,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         }
     }
 

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -730,6 +730,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         }
     }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -134,6 +134,30 @@ pub struct Config {
     /// **Security note:** ensure this port is not reachable from untrusted
     /// networks (e.g. restrict via firewall or Kubernetes NetworkPolicy).
     pub metrics_port: Option<u16>,
+
+    /// Maximum number of connections in the PostgreSQL pool.
+    /// Defaults to 20. Increase for higher concurrency, decrease for
+    /// databases with restricted connection budgets (e.g., shared RDS).
+    pub database_max_connections: u32,
+
+    /// Minimum number of idle connections kept in the PostgreSQL pool.
+    /// Defaults to 5. Set to 0 to allow the pool to scale down completely.
+    pub database_min_connections: u32,
+
+    /// Timeout in seconds for acquiring a connection from the pool before
+    /// returning an error. Defaults to 30.
+    pub database_acquire_timeout_secs: u64,
+
+    /// Idle timeout in seconds. Connections idle longer than this will be
+    /// closed. Defaults to 600 (10 minutes).
+    pub database_idle_timeout_secs: u64,
+
+    /// Maximum lifetime in seconds for a pooled connection. Connections
+    /// older than this are recycled even if still healthy. Defaults to
+    /// 1800 (30 minutes). Useful when the database has a connection
+    /// lifetime policy or when running behind a TCP load balancer with an
+    /// idle disconnect.
+    pub database_max_lifetime_secs: u64,
 }
 
 redacted_debug!(Config {
@@ -173,6 +197,11 @@ redacted_debug!(Config {
     show max_upload_size_bytes,
     show allow_local_admin_login,
     show metrics_port,
+    show database_max_connections,
+    show database_min_connections,
+    show database_acquire_timeout_secs,
+    show database_idle_timeout_secs,
+    show database_max_lifetime_secs,
 });
 
 impl Config {
@@ -256,6 +285,11 @@ impl Config {
                 },
                 Err(_) => None,
             },
+            database_max_connections: env_parse("DATABASE_MAX_CONNECTIONS", 20),
+            database_min_connections: env_parse("DATABASE_MIN_CONNECTIONS", 5),
+            database_acquire_timeout_secs: env_parse("DATABASE_ACQUIRE_TIMEOUT_SECS", 30),
+            database_idle_timeout_secs: env_parse("DATABASE_IDLE_TIMEOUT_SECS", 600),
+            database_max_lifetime_secs: env_parse("DATABASE_MAX_LIFETIME_SECS", 1800),
         };
 
         config.validate_jwt_secret()?;
@@ -459,6 +493,13 @@ mod tests {
         assert_eq!(config.peer_public_endpoint, "http://localhost:8080");
         assert_eq!(config.max_upload_size_bytes, 10_737_418_240);
 
+        // Database pool defaults (#678)
+        assert_eq!(config.database_max_connections, 20);
+        assert_eq!(config.database_min_connections, 5);
+        assert_eq!(config.database_acquire_timeout_secs, 30);
+        assert_eq!(config.database_idle_timeout_secs, 600);
+        assert_eq!(config.database_max_lifetime_secs, 1800);
+
         // Restore
         if let Some(v) = saved_db {
             env::set_var("DATABASE_URL", v);
@@ -481,6 +522,96 @@ mod tests {
         }
         if let Some(v) = saved_demo {
             env::set_var("DEMO_MODE", v);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Database pool configuration (#678)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_config_database_pool_env_overrides() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_max = env::var("DATABASE_MAX_CONNECTIONS").ok();
+        let saved_min = env::var("DATABASE_MIN_CONNECTIONS").ok();
+        let saved_acq = env::var("DATABASE_ACQUIRE_TIMEOUT_SECS").ok();
+        let saved_idle = env::var("DATABASE_IDLE_TIMEOUT_SECS").ok();
+        let saved_life = env::var("DATABASE_MAX_LIFETIME_SECS").ok();
+
+        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("JWT_SECRET", "super-secret");
+        env::set_var("DATABASE_MAX_CONNECTIONS", "50");
+        env::set_var("DATABASE_MIN_CONNECTIONS", "10");
+        env::set_var("DATABASE_ACQUIRE_TIMEOUT_SECS", "15");
+        env::set_var("DATABASE_IDLE_TIMEOUT_SECS", "300");
+        env::set_var("DATABASE_MAX_LIFETIME_SECS", "900");
+
+        let config = Config::from_env().expect("Config should load");
+
+        assert_eq!(config.database_max_connections, 50);
+        assert_eq!(config.database_min_connections, 10);
+        assert_eq!(config.database_acquire_timeout_secs, 15);
+        assert_eq!(config.database_idle_timeout_secs, 300);
+        assert_eq!(config.database_max_lifetime_secs, 900);
+
+        // Restore
+        if let Some(v) = saved_db {
+            env::set_var("DATABASE_URL", v);
+        } else {
+            env::remove_var("DATABASE_URL");
+        }
+        if let Some(v) = saved_jwt {
+            env::set_var("JWT_SECRET", v);
+        } else {
+            env::remove_var("JWT_SECRET");
+        }
+        for (k, v) in [
+            ("DATABASE_MAX_CONNECTIONS", saved_max),
+            ("DATABASE_MIN_CONNECTIONS", saved_min),
+            ("DATABASE_ACQUIRE_TIMEOUT_SECS", saved_acq),
+            ("DATABASE_IDLE_TIMEOUT_SECS", saved_idle),
+            ("DATABASE_MAX_LIFETIME_SECS", saved_life),
+        ] {
+            match v {
+                Some(val) => env::set_var(k, val),
+                None => env::remove_var(k),
+            }
+        }
+    }
+
+    #[test]
+    fn test_config_database_pool_invalid_value_falls_back_to_default() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_max = env::var("DATABASE_MAX_CONNECTIONS").ok();
+
+        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("JWT_SECRET", "super-secret");
+        env::set_var("DATABASE_MAX_CONNECTIONS", "not-a-number");
+
+        let config = Config::from_env().expect("Config should load even with invalid pool setting");
+
+        // env_parse falls back to the default when the value cannot be parsed
+        assert_eq!(config.database_max_connections, 20);
+
+        // Restore
+        if let Some(v) = saved_db {
+            env::set_var("DATABASE_URL", v);
+        } else {
+            env::remove_var("DATABASE_URL");
+        }
+        if let Some(v) = saved_jwt {
+            env::set_var("JWT_SECRET", v);
+        } else {
+            env::remove_var("JWT_SECRET");
+        }
+        if let Some(v) = saved_max {
+            env::set_var("DATABASE_MAX_CONNECTIONS", v);
+        } else {
+            env::remove_var("DATABASE_MAX_CONNECTIONS");
         }
     }
 

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,17 +1,24 @@
 //! Database connection pool setup.
 
+use crate::config::Config;
 use crate::error::Result;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::time::Duration;
 
-/// Create a new database connection pool
-pub async fn create_pool(database_url: &str) -> Result<PgPool> {
+/// Create a new database connection pool using the connection pool settings
+/// from [`Config`]. Pool sizing and timeouts are configurable via the
+/// `DATABASE_MAX_CONNECTIONS`, `DATABASE_MIN_CONNECTIONS`,
+/// `DATABASE_ACQUIRE_TIMEOUT_SECS`, `DATABASE_IDLE_TIMEOUT_SECS`, and
+/// `DATABASE_MAX_LIFETIME_SECS` environment variables. See `.env.example`
+/// for the default values.
+pub async fn create_pool(config: &Config) -> Result<PgPool> {
     let pool = PgPoolOptions::new()
-        .max_connections(20)
-        .min_connections(5)
-        .acquire_timeout(Duration::from_secs(30))
-        .idle_timeout(Duration::from_secs(600))
-        .connect(database_url)
+        .max_connections(config.database_max_connections)
+        .min_connections(config.database_min_connections)
+        .acquire_timeout(Duration::from_secs(config.database_acquire_timeout_secs))
+        .idle_timeout(Duration::from_secs(config.database_idle_timeout_secs))
+        .max_lifetime(Duration::from_secs(config.database_max_lifetime_secs))
+        .connect(&config.database_url)
         .await?;
 
     Ok(pool)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -111,7 +111,7 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     tracing::info!("Starting Artifact Keeper");
 
     // Connect to database
-    let db_pool = db::create_pool(&config.database_url).await?;
+    let db_pool = db::create_pool(&config).await?;
     tracing::info!("Connected to database");
 
     // Run migrations (skip with SKIP_MIGRATIONS=true for pre-applied migrations)

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -1254,6 +1254,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         })
     }
 

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -766,6 +766,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         }
     }
 

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -757,6 +757,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         };
 
         let oidc_config = OidcConfig::from_config(&config);
@@ -804,6 +809,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         }
     }
 

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -768,6 +768,11 @@ mod tests {
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
             metrics_port: None,
+            database_max_connections: 20,
+            database_min_connections: 5,
+            database_acquire_timeout_secs: 30,
+            database_idle_timeout_secs: 600,
+            database_max_lifetime_secs: 1800,
         }
     }
 

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -63,6 +63,11 @@ fn test_config(storage_path: &str) -> Config {
         allow_local_admin_login: false,
         max_upload_size_bytes: 10_737_418_240,
         metrics_port: None,
+        database_max_connections: 20,
+        database_min_connections: 5,
+        database_acquire_timeout_secs: 30,
+        database_idle_timeout_secs: 600,
+        database_max_lifetime_secs: 1800,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #678: expose PostgreSQL connection pool settings via environment variables instead of hardcoding them in \`db::create_pool\`.

### New environment variables

All five are optional and default to the existing hardcoded values, so this is a drop-in backwards-compatible upgrade.

| Variable | Default | Notes |
|----------|---------|-------|
| \`DATABASE_MAX_CONNECTIONS\` | 20 | Previously hardcoded |
| \`DATABASE_MIN_CONNECTIONS\` | 5 | Previously hardcoded |
| \`DATABASE_ACQUIRE_TIMEOUT_SECS\` | 30 | Previously hardcoded |
| \`DATABASE_IDLE_TIMEOUT_SECS\` | 600 | Previously hardcoded |
| \`DATABASE_MAX_LIFETIME_SECS\` | 1800 | **Newly exposed** - was not previously set |

### Motivation

Useful for deployments running against:
- Managed databases with restricted connection budgets (shared RDS, PgBouncer pools)
- TCP load balancers that cut idle connections (requires \`DATABASE_MAX_LIFETIME_SECS\`)
- Horizontally scaled deployments where per-pod connection caps matter
- Development vs production where the pool should be sized differently

### Implementation

- Added five fields to \`Config\` struct in \`backend/src/config.rs\` with inline doc comments
- Wired up via the existing \`env_parse\` helper, so invalid values fall back to the default with no error
- Updated \`redacted_debug!\` macro to include the new fields in debug output
- \`db::create_pool\` now takes \`&Config\` instead of \`&str\` so all pool settings are wired from the same place, and explicitly sets \`max_lifetime\` (which wasn't configured before)
- Updated all 7 test sites that construct \`Config\` literals to include the new fields
- Updated \`.env.example\` with per-variable documentation comments

### Tests

Added 2 unit tests in \`config::tests\`:
- \`test_config_database_pool_env_overrides\`: verifies all 5 env vars override the defaults
- \`test_config_database_pool_invalid_value_falls_back_to_default\`: verifies \`env_parse\` graceful fallback
- Updated \`test_config_from_env_defaults\` to assert the new default values

All 7291 workspace lib tests pass (+2 new).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (cargo test --workspace --lib: 7291 passed)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (internal-only configuration change)

Closes #678