### PR TITLE
Add tar and gzip to UBI runtime image for scanner extraction

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -62,6 +62,8 @@ RUN mkdir -p /mnt/rootfs && \
         bzip2-libs \
         curl-minimal \
         jq \
+        tar \
+        gzip \
     && dnf --installroot /mnt/rootfs clean all \
     && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 


### PR DESCRIPTION
## Summary

The Trivy and Grype scanners shell out to `tar` to extract archives (`.tar.gz`, `.tgz`, `.crate`, `.gem`) before scanning them. The `ubi9/ubi-micro:9.7` base image used for the runtime stage does not include `tar` or `gzip`, so these scans fail at runtime with a "command not found" error.

This adds `tar` and `gzip` to the rootfs-builder `dnf install` list in `docker/Dockerfile.backend`. The packages are installed into the custom rootfs that gets copied into the final ubi-micro image, following the same pattern used for other runtime dependencies like `curl-minimal` and `jq`.

The Alpine variant (`Dockerfile.backend.alpine`) is not affected because Alpine 3.23 includes `tar` and `gzip` in the base image.

Fixes #708

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes