### PR TITLE
feat: add quality gate quarantine period for newly published artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,6 +195,15 @@ JWT_EXPIRATION_SECS=86400
 # GITHUB_TOKEN=ghp_xxx
 
 # -----------------------------------------------------------------------------
+# Quarantine period (backend)
+# -----------------------------------------------------------------------------
+# When enabled, newly uploaded artifacts are held in a quarantine state until
+# security scans complete or the timeout expires. During quarantine, artifacts
+# are stored but not available for download.
+# QUARANTINE_ENABLED=false
+# QUARANTINE_DURATION_MINUTES=60
+
+# -----------------------------------------------------------------------------
 # Search indexing (backend)
 # -----------------------------------------------------------------------------
 # MEILISEARCH_URL=http://meilisearch:7700

--- a/backend/migrations/073_quarantine_period.sql
+++ b/backend/migrations/073_quarantine_period.sql
@@ -1,0 +1,21 @@
+-- Add quarantine period support for quality gate enforcement.
+-- When quarantine is enabled, newly uploaded artifacts are held in a
+-- 'quarantined' state until security scans complete or the timeout expires.
+
+-- Extend the quarantine_status CHECK constraint to include new states.
+-- The existing column (from migration 022) allows: 'unscanned', 'clean', 'flagged'.
+-- We add: 'quarantined' (held pending scan), 'released' (scan passed, available),
+-- and 'rejected' (scan failed, blocked).
+ALTER TABLE artifacts DROP CONSTRAINT IF EXISTS artifacts_quarantine_status_check;
+ALTER TABLE artifacts ADD CONSTRAINT artifacts_quarantine_status_check
+    CHECK (quarantine_status IN ('unscanned', 'clean', 'flagged', 'quarantined', 'released', 'rejected'));
+
+-- Timestamp indicating when quarantine expires. NULL means no quarantine.
+-- If quarantine_until is in the future and quarantine_status = 'quarantined',
+-- the artifact is blocked from download.
+ALTER TABLE artifacts ADD COLUMN IF NOT EXISTS quarantine_until TIMESTAMPTZ;
+
+-- Index for efficient lookup of quarantined artifacts nearing expiry.
+CREATE INDEX IF NOT EXISTS idx_artifacts_quarantine_until
+    ON artifacts(quarantine_until)
+    WHERE quarantine_until IS NOT NULL AND quarantine_status = 'quarantined';

--- a/backend/src/api/handlers/events.rs
+++ b/backend/src/api/handlers/events.rs
@@ -121,6 +121,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         }
     }
 

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -740,6 +740,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         }
     }
 

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -71,6 +71,7 @@ pub mod pub_registry;
 pub mod puppet;
 pub mod pypi;
 pub mod quality_gates;
+pub mod quarantine;
 pub mod remote_instances;
 pub mod repositories;
 pub mod repository_labels;

--- a/backend/src/api/handlers/quarantine.rs
+++ b/backend/src/api/handlers/quarantine.rs
@@ -1,0 +1,251 @@
+//! Quarantine status API handler.
+//!
+//! Provides an endpoint to check the quarantine status of an artifact, and
+//! admin endpoints to manually release or reject a quarantined artifact.
+
+use axum::{
+    extract::{Path, State},
+    routing::{get, post},
+    Extension, Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::{OpenApi, ToSchema};
+use uuid::Uuid;
+
+use crate::api::middleware::auth::AuthExtension;
+use crate::api::SharedState;
+use crate::error::{AppError, Result};
+use crate::services::quarantine_service;
+
+/// OpenAPI documentation for quarantine endpoints.
+#[derive(OpenApi)]
+#[openapi(
+    paths(get_quarantine_status, release_artifact, reject_artifact),
+    components(schemas(QuarantineStatusResponse, QuarantineActionRequest)),
+    tags(
+        (name = "quarantine", description = "Artifact quarantine management")
+    )
+)]
+pub struct QuarantineApiDoc;
+
+/// Create quarantine routes.
+pub fn router() -> Router<SharedState> {
+    Router::new()
+        .route("/artifacts/:id/quarantine", get(get_quarantine_status))
+        .route("/artifacts/:id/quarantine/release", post(release_artifact))
+        .route("/artifacts/:id/quarantine/reject", post(reject_artifact))
+}
+
+/// Quarantine status response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct QuarantineStatusResponse {
+    /// The artifact ID.
+    pub artifact_id: Uuid,
+    /// Current quarantine status: 'quarantined', 'released', 'rejected',
+    /// 'clean', 'flagged', 'unscanned', or null (no status set).
+    pub quarantine_status: String,
+    /// When the quarantine period expires. Null if not quarantined.
+    pub quarantine_until: Option<DateTime<Utc>>,
+    /// Whether the artifact is currently blocked from download.
+    pub is_blocked: bool,
+    /// Human-readable reason for the current state.
+    pub reason: String,
+}
+
+/// Request body for manual quarantine actions.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct QuarantineActionRequest {
+    /// Optional reason for the manual action (for audit trail).
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Get the quarantine status of an artifact.
+#[utoipa::path(
+    get,
+    path = "/artifacts/{id}/quarantine",
+    context_path = "/api/v1/quarantine",
+    tag = "quarantine",
+    params(
+        ("id" = Uuid, Path, description = "Artifact ID")
+    ),
+    responses(
+        (status = 200, description = "Quarantine status", body = QuarantineStatusResponse),
+        (status = 404, description = "Artifact not found"),
+    )
+)]
+pub async fn get_quarantine_status(
+    State(state): State<SharedState>,
+    Extension(_auth): Extension<Option<AuthExtension>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<QuarantineStatusResponse>> {
+    let info = quarantine_service::get_quarantine_info(&state.db, id)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+
+    let (status, until) = info;
+    let now = Utc::now();
+    let status_str = status.as_deref().unwrap_or("none");
+    let decision = quarantine_service::is_quarantine_blocked(Some(status_str), until, now);
+
+    let (is_blocked, reason) = match decision {
+        quarantine_service::QuarantineDecision::Blocked { expires_at } => (
+            true,
+            format!(
+                "Artifact is under quarantine review until {}",
+                expires_at.to_rfc3339()
+            ),
+        ),
+        quarantine_service::QuarantineDecision::Rejected => {
+            (true, "Artifact was rejected by security scans".to_string())
+        }
+        quarantine_service::QuarantineDecision::Expired => (
+            false,
+            "Quarantine period has expired, artifact will be auto-released on next download"
+                .to_string(),
+        ),
+        quarantine_service::QuarantineDecision::Allowed => {
+            (false, "Artifact is available for download".to_string())
+        }
+    };
+
+    Ok(Json(QuarantineStatusResponse {
+        artifact_id: id,
+        quarantine_status: status_str.to_string(),
+        quarantine_until: until,
+        is_blocked,
+        reason,
+    }))
+}
+
+/// Manually release an artifact from quarantine. Requires admin privileges.
+#[utoipa::path(
+    post,
+    path = "/artifacts/{id}/quarantine/release",
+    context_path = "/api/v1/quarantine",
+    tag = "quarantine",
+    params(
+        ("id" = Uuid, Path, description = "Artifact ID")
+    ),
+    request_body(content = QuarantineActionRequest, description = "Release details"),
+    responses(
+        (status = 200, description = "Artifact released from quarantine", body = QuarantineStatusResponse),
+        (status = 403, description = "Admin privileges required"),
+        (status = 404, description = "Artifact not found"),
+    )
+)]
+pub async fn release_artifact(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(id): Path<Uuid>,
+    Json(_body): Json<QuarantineActionRequest>,
+) -> Result<Json<QuarantineStatusResponse>> {
+    let auth =
+        auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
+
+    if !auth.is_admin {
+        return Err(AppError::Authorization(
+            "Admin privileges required to release quarantined artifacts".to_string(),
+        ));
+    }
+
+    // Verify artifact exists and check current status
+    let info = quarantine_service::get_quarantine_info(&state.db, id)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+
+    let (current_status, _) = &info;
+    let current = current_status.as_deref().unwrap_or("none");
+
+    if current != "quarantined" && current != "rejected" {
+        return Err(AppError::Validation(format!(
+            "Artifact is not in a quarantined or rejected state (current: {})",
+            current
+        )));
+    }
+
+    quarantine_service::release_quarantine(&state.db, id)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    tracing::info!(
+        artifact_id = %id,
+        admin = %auth.username,
+        "Artifact manually released from quarantine"
+    );
+
+    state
+        .event_bus
+        .emit("quarantine.released", id, Some(auth.username.clone()));
+
+    Ok(Json(QuarantineStatusResponse {
+        artifact_id: id,
+        quarantine_status: "released".to_string(),
+        quarantine_until: None,
+        is_blocked: false,
+        reason: "Artifact manually released by administrator".to_string(),
+    }))
+}
+
+/// Manually reject a quarantined artifact. Requires admin privileges.
+#[utoipa::path(
+    post,
+    path = "/artifacts/{id}/quarantine/reject",
+    context_path = "/api/v1/quarantine",
+    tag = "quarantine",
+    params(
+        ("id" = Uuid, Path, description = "Artifact ID")
+    ),
+    request_body(content = QuarantineActionRequest, description = "Rejection details"),
+    responses(
+        (status = 200, description = "Artifact rejected", body = QuarantineStatusResponse),
+        (status = 403, description = "Admin privileges required"),
+        (status = 404, description = "Artifact not found"),
+    )
+)]
+pub async fn reject_artifact(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(id): Path<Uuid>,
+    Json(_body): Json<QuarantineActionRequest>,
+) -> Result<Json<QuarantineStatusResponse>> {
+    let auth =
+        auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
+
+    if !auth.is_admin {
+        return Err(AppError::Authorization(
+            "Admin privileges required to reject quarantined artifacts".to_string(),
+        ));
+    }
+
+    // Verify artifact exists
+    quarantine_service::get_quarantine_info(&state.db, id)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+
+    quarantine_service::reject_quarantine(&state.db, id)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    tracing::info!(
+        artifact_id = %id,
+        admin = %auth.username,
+        "Artifact manually rejected"
+    );
+
+    state
+        .event_bus
+        .emit("quarantine.rejected", id, Some(auth.username.clone()));
+
+    Ok(Json(QuarantineStatusResponse {
+        artifact_id: id,
+        quarantine_status: "rejected".to_string(),
+        quarantine_until: None,
+        is_blocked: true,
+        reason: "Artifact manually rejected by administrator".to_string(),
+    }))
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -217,6 +217,10 @@ impl AppState {
         if let Some(ref qc) = self.quality_check_service {
             svc.set_quality_check_service(qc.clone());
         }
+        svc.set_quarantine_config(crate::services::quarantine_service::QuarantineConfig {
+            enabled: self.config.quarantine_enabled,
+            duration_minutes: self.config.quarantine_duration_minutes,
+        });
         svc
     }
 

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -47,6 +47,7 @@ use utoipa::{Modify, OpenApi};
         (name = "sso", description = "Single sign-on configuration"),
         (name = "migration", description = "Data migration and import"),
         (name = "quality", description = "Artifact health scoring and quality gates"),
+        (name = "quarantine", description = "Artifact quarantine management"),
         (name = "service_accounts", description = "Service account management"),
         (name = "health", description = "Health and readiness checks"),
         (name = "system", description = "Public system configuration"),
@@ -132,6 +133,7 @@ pub fn build_openapi() -> utoipa::openapi::OpenApi {
     doc.merge(super::handlers::curation::CurationApiDoc::openapi());
     doc.merge(super::handlers::upload::UploadApiDoc::openapi());
     doc.merge(super::handlers::system_config::SystemConfigApiDoc::openapi());
+    doc.merge(super::handlers::quarantine::QuarantineApiDoc::openapi());
 
     doc
 }

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -457,6 +457,14 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
+        // Quarantine management routes with auth middleware
+        .nest(
+            "/quarantine",
+            handlers::quarantine::router().layer(middleware::from_fn_with_state(
+                auth_service.clone(),
+                auth_middleware,
+            )),
+        )
         // Package curation routes with auth middleware
         .nest(
             "/curation",

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -164,6 +164,16 @@ pub struct Config {
     pub rate_limit_window_secs: u64,
     pub rate_limit_exempt_usernames: Vec<String>,
     pub rate_limit_exempt_service_accounts: bool,
+
+    /// When true, newly uploaded artifacts are placed in quarantine until
+    /// security scans complete or the quarantine timeout expires. Disabled
+    /// by default so existing deployments are unaffected.
+    pub quarantine_enabled: bool,
+
+    /// Duration in minutes that a quarantined artifact is held before
+    /// automatic release. Only used when quarantine_enabled is true.
+    /// Default: 60.
+    pub quarantine_duration_minutes: u64,
 }
 
 redacted_debug!(Config {
@@ -213,6 +223,8 @@ redacted_debug!(Config {
     show rate_limit_window_secs,
     show rate_limit_exempt_usernames,
     show rate_limit_exempt_service_accounts,
+    show quarantine_enabled,
+    show quarantine_duration_minutes,
 });
 
 impl Config {
@@ -317,6 +329,11 @@ impl Config {
                 env::var("RATE_LIMIT_EXEMPT_SERVICE_ACCOUNTS").as_deref(),
                 Ok("true" | "1")
             ),
+            quarantine_enabled: matches!(
+                env::var("QUARANTINE_ENABLED").as_deref(),
+                Ok("true" | "1")
+            ),
+            quarantine_duration_minutes: env_parse("QUARANTINE_DURATION_MINUTES", 60),
         };
 
         config.validate_jwt_secret()?;

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -15,6 +15,7 @@ use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::services::meili_service::{ArtifactDocument, MeiliService};
 use crate::services::plugin_service::{ArtifactInfo, PluginEventType, PluginService};
 use crate::services::quality_check_service::QualityCheckService;
+use crate::services::quarantine_service::QuarantineConfig;
 use crate::services::repository_service::RepositoryService;
 use crate::services::scanner_service::ScannerService;
 use crate::storage::StorageBackend;
@@ -28,6 +29,7 @@ pub struct ArtifactService {
     scanner_service: Option<Arc<ScannerService>>,
     quality_check_service: Option<Arc<QualityCheckService>>,
     meili_service: Option<Arc<MeiliService>>,
+    quarantine_config: QuarantineConfig,
 }
 
 impl ArtifactService {
@@ -42,6 +44,7 @@ impl ArtifactService {
             scanner_service: None,
             quality_check_service: None,
             meili_service: None,
+            quarantine_config: QuarantineConfig::default(),
         }
     }
 
@@ -60,6 +63,7 @@ impl ArtifactService {
             scanner_service: None,
             quality_check_service: None,
             meili_service,
+            quarantine_config: QuarantineConfig::default(),
         }
     }
 
@@ -78,6 +82,7 @@ impl ArtifactService {
             scanner_service: None,
             quality_check_service: None,
             meili_service: None,
+            quarantine_config: QuarantineConfig::default(),
         }
     }
 
@@ -94,6 +99,11 @@ impl ArtifactService {
     /// Set the quality check service for quality-on-upload.
     pub fn set_quality_check_service(&mut self, qc_service: Arc<QualityCheckService>) {
         self.quality_check_service = Some(qc_service);
+    }
+
+    /// Set the quarantine configuration for upload-time quarantine enforcement.
+    pub fn set_quarantine_config(&mut self, config: QuarantineConfig) {
+        self.quarantine_config = config;
     }
 
     /// Set the Meilisearch service for search indexing.
@@ -312,6 +322,35 @@ impl ArtifactService {
         .fetch_one(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Set quarantine status if quarantine is enabled
+        if self.quarantine_config.enabled {
+            let now = chrono::Utc::now();
+            let until = crate::services::quarantine_service::compute_quarantine_until(
+                &self.quarantine_config,
+                now,
+            );
+            if let Err(e) = crate::services::quarantine_service::set_quarantine(
+                &self.db,
+                artifact.id,
+                crate::services::quarantine_service::STATUS_QUARANTINED,
+                Some(until),
+            )
+            .await
+            {
+                tracing::warn!(
+                    "Failed to set quarantine on artifact {}: {}",
+                    artifact.id,
+                    e
+                );
+            } else {
+                tracing::info!(
+                    artifact_id = %artifact.id,
+                    quarantine_until = %until,
+                    "Artifact placed in quarantine"
+                );
+            }
+        }
 
         // Check quota warning threshold after successful upload
         if let Ok(repo) = self.repo_service.get_by_id(repository_id).await {
@@ -578,6 +617,58 @@ impl ArtifactService {
         .await
         .map_err(|e| AppError::Database(e.to_string()))?
         .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+
+        // Check quarantine status before allowing download
+        if self.quarantine_config.enabled {
+            if let Ok(Some((status, until))) =
+                crate::services::quarantine_service::get_quarantine_info(&self.db, artifact.id)
+                    .await
+            {
+                let now = chrono::Utc::now();
+                let decision = crate::services::quarantine_service::is_quarantine_blocked(
+                    status.as_deref(),
+                    until,
+                    now,
+                );
+                match decision {
+                    crate::services::quarantine_service::QuarantineDecision::Blocked {
+                        expires_at,
+                    } => {
+                        return Err(AppError::Conflict(format!(
+                            "Artifact is under quarantine review until {}",
+                            expires_at.to_rfc3339()
+                        )));
+                    }
+                    crate::services::quarantine_service::QuarantineDecision::Rejected => {
+                        return Err(AppError::Conflict(
+                            "Artifact was rejected by security scans and is not available for download"
+                                .to_string(),
+                        ));
+                    }
+                    crate::services::quarantine_service::QuarantineDecision::Expired => {
+                        // Auto-release: quarantine period has passed without a scan verdict.
+                        if let Err(e) = crate::services::quarantine_service::release_quarantine(
+                            &self.db,
+                            artifact.id,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                "Failed to auto-release quarantine for artifact {}: {}",
+                                artifact.id,
+                                e
+                            );
+                        } else {
+                            tracing::info!(
+                                artifact_id = %artifact.id,
+                                "Quarantine expired, artifact auto-released"
+                            );
+                        }
+                    }
+                    crate::services::quarantine_service::QuarantineDecision::Allowed => {}
+                }
+            }
+        }
 
         // Trigger BeforeDownload hooks - validators can reject the download
         let artifact_info = ArtifactInfo::from(&artifact);

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -1264,6 +1264,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         })
     }
 

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -776,6 +776,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         }
     }
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -36,6 +36,7 @@ pub mod promotion_policy_service;
 pub mod promotion_rule_service;
 pub mod proxy_service;
 pub mod quality_check_service;
+pub mod quarantine_service;
 pub mod remote_instance_service;
 pub mod repo_selector_service;
 pub mod repository_label_service;

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -767,6 +767,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         };
 
         let oidc_config = OidcConfig::from_config(&config);
@@ -824,6 +826,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         }
     }
 

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -1,0 +1,303 @@
+//! Quarantine period enforcement for newly published artifacts.
+//!
+//! When quarantine is enabled, artifacts enter a holding period after upload.
+//! During this period they are stored but not available for download. Security
+//! scanners run against the artifact, and on completion the quarantine is either
+//! released (scans pass) or the artifact is rejected (scans fail). If no scan
+//! completes before the quarantine timeout, the artifact is auto-released on
+//! the next download attempt.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Quarantine status values
+// ---------------------------------------------------------------------------
+
+/// Status value for artifacts under active quarantine hold.
+pub const STATUS_QUARANTINED: &str = "quarantined";
+/// Status value for artifacts released from quarantine (scans passed or admin override).
+pub const STATUS_RELEASED: &str = "released";
+/// Status value for artifacts rejected by security scans.
+pub const STATUS_REJECTED: &str = "rejected";
+/// Legacy status: scan completed with no findings.
+pub const STATUS_CLEAN: &str = "clean";
+/// Legacy status: scan completed with findings.
+pub const STATUS_FLAGGED: &str = "flagged";
+/// Legacy status: not yet scanned.
+pub const STATUS_UNSCANNED: &str = "unscanned";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Quarantine configuration loaded from environment variables.
+#[derive(Debug, Clone)]
+pub struct QuarantineConfig {
+    /// Whether quarantine is enabled globally.
+    pub enabled: bool,
+    /// Duration of the quarantine hold in minutes.
+    pub duration_minutes: u64,
+}
+
+impl Default for QuarantineConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            duration_minutes: 60,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision logic (pure functions, easily testable)
+// ---------------------------------------------------------------------------
+
+/// Determine whether an artifact is currently blocked by quarantine.
+///
+/// Returns a `QuarantineDecision` describing whether download should proceed.
+/// An artifact is blocked when:
+/// - quarantine_status is 'quarantined' AND quarantine_until is in the future
+/// - quarantine_status is 'rejected'
+///
+/// An artifact is NOT blocked when:
+/// - quarantine_status is NULL, 'released', 'clean', or 'unscanned'
+/// - quarantine_status is 'quarantined' but quarantine_until has passed (auto-release)
+/// - quarantine_status is 'flagged' (legacy scan status, not a download block)
+pub fn is_quarantine_blocked(
+    quarantine_status: Option<&str>,
+    quarantine_until: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> QuarantineDecision {
+    match quarantine_status {
+        Some(STATUS_REJECTED) => QuarantineDecision::Rejected,
+        Some(STATUS_QUARANTINED) => {
+            if let Some(until) = quarantine_until {
+                if now < until {
+                    QuarantineDecision::Blocked { expires_at: until }
+                } else {
+                    // Quarantine period expired, auto-release
+                    QuarantineDecision::Expired
+                }
+            } else {
+                // Quarantined without a deadline should not happen, but treat
+                // as expired (safe fallback).
+                QuarantineDecision::Expired
+            }
+        }
+        // 'released', 'clean', 'unscanned', 'flagged', or NULL: not blocked
+        _ => QuarantineDecision::Allowed,
+    }
+}
+
+/// Result of evaluating quarantine status for an artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuarantineDecision {
+    /// Artifact is available for download.
+    Allowed,
+    /// Artifact is under active quarantine. Download is blocked until `expires_at`.
+    Blocked { expires_at: DateTime<Utc> },
+    /// Quarantine period has expired. The artifact should be auto-released.
+    Expired,
+    /// Artifact was rejected by security scans. Download is permanently blocked
+    /// until an administrator manually overrides the status.
+    Rejected,
+}
+
+/// Compute the quarantine_until timestamp for a new upload.
+pub fn compute_quarantine_until(config: &QuarantineConfig, now: DateTime<Utc>) -> DateTime<Utc> {
+    now + chrono::Duration::minutes(config.duration_minutes as i64)
+}
+
+/// Determine the new quarantine_status after all scans complete.
+///
+/// If any scan found vulnerabilities (findings_count > 0), the artifact
+/// is rejected. Otherwise it is released.
+pub fn status_after_scan(findings_count: i32) -> &'static str {
+    if findings_count > 0 {
+        STATUS_REJECTED
+    } else {
+        STATUS_RELEASED
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Database helpers
+// ---------------------------------------------------------------------------
+
+/// Set quarantine status and deadline on an artifact.
+pub async fn set_quarantine(
+    db: &sqlx::PgPool,
+    artifact_id: Uuid,
+    status: &str,
+    until: Option<DateTime<Utc>>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE artifacts SET quarantine_status = $2, quarantine_until = $3 WHERE id = $1")
+        .bind(artifact_id)
+        .bind(status)
+        .bind(until)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Release an artifact from quarantine (set status to 'released', clear deadline).
+pub async fn release_quarantine(db: &sqlx::PgPool, artifact_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE artifacts SET quarantine_status = 'released', quarantine_until = NULL WHERE id = $1",
+    )
+    .bind(artifact_id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Reject an artifact (set status to 'rejected', clear deadline).
+pub async fn reject_quarantine(db: &sqlx::PgPool, artifact_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE artifacts SET quarantine_status = 'rejected', quarantine_until = NULL WHERE id = $1",
+    )
+    .bind(artifact_id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Fetch quarantine fields for an artifact. Returns (quarantine_status, quarantine_until).
+pub async fn get_quarantine_info(
+    db: &sqlx::PgPool,
+    artifact_id: Uuid,
+) -> Result<Option<(Option<String>, Option<DateTime<Utc>>)>, sqlx::Error> {
+    let row: Option<(Option<String>, Option<DateTime<Utc>>)> = sqlx::query_as(
+        "SELECT quarantine_status, quarantine_until FROM artifacts WHERE id = $1 AND is_deleted = false",
+    )
+    .bind(artifact_id)
+    .fetch_optional(db)
+    .await?;
+    Ok(row)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn test_allowed_when_no_quarantine() {
+        let decision = is_quarantine_blocked(None, None, Utc::now());
+        assert_eq!(decision, QuarantineDecision::Allowed);
+    }
+
+    #[test]
+    fn test_allowed_when_released() {
+        let decision = is_quarantine_blocked(Some(STATUS_RELEASED), None, Utc::now());
+        assert_eq!(decision, QuarantineDecision::Allowed);
+    }
+
+    #[test]
+    fn test_allowed_when_clean() {
+        let decision = is_quarantine_blocked(Some(STATUS_CLEAN), None, Utc::now());
+        assert_eq!(decision, QuarantineDecision::Allowed);
+    }
+
+    #[test]
+    fn test_allowed_when_unscanned() {
+        let decision = is_quarantine_blocked(Some(STATUS_UNSCANNED), None, Utc::now());
+        assert_eq!(decision, QuarantineDecision::Allowed);
+    }
+
+    #[test]
+    fn test_allowed_when_flagged_legacy() {
+        // 'flagged' is a legacy scan status. It is informational and should
+        // not block downloads (the policy engine handles enforcement separately).
+        let decision = is_quarantine_blocked(Some(STATUS_FLAGGED), None, Utc::now());
+        assert_eq!(decision, QuarantineDecision::Allowed);
+    }
+
+    #[test]
+    fn test_blocked_during_quarantine() {
+        let now = Utc::now();
+        let until = now + Duration::hours(1);
+        let decision = is_quarantine_blocked(Some(STATUS_QUARANTINED), Some(until), now);
+        assert_eq!(decision, QuarantineDecision::Blocked { expires_at: until });
+    }
+
+    #[test]
+    fn test_expired_quarantine() {
+        let now = Utc::now();
+        let until = now - Duration::minutes(5);
+        let decision = is_quarantine_blocked(Some(STATUS_QUARANTINED), Some(until), now);
+        assert_eq!(decision, QuarantineDecision::Expired);
+    }
+
+    #[test]
+    fn test_expired_quarantine_no_deadline() {
+        let now = Utc::now();
+        let decision = is_quarantine_blocked(Some(STATUS_QUARANTINED), None, now);
+        assert_eq!(decision, QuarantineDecision::Expired);
+    }
+
+    #[test]
+    fn test_rejected() {
+        let now = Utc::now();
+        let decision = is_quarantine_blocked(Some(STATUS_REJECTED), None, now);
+        assert_eq!(decision, QuarantineDecision::Rejected);
+    }
+
+    #[test]
+    fn test_rejected_ignores_deadline() {
+        let now = Utc::now();
+        let until = now + Duration::hours(1);
+        let decision = is_quarantine_blocked(Some(STATUS_REJECTED), Some(until), now);
+        assert_eq!(decision, QuarantineDecision::Rejected);
+    }
+
+    #[test]
+    fn test_compute_quarantine_until() {
+        let config = QuarantineConfig {
+            enabled: true,
+            duration_minutes: 120,
+        };
+        let now = Utc::now();
+        let until = compute_quarantine_until(&config, now);
+        let diff = until - now;
+        assert_eq!(diff.num_minutes(), 120);
+    }
+
+    #[test]
+    fn test_status_after_scan_clean() {
+        assert_eq!(status_after_scan(0), STATUS_RELEASED);
+    }
+
+    #[test]
+    fn test_status_after_scan_findings() {
+        assert_eq!(status_after_scan(1), STATUS_REJECTED);
+        assert_eq!(status_after_scan(50), STATUS_REJECTED);
+    }
+
+    #[test]
+    fn test_status_after_scan_negative_treated_as_clean() {
+        // Negative findings count should not happen, but treat it safely.
+        assert_eq!(status_after_scan(-1), STATUS_RELEASED);
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = QuarantineConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.duration_minutes, 60);
+    }
+
+    #[test]
+    fn test_blocked_at_exact_deadline() {
+        // At the exact deadline moment, quarantine should be expired (not blocked).
+        // The check is now < until, so at the exact boundary it is NOT less than.
+        let now = Utc::now();
+        let decision = is_quarantine_blocked(Some(STATUS_QUARANTINED), Some(now), now);
+        assert_eq!(decision, QuarantineDecision::Expired);
+    }
+}

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -1125,10 +1125,29 @@ impl ScannerService {
                         .fail_scan(scan_result.id, &e.to_string())
                         .await?;
 
-                    // Mark as flagged on failure (conservative)
+                    // Mark as flagged/rejected on failure (conservative).
+                    // If under quarantine period hold, reject the artifact.
+                    let current_qs: Option<Option<String>> =
+                        sqlx::query_scalar("SELECT quarantine_status FROM artifacts WHERE id = $1")
+                            .bind(artifact_id)
+                            .fetch_optional(&self.db)
+                            .await
+                            .ok()
+                            .flatten();
+
+                    let fail_status = if matches!(
+                        current_qs.as_ref().and_then(|s| s.as_deref()),
+                        Some("quarantined")
+                    ) {
+                        "rejected"
+                    } else {
+                        "flagged"
+                    };
+
                     sqlx::query!(
-                        "UPDATE artifacts SET quarantine_status = 'flagged' WHERE id = $1",
+                        "UPDATE artifacts SET quarantine_status = $2 WHERE id = $1",
                         artifact_id,
+                        fail_status,
                     )
                     .execute(&self.db)
                     .await
@@ -1353,12 +1372,36 @@ impl ScannerService {
     }
 
     /// Update artifact quarantine_status based on scan findings.
+    ///
+    /// If the artifact is currently in the 'quarantined' state (quality gate
+    /// quarantine period), the scan verdict transitions it to 'released' or
+    /// 'rejected'. Otherwise the legacy 'clean'/'flagged' statuses are used.
     async fn update_quarantine_status(&self, artifact_id: Uuid, findings_count: i32) -> Result<()> {
-        let status = if findings_count > 0 {
-            "flagged"
+        // Check if the artifact is currently under quarantine period hold
+        let current_status: Option<Option<String>> =
+            sqlx::query_scalar("SELECT quarantine_status FROM artifacts WHERE id = $1")
+                .bind(artifact_id)
+                .fetch_optional(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let is_quarantined = matches!(
+            current_status.as_ref().and_then(|s| s.as_deref()),
+            Some("quarantined")
+        );
+
+        let status = if is_quarantined {
+            // Quarantine period: use released/rejected to lift or block the hold
+            crate::services::quarantine_service::status_after_scan(findings_count)
         } else {
-            "clean"
+            // Legacy scan-based status: clean/flagged
+            if findings_count > 0 {
+                "flagged"
+            } else {
+                "clean"
+            }
         };
+
         sqlx::query!(
             "UPDATE artifacts SET quarantine_status = $2 WHERE id = $1",
             artifact_id,
@@ -1367,6 +1410,16 @@ impl ScannerService {
         .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Clear the quarantine_until deadline when releasing or rejecting
+        if is_quarantined {
+            sqlx::query("UPDATE artifacts SET quarantine_until = NULL WHERE id = $1")
+                .bind(artifact_id)
+                .execute(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
         Ok(())
     }
 }

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -778,6 +778,8 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            quarantine_enabled: false,
+            quarantine_duration_minutes: 60,
         }
     }
 

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -73,6 +73,8 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_window_secs: 60,
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,
+        quarantine_enabled: false,
+        quarantine_duration_minutes: 60,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #472. Adds a configurable quarantine period for newly uploaded artifacts. When enabled, artifacts are held in a quarantine state after upload, blocking downloads until security scans complete or a configurable timeout expires. This provides a buffer against supply-chain attacks by preventing consumption of unverified packages before scanners have had time to analyze them.

Key changes:
- New `quarantine_service` with pure decision logic and database helpers
- ArtifactService sets quarantine on upload, checks it on download
- ScannerService transitions quarantined artifacts to released/rejected based on scan results
- Three new API endpoints: GET status, POST release, POST reject (admin only)
- Migration 073 extends the quarantine_status CHECK constraint and adds quarantine_until column
- Controlled by QUARANTINE_ENABLED (default: false) and QUARANTINE_DURATION_MINUTES (default: 60)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes