### PR TITLE
feat: configurable password policies for local users (#677)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -315,6 +315,17 @@ JWT_EXPIRATION_SECS=86400
 # ALLOW_LOCAL_ADMIN_LOGIN=false
 
 # -----------------------------------------------------------------------------
+# Password policy (backend, local users only)
+# -----------------------------------------------------------------------------
+# PASSWORD_MIN_LENGTH=8               # Minimum password length (default: 8)
+# PASSWORD_MAX_LENGTH=128             # Maximum password length (default: 128)
+# PASSWORD_REQUIRE_UPPERCASE=false    # Require at least one uppercase letter
+# PASSWORD_REQUIRE_LOWERCASE=false    # Require at least one lowercase letter
+# PASSWORD_REQUIRE_DIGIT=false        # Require at least one digit
+# PASSWORD_REQUIRE_SPECIAL=false      # Require at least one special character
+# PASSWORD_MIN_STRENGTH=0             # zxcvbn strength score: 0=disabled, 1-4=increasingly strict
+
+# -----------------------------------------------------------------------------
 # Edge Node (for edge binary, not the main backend)
 # -----------------------------------------------------------------------------
 # PRIMARY_URL=https://primary.example.com

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "xz2",
  "zip 8.5.1",
  "zstd",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -706,6 +707,21 @@ dependencies = [
  "bergshamra-core",
  "uppsala",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -1439,6 +1455,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1574,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -1777,6 +1859,17 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -2564,6 +2657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2780,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -7627,4 +7735,21 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools 0.13.0",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -152,6 +152,7 @@ tonic.workspace = true
 tonic-reflection.workspace = true
 prost.workspace = true
 prost-types.workspace = true
+zxcvbn = "3"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8"

--- a/backend/src/api/handlers/events.rs
+++ b/backend/src/api/handlers/events.rs
@@ -121,6 +121,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         }
     }
 

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -740,6 +740,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         }
     }
 

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -16,6 +16,7 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
 use crate::services::auth_service::AuthService;
+use crate::services::password_policy::PasswordPolicyConfig;
 use std::sync::atomic::Ordering;
 
 /// Create user routes
@@ -62,47 +63,13 @@ pub(crate) fn generate_password() -> String {
         .collect()
 }
 
-/// Validate password strength beyond minimum length.
-fn validate_password(password: &str) -> Result<()> {
-    if password.len() < 8 {
-        return Err(AppError::Validation(
-            "Password must be at least 8 characters".to_string(),
-        ));
-    }
-    if password.len() > 128 {
-        return Err(AppError::Validation(
-            "Password must be at most 128 characters".to_string(),
-        ));
-    }
-    const COMMON_PASSWORDS: &[&str] = &[
-        "password",
-        "12345678",
-        "123456789",
-        "1234567890",
-        "qwerty123",
-        "qwertyui",
-        "password1",
-        "iloveyou",
-        "12341234",
-        "00000000",
-        "abc12345",
-        "11111111",
-        "password123",
-        "admin123",
-        "letmein1",
-        "welcome1",
-        "monkey12",
-        "dragon12",
-        "baseball1",
-        "trustno1",
-    ];
-    let lower = password.to_lowercase();
-    if COMMON_PASSWORDS.contains(&lower.as_str()) {
-        return Err(AppError::Validation(
-            "Password is too common; choose a stronger password".to_string(),
-        ));
-    }
-    Ok(())
+/// Validate a password against the configurable password policy.
+///
+/// Delegates to [`crate::services::password_policy::validate_password`] and
+/// converts the list of violations into a single [`AppError::Validation`].
+fn validate_password_with_policy(password: &str, policy: &PasswordPolicyConfig) -> Result<()> {
+    crate::services::password_policy::validate_password(password, policy)
+        .map_err(|violations| AppError::Validation(violations.join("; ")))
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -258,10 +225,13 @@ pub async fn create_user(
         ));
     }
 
+    // Build the password policy from config
+    let policy = PasswordPolicyConfig::from_config(&state.config);
+
     // Generate password if not provided, otherwise validate
     let (password, auto_generated) = match payload.password {
         Some(ref p) => {
-            validate_password(p)?;
+            validate_password_with_policy(p, &policy)?;
             (p.clone(), false)
         }
         None => (generate_password(), true),
@@ -788,8 +758,9 @@ pub async fn change_password(
     Path(id): Path<Uuid>,
     Json(payload): Json<ChangePasswordRequest>,
 ) -> Result<()> {
-    // Validate new password
-    validate_password(&payload.new_password)?;
+    // Validate new password against configurable policy
+    let policy = PasswordPolicyConfig::from_config(&state.config);
+    validate_password_with_policy(&payload.new_password, &policy)?;
 
     // For non-admins changing their own password, verify current password
     if auth.user_id == id && !auth.is_admin {
@@ -1459,11 +1430,18 @@ mod tests {
         assert_eq!(offset, 0);
     }
 
-    // -- validate_password tests --
+    // -- validate_password_with_policy tests --
+    // (Comprehensive policy rule tests live in services::password_policy::tests.
+    //  These handler-level tests verify that the wrapper correctly converts
+    //  violations into AppError::Validation.)
+
+    fn default_policy() -> PasswordPolicyConfig {
+        PasswordPolicyConfig::default()
+    }
 
     #[test]
     fn test_validate_password_too_short() {
-        let result = validate_password("abc");
+        let result = validate_password_with_policy("abc", &default_policy());
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("at least 8 characters"));
@@ -1471,15 +1449,14 @@ mod tests {
 
     #[test]
     fn test_validate_password_exactly_min_length() {
-        // 8 chars, not a common password
-        let result = validate_password("xK9!mZ2q");
+        let result = validate_password_with_policy("xK9!mZ2q", &default_policy());
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_password_too_long() {
         let long = "a".repeat(129);
-        let result = validate_password(&long);
+        let result = validate_password_with_policy(&long, &default_policy());
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("at most 128 characters"));
@@ -1488,62 +1465,62 @@ mod tests {
     #[test]
     fn test_validate_password_exactly_max_length() {
         let long = "aB3!".repeat(32); // 128 chars
-        let result = validate_password(&long);
+        let result = validate_password_with_policy(&long, &default_policy());
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_password_common_password_rejected() {
-        let result = validate_password("password");
+        let result = validate_password_with_policy("password", &default_policy());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("too common"));
     }
 
     #[test]
     fn test_validate_password_common_password_case_insensitive() {
-        // "Password" differs in case but should still be rejected
-        let result = validate_password("Password");
+        let result = validate_password_with_policy("Password", &default_policy());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("too common"));
     }
 
     #[test]
     fn test_validate_password_common_numeric() {
-        let result = validate_password("12345678");
+        let result = validate_password_with_policy("12345678", &default_policy());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("too common"));
     }
 
     #[test]
     fn test_validate_password_common_qwerty() {
-        let result = validate_password("qwerty123");
+        let result = validate_password_with_policy("qwerty123", &default_policy());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("too common"));
     }
 
     #[test]
     fn test_validate_password_common_admin123() {
-        let result = validate_password("admin123");
+        let result = validate_password_with_policy("admin123", &default_policy());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("too common"));
     }
 
     #[test]
     fn test_validate_password_common_trustno1() {
-        let result = validate_password("trustno1");
+        let result = validate_password_with_policy("trustno1", &default_policy());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("too common"));
     }
 
     #[test]
     fn test_validate_password_valid_strong_password() {
-        let result = validate_password("Correct-Horse-Battery-Staple!");
+        let result =
+            validate_password_with_policy("Correct-Horse-Battery-Staple!", &default_policy());
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_password_seven_chars_rejected() {
-        let result = validate_password("aB3!xYz");
+        let result = validate_password_with_policy("aB3!xYz", &default_policy());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -164,6 +164,30 @@ pub struct Config {
     pub rate_limit_window_secs: u64,
     pub rate_limit_exempt_usernames: Vec<String>,
     pub rate_limit_exempt_service_accounts: bool,
+
+    // -- Password policy (local users) --
+    /// Minimum password length (default: 8).
+    pub password_min_length: usize,
+
+    /// Maximum password length (default: 128).
+    pub password_max_length: usize,
+
+    /// Require at least one uppercase letter (default: false).
+    pub password_require_uppercase: bool,
+
+    /// Require at least one lowercase letter (default: false).
+    pub password_require_lowercase: bool,
+
+    /// Require at least one digit (default: false).
+    pub password_require_digit: bool,
+
+    /// Require at least one special character (default: false).
+    pub password_require_special: bool,
+
+    /// Minimum zxcvbn strength score (0 = disabled, 1-4 = increasingly strict).
+    /// When set to a value > 0, passwords are evaluated by the zxcvbn estimator
+    /// and must meet or exceed the given score.
+    pub password_min_strength: u8,
 }
 
 redacted_debug!(Config {
@@ -213,6 +237,13 @@ redacted_debug!(Config {
     show rate_limit_window_secs,
     show rate_limit_exempt_usernames,
     show rate_limit_exempt_service_accounts,
+    show password_min_length,
+    show password_max_length,
+    show password_require_uppercase,
+    show password_require_lowercase,
+    show password_require_digit,
+    show password_require_special,
+    show password_min_strength,
 });
 
 impl Config {
@@ -317,6 +348,28 @@ impl Config {
                 env::var("RATE_LIMIT_EXEMPT_SERVICE_ACCOUNTS").as_deref(),
                 Ok("true" | "1")
             ),
+            password_min_length: env_parse("PASSWORD_MIN_LENGTH", 8),
+            password_max_length: env_parse("PASSWORD_MAX_LENGTH", 128),
+            password_require_uppercase: matches!(
+                env::var("PASSWORD_REQUIRE_UPPERCASE").as_deref(),
+                Ok("true" | "1")
+            ),
+            password_require_lowercase: matches!(
+                env::var("PASSWORD_REQUIRE_LOWERCASE").as_deref(),
+                Ok("true" | "1")
+            ),
+            password_require_digit: matches!(
+                env::var("PASSWORD_REQUIRE_DIGIT").as_deref(),
+                Ok("true" | "1")
+            ),
+            password_require_special: matches!(
+                env::var("PASSWORD_REQUIRE_SPECIAL").as_deref(),
+                Ok("true" | "1")
+            ),
+            password_min_strength: {
+                let raw = env_parse::<u8>("PASSWORD_MIN_STRENGTH", 0);
+                raw.min(4)
+            },
         };
 
         config.validate_jwt_secret()?;

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -1264,6 +1264,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         })
     }
 

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -776,6 +776,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         }
     }
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -26,6 +26,7 @@ pub mod nexus_client;
 pub mod oidc_service;
 pub mod openscap_scanner;
 pub mod package_service;
+pub mod password_policy;
 pub mod peer_instance_label_service;
 pub mod peer_instance_service;
 pub mod peer_service;

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -767,6 +767,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         };
 
         let oidc_config = OidcConfig::from_config(&config);
@@ -824,6 +831,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         }
     }
 

--- a/backend/src/services/password_policy.rs
+++ b/backend/src/services/password_policy.rs
@@ -1,0 +1,376 @@
+//! Configurable password policy validation for local user accounts.
+//!
+//! All validation logic lives in a single pure function
+//! [`validate_password`] so it can be tested exhaustively without
+//! database or application state.
+
+/// Configuration for password policy checks, extracted from [`crate::config::Config`].
+#[derive(Debug, Clone)]
+pub struct PasswordPolicyConfig {
+    pub min_length: usize,
+    pub max_length: usize,
+    pub require_uppercase: bool,
+    pub require_lowercase: bool,
+    pub require_digit: bool,
+    pub require_special: bool,
+    /// 0 = disabled, 1-4 maps to zxcvbn scores.
+    pub min_strength: u8,
+}
+
+impl Default for PasswordPolicyConfig {
+    fn default() -> Self {
+        Self {
+            min_length: 8,
+            max_length: 128,
+            require_uppercase: false,
+            require_lowercase: false,
+            require_digit: false,
+            require_special: false,
+            min_strength: 0,
+        }
+    }
+}
+
+impl PasswordPolicyConfig {
+    /// Build a policy config from the application config.
+    pub fn from_config(config: &crate::config::Config) -> Self {
+        Self {
+            min_length: config.password_min_length,
+            max_length: config.password_max_length,
+            require_uppercase: config.password_require_uppercase,
+            require_lowercase: config.password_require_lowercase,
+            require_digit: config.password_require_digit,
+            require_special: config.password_require_special,
+            min_strength: config.password_min_strength,
+        }
+    }
+}
+
+/// Characters considered "special" for the `require_special` policy.
+const SPECIAL_CHARS: &str = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~\\";
+
+/// Validate a password against the given policy configuration.
+///
+/// Returns `Ok(())` when the password satisfies every enabled rule.
+/// On failure, returns a `Vec<String>` with one human-readable message
+/// per violated rule, so the caller can present all problems at once
+/// rather than making users fix them one by one.
+pub fn validate_password(password: &str, config: &PasswordPolicyConfig) -> Result<(), Vec<String>> {
+    // Common passwords list (checked regardless of policy settings).
+    const COMMON_PASSWORDS: &[&str] = &[
+        "password",
+        "12345678",
+        "123456789",
+        "1234567890",
+        "qwerty123",
+        "qwertyui",
+        "password1",
+        "iloveyou",
+        "12341234",
+        "00000000",
+        "abc12345",
+        "11111111",
+        "password123",
+        "admin123",
+        "letmein1",
+        "welcome1",
+        "monkey12",
+        "dragon12",
+        "baseball1",
+        "trustno1",
+    ];
+
+    let mut violations: Vec<String> = Vec::new();
+
+    // Length checks
+    if password.len() < config.min_length {
+        violations.push(format!(
+            "Password must be at least {} characters",
+            config.min_length
+        ));
+    }
+    if password.len() > config.max_length {
+        violations.push(format!(
+            "Password must be at most {} characters",
+            config.max_length
+        ));
+    }
+
+    // Character class checks
+    if config.require_uppercase && !password.chars().any(|c| c.is_ascii_uppercase()) {
+        violations.push("Password must contain at least one uppercase letter".to_string());
+    }
+    if config.require_lowercase && !password.chars().any(|c| c.is_ascii_lowercase()) {
+        violations.push("Password must contain at least one lowercase letter".to_string());
+    }
+    if config.require_digit && !password.chars().any(|c| c.is_ascii_digit()) {
+        violations.push("Password must contain at least one digit".to_string());
+    }
+    if config.require_special && !password.chars().any(|c| SPECIAL_CHARS.contains(c)) {
+        violations.push("Password must contain at least one special character".to_string());
+    }
+
+    // Common password check
+    let lower = password.to_lowercase();
+    if COMMON_PASSWORDS.contains(&lower.as_str()) {
+        violations.push("Password is too common; choose a stronger password".to_string());
+    }
+
+    // zxcvbn strength check (only when enabled)
+    if config.min_strength > 0 {
+        if let Ok(min_score) = zxcvbn::Score::try_from(config.min_strength) {
+            let estimate = zxcvbn::zxcvbn(password, &[]);
+            if estimate.score() < min_score {
+                let label = match config.min_strength {
+                    1 => "very weak",
+                    2 => "weak",
+                    3 => "moderate",
+                    4 => "strong",
+                    _ => "sufficient",
+                };
+                violations.push(format!(
+                    "Password is not strong enough (minimum strength: {label})"
+                ));
+            }
+        }
+    }
+
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> PasswordPolicyConfig {
+        PasswordPolicyConfig::default()
+    }
+
+    // -----------------------------------------------------------------------
+    // Length checks
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn accepts_valid_password_with_defaults() {
+        let cfg = default_config();
+        assert!(validate_password("a-fine-pass", &cfg).is_ok());
+    }
+
+    #[test]
+    fn rejects_too_short() {
+        let cfg = PasswordPolicyConfig {
+            min_length: 12,
+            ..default_config()
+        };
+        let errs = validate_password("short", &cfg).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("at least 12 characters"));
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let cfg = PasswordPolicyConfig {
+            max_length: 16,
+            ..default_config()
+        };
+        let long = "a".repeat(17);
+        let errs = validate_password(&long, &cfg).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("at most 16 characters"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Character class checks
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn requires_uppercase() {
+        let cfg = PasswordPolicyConfig {
+            require_uppercase: true,
+            ..default_config()
+        };
+        let errs = validate_password("alllowercase1", &cfg).unwrap_err();
+        assert!(errs[0].contains("uppercase"));
+
+        assert!(validate_password("hasUppercase1", &cfg).is_ok());
+    }
+
+    #[test]
+    fn requires_lowercase() {
+        let cfg = PasswordPolicyConfig {
+            require_lowercase: true,
+            ..default_config()
+        };
+        let errs = validate_password("ALLUPPERCASE1", &cfg).unwrap_err();
+        assert!(errs[0].contains("lowercase"));
+
+        assert!(validate_password("HASLOWERa1234", &cfg).is_ok());
+    }
+
+    #[test]
+    fn requires_digit() {
+        let cfg = PasswordPolicyConfig {
+            require_digit: true,
+            ..default_config()
+        };
+        let errs = validate_password("noDigitsHere", &cfg).unwrap_err();
+        assert!(errs[0].contains("digit"));
+
+        assert!(validate_password("hasDigit7xx", &cfg).is_ok());
+    }
+
+    #[test]
+    fn requires_special() {
+        let cfg = PasswordPolicyConfig {
+            require_special: true,
+            ..default_config()
+        };
+        let errs = validate_password("NoSpecials123", &cfg).unwrap_err();
+        assert!(errs[0].contains("special"));
+
+        assert!(validate_password("has$pecial1", &cfg).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Combined rules
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn reports_all_violations_at_once() {
+        let cfg = PasswordPolicyConfig {
+            min_length: 12,
+            require_uppercase: true,
+            require_digit: true,
+            require_special: true,
+            ..default_config()
+        };
+        // "short" violates length, uppercase, digit, and special
+        let errs = validate_password("short", &cfg).unwrap_err();
+        assert!(errs.len() >= 4, "Expected >= 4 violations, got {errs:?}");
+    }
+
+    #[test]
+    fn all_rules_enabled_and_satisfied() {
+        let cfg = PasswordPolicyConfig {
+            min_length: 10,
+            max_length: 64,
+            require_uppercase: true,
+            require_lowercase: true,
+            require_digit: true,
+            require_special: true,
+            min_strength: 0,
+        };
+        assert!(validate_password("Str0ng!Pass", &cfg).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Common password check
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_common_passwords() {
+        let cfg = default_config();
+        let errs = validate_password("password", &cfg).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("too common")));
+    }
+
+    #[test]
+    fn common_password_check_is_case_insensitive() {
+        let cfg = default_config();
+        let errs = validate_password("Password", &cfg).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("too common")));
+    }
+
+    // -----------------------------------------------------------------------
+    // zxcvbn strength scoring
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn strength_check_disabled_by_default() {
+        let cfg = default_config();
+        // "aaaaaaaa" is weak but should pass when min_strength = 0
+        assert!(validate_password("aaaaaaaa", &cfg).is_ok());
+    }
+
+    #[test]
+    fn strength_check_rejects_weak_password() {
+        let cfg = PasswordPolicyConfig {
+            min_strength: 3,
+            ..default_config()
+        };
+        let errs = validate_password("aaaaaaaa", &cfg).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("not strong enough")));
+    }
+
+    #[test]
+    fn strength_check_accepts_strong_password() {
+        let cfg = PasswordPolicyConfig {
+            min_strength: 3,
+            ..default_config()
+        };
+        // A sufficiently complex passphrase should score >= 3
+        assert!(validate_password("correct-horse-battery-staple-xyz", &cfg).is_ok());
+    }
+
+    #[test]
+    fn strength_check_level_4() {
+        let cfg = PasswordPolicyConfig {
+            min_strength: 4,
+            ..default_config()
+        };
+        // Simple passwords should fail at level 4
+        let result = validate_password("Summer2024", &cfg);
+        assert!(result.is_err());
+
+        // A long random-looking password should pass
+        assert!(validate_password("j7$Kx!2mQ9@pLw4#rV6&nF8", &cfg).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_password_fails_length_check() {
+        let cfg = default_config();
+        let errs = validate_password("", &cfg).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("at least")));
+    }
+
+    #[test]
+    fn unicode_characters_counted_by_byte_length() {
+        // Rust's str::len() returns bytes, not chars, so a short
+        // string of multi-byte characters can pass the length check.
+        let cfg = PasswordPolicyConfig {
+            min_length: 4,
+            ..default_config()
+        };
+        // 4 emoji = 16 bytes, well above min_length of 4
+        let emoji_pwd = "\u{1F600}\u{1F601}\u{1F602}\u{1F603}";
+        assert!(validate_password(emoji_pwd, &cfg).is_ok());
+    }
+
+    #[test]
+    fn exact_min_length_accepted() {
+        let cfg = PasswordPolicyConfig {
+            min_length: 8,
+            ..default_config()
+        };
+        // Use a non-common 8-character password
+        assert!(validate_password("xK9!mZ2q", &cfg).is_ok());
+    }
+
+    #[test]
+    fn exact_max_length_accepted() {
+        let cfg = PasswordPolicyConfig {
+            max_length: 10,
+            ..default_config()
+        };
+        // Use a non-common 10-character password
+        assert!(validate_password("aB3!xYz9kL", &cfg).is_ok());
+    }
+}

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -778,6 +778,13 @@ mod tests {
             rate_limit_window_secs: 60,
             rate_limit_exempt_usernames: Vec::new(),
             rate_limit_exempt_service_accounts: false,
+            password_min_length: 8,
+            password_max_length: 128,
+            password_require_uppercase: false,
+            password_require_lowercase: false,
+            password_require_digit: false,
+            password_require_special: false,
+            password_min_strength: 0,
         }
     }
 

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -73,6 +73,13 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_window_secs: 60,
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,
+        password_min_length: 8,
+        password_max_length: 128,
+        password_require_uppercase: false,
+        password_require_lowercase: false,
+        password_require_digit: false,
+        password_require_special: false,
+        password_min_strength: 0,
     }
 }
 


### PR DESCRIPTION
## Summary

Rebased version of #705 on current main. Implements #677: configurable password validation rules for local users.

New env vars (all optional, backwards-compatible defaults):
- PASSWORD_MIN_LENGTH (default 8), PASSWORD_MAX_LENGTH (default 128)
- PASSWORD_REQUIRE_UPPERCASE/LOWERCASE/DIGIT/SPECIAL (all default false)
- PASSWORD_MIN_STRENGTH (default 0, 1-4 maps to zxcvbn scores)

Validation runs on user creation and password change. Common password blocklist included.

19 unit tests. 7387 tests pass.

## Test Checklist
- [x] Unit tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - validation is internal, errors surface through existing error responses

Closes #677