### PR TITLE
feat: link staging repos to release repos for controlled promotion

### DIFF
--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -35,11 +35,17 @@ pub fn router() -> Router<SharedState> {
             "/repositories/:key/promotion-history",
             get(promotion_history),
         )
+        .route(
+            "/repositories/:key/release-target",
+            get(get_release_target).put(set_release_target),
+        )
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct PromoteArtifactRequest {
-    pub target_repository: String,
+    /// Target release repository key. When omitted, the staging repository's
+    /// linked release target (from `repository_config`) is used instead.
+    pub target_repository: Option<String>,
     #[serde(default)]
     pub skip_policy_check: bool,
     pub notes: Option<String>,
@@ -47,7 +53,9 @@ pub struct PromoteArtifactRequest {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct BulkPromoteRequest {
-    pub target_repository: String,
+    /// Target release repository key. When omitted, the staging repository's
+    /// linked release target (from `repository_config`) is used instead.
+    pub target_repository: Option<String>,
     pub artifact_ids: Vec<Uuid>,
     #[serde(default)]
     pub skip_policy_check: bool,
@@ -149,6 +157,91 @@ pub fn validate_promotion_repos(
     Ok(())
 }
 
+/// Look up the linked release repository key for a staging repository.
+///
+/// Reads the `release_repository_id` value from the `repository_config` table,
+/// then resolves it to a repository key. Returns `None` when no link is configured.
+pub async fn resolve_release_target_key(
+    db: &sqlx::PgPool,
+    staging_repo_id: Uuid,
+) -> Result<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = 'release_repository_id'",
+    )
+    .bind(staging_repo_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let release_id_str = match row {
+        Some((v,)) => v,
+        None => return Ok(None),
+    };
+
+    let release_id: Uuid = release_id_str.parse().map_err(|_| {
+        AppError::Internal(format!(
+            "Invalid UUID in release_repository_id config: {}",
+            release_id_str
+        ))
+    })?;
+
+    let key: Option<(String,)> = sqlx::query_as("SELECT key FROM repositories WHERE id = $1")
+        .bind(release_id)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(key.map(|(k,)| k))
+}
+
+/// Determine the effective target repository key for a promotion.
+///
+/// If the caller supplied an explicit target, it is used directly. Otherwise the
+/// linked release target from `repository_config` is used. Returns an error when
+/// neither is available.
+async fn resolve_effective_target(
+    db: &sqlx::PgPool,
+    explicit_target: Option<&str>,
+    staging_repo_id: Uuid,
+) -> Result<String> {
+    if let Some(target) = explicit_target {
+        return Ok(target.to_string());
+    }
+
+    resolve_release_target_key(db, staging_repo_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::Validation(
+                "No target_repository specified and no linked release repository configured \
+                 for this staging repository. Set a release target via PATCH /api/v1/repositories/{key} \
+                 with the release_repository_key field, or provide target_repository in the request."
+                    .to_string(),
+            )
+        })
+}
+
+/// Validate that the explicit promotion target matches the staging repository's
+/// linked release target, if one is configured.
+///
+/// When a staging repository has a linked release repository, promotions to any
+/// other repository are rejected.
+async fn enforce_release_target_link(
+    db: &sqlx::PgPool,
+    staging_repo_id: Uuid,
+    actual_target_key: &str,
+) -> Result<()> {
+    if let Some(linked_key) = resolve_release_target_key(db, staging_repo_id).await? {
+        if linked_key != actual_target_key {
+            return Err(AppError::Validation(format!(
+                "This staging repository is linked to release repository '{}'. \
+                 Promotion to '{}' is not allowed.",
+                linked_key, actual_target_key,
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn failed_response(source: String, target: String, message: String) -> PromotionResponse {
     PromotionResponse {
         promoted: false,
@@ -187,14 +280,23 @@ pub async fn promote_artifact(
     let repo_service = RepositoryService::new(state.db.clone());
 
     let source_repo = repo_service.get_by_key(&repo_key).await?;
-    let target_repo = repo_service.get_by_key(&req.target_repository).await?;
+
+    // Resolve the target: explicit request field, or linked release repo from config.
+    let target_key =
+        resolve_effective_target(&state.db, req.target_repository.as_deref(), source_repo.id)
+            .await?;
+
+    // When a release link is configured, reject promotions to any other repo.
+    enforce_release_target_link(&state.db, source_repo.id, &target_key).await?;
+
+    let target_repo = repo_service.get_by_key(&target_key).await?;
     validate_promotion_repos(&source_repo, &target_repo)?;
 
     if super::approval::check_approval_required(&state.db, source_repo.id).await? {
         return Ok(Json(PromotionResponse {
             promoted: false,
             source: format!("{}/{}", repo_key, artifact_id),
-            target: req.target_repository.clone(),
+            target: target_key.clone(),
             promotion_id: None,
             policy_violations: vec![],
             message: Some(
@@ -256,7 +358,7 @@ pub async fn promote_artifact(
             return Ok(Json(PromotionResponse {
                 promoted: false,
                 source: format!("{}/{}", repo_key, artifact.path),
-                target: format!("{}/{}", req.target_repository, artifact.path),
+                target: format!("{}/{}", target_key, artifact.path),
                 promotion_id: None,
                 policy_violations,
                 message: Some("Promotion blocked by policy violations".to_string()),
@@ -280,7 +382,7 @@ pub async fn promote_artifact(
                         return Ok(Json(PromotionResponse {
                             promoted: false,
                             source: format!("{}/{}", repo_key, artifact.path),
-                            target: format!("{}/{}", req.target_repository, artifact.path),
+                            target: format!("{}/{}", target_key, artifact.path),
                             promotion_id: None,
                             policy_violations: gate_violations,
                             message: Some(format!(
@@ -384,7 +486,7 @@ pub async fn promote_artifact(
 
     tracing::info!(
         source_repo = %repo_key,
-        target_repo = %req.target_repository,
+        target_repo = %target_key,
         artifact = %artifact.path,
         promoted_by = %auth.user_id,
         "Artifact promoted successfully"
@@ -393,7 +495,7 @@ pub async fn promote_artifact(
     Ok(Json(PromotionResponse {
         promoted: true,
         source: format!("{}/{}", repo_key, artifact.path),
-        target: format!("{}/{}", req.target_repository, artifact.path),
+        target: format!("{}/{}", target_key, artifact.path),
         promotion_id: Some(promotion_id),
         policy_violations: vec![],
         message: Some("Artifact promoted successfully".to_string()),
@@ -425,7 +527,16 @@ pub async fn promote_artifacts_bulk(
     let repo_service = RepositoryService::new(state.db.clone());
 
     let source_repo = repo_service.get_by_key(&repo_key).await?;
-    let target_repo = repo_service.get_by_key(&req.target_repository).await?;
+
+    // Resolve the target: explicit request field, or linked release repo from config.
+    let target_key =
+        resolve_effective_target(&state.db, req.target_repository.as_deref(), source_repo.id)
+            .await?;
+
+    // When a release link is configured, reject promotions to any other repo.
+    enforce_release_target_link(&state.db, source_repo.id, &target_key).await?;
+
+    let target_repo = repo_service.get_by_key(&target_key).await?;
     validate_promotion_repos(&source_repo, &target_repo)?;
 
     let mut results = Vec::new();
@@ -456,7 +567,7 @@ pub async fn promote_artifacts_bulk(
                 failed += 1;
                 results.push(failed_response(
                     format!("{}/{}", repo_key, artifact_id),
-                    req.target_repository.clone(),
+                    target_key.clone(),
                     "Artifact not found".to_string(),
                 ));
                 continue;
@@ -465,7 +576,7 @@ pub async fn promote_artifacts_bulk(
                 failed += 1;
                 results.push(failed_response(
                     format!("{}/{}", repo_key, artifact_id),
-                    req.target_repository.clone(),
+                    target_key.clone(),
                     format!("Database error: {}", e),
                 ));
                 continue;
@@ -473,7 +584,7 @@ pub async fn promote_artifacts_bulk(
         };
 
         let source_display = format!("{}/{}", repo_key, artifact.path);
-        let target_display = format!("{}/{}", req.target_repository, artifact.path);
+        let target_display = format!("{}/{}", target_key, artifact.path);
 
         let source_storage = state.storage_for_repo(&source_repo.storage_location())?;
         let target_storage = state.storage_for_repo(&target_repo.storage_location())?;
@@ -574,7 +685,7 @@ pub async fn promote_artifacts_bulk(
 
     tracing::info!(
         source_repo = %repo_key,
-        target_repo = %req.target_repository,
+        target_repo = %target_key,
         total = req.artifact_ids.len(),
         promoted = promoted,
         failed = failed,
@@ -798,6 +909,222 @@ pub async fn promotion_history(
     }))
 }
 
+// ---------------------------------------------------------------------------
+// Release target linking
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReleaseTargetResponse {
+    /// Whether this staging repository has a linked release target.
+    pub linked: bool,
+    /// The release repository key, if linked.
+    pub release_repository_key: Option<String>,
+    /// The release repository ID, if linked.
+    pub release_repository_id: Option<Uuid>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetReleaseTargetRequest {
+    /// Repository key of the release (local) repository to link.
+    /// Pass `null` or omit to remove the link.
+    pub release_repository_key: Option<String>,
+}
+
+/// Get the linked release target for a staging repository.
+#[utoipa::path(
+    get,
+    path = "/repositories/{key}/release-target",
+    context_path = "/api/v1/promotion",
+    tag = "promotion",
+    params(
+        ("key" = String, Path, description = "Staging repository key"),
+    ),
+    responses(
+        (status = 200, description = "Release target information", body = ReleaseTargetResponse),
+        (status = 404, description = "Repository not found", body = crate::api::openapi::ErrorResponse),
+        (status = 422, description = "Repository is not a staging repository", body = crate::api::openapi::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn get_release_target(
+    State(state): State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Json<ReleaseTargetResponse>> {
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&repo_key).await?;
+
+    if repo.repo_type != RepositoryType::Staging {
+        return Err(AppError::Validation(
+            "Release target linking is only available for staging repositories".to_string(),
+        ));
+    }
+
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = 'release_repository_id'",
+    )
+    .bind(repo.id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    match row {
+        Some((release_id_str,)) => {
+            let release_id: Uuid = release_id_str.parse().map_err(|_| {
+                AppError::Internal(format!(
+                    "Invalid UUID in release_repository_id config: {}",
+                    release_id_str
+                ))
+            })?;
+            let release_key: Option<(String,)> =
+                sqlx::query_as("SELECT key FROM repositories WHERE id = $1")
+                    .bind(release_id)
+                    .fetch_optional(&state.db)
+                    .await
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+
+            match release_key {
+                Some((key,)) => Ok(Json(ReleaseTargetResponse {
+                    linked: true,
+                    release_repository_key: Some(key),
+                    release_repository_id: Some(release_id),
+                })),
+                None => {
+                    // The linked repo was deleted; treat as unlinked.
+                    Ok(Json(ReleaseTargetResponse {
+                        linked: false,
+                        release_repository_key: None,
+                        release_repository_id: None,
+                    }))
+                }
+            }
+        }
+        None => Ok(Json(ReleaseTargetResponse {
+            linked: false,
+            release_repository_key: None,
+            release_repository_id: None,
+        })),
+    }
+}
+
+/// Set or remove the linked release target for a staging repository.
+///
+/// The release repository must exist, be type Local, and share the same package
+/// format as the staging repository. Pass `null` for `release_repository_key` to
+/// remove the link.
+#[utoipa::path(
+    put,
+    path = "/repositories/{key}/release-target",
+    context_path = "/api/v1/promotion",
+    tag = "promotion",
+    params(
+        ("key" = String, Path, description = "Staging repository key"),
+    ),
+    request_body = SetReleaseTargetRequest,
+    responses(
+        (status = 200, description = "Release target updated", body = ReleaseTargetResponse),
+        (status = 404, description = "Repository not found", body = crate::api::openapi::ErrorResponse),
+        (status = 422, description = "Validation error", body = crate::api::openapi::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn set_release_target(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Path(repo_key): Path<String>,
+    Json(req): Json<SetReleaseTargetRequest>,
+) -> Result<Json<ReleaseTargetResponse>> {
+    auth.require_scope("write")?;
+
+    let repo_service = RepositoryService::new(state.db.clone());
+    let staging_repo = repo_service.get_by_key(&repo_key).await?;
+
+    if staging_repo.repo_type != RepositoryType::Staging {
+        return Err(AppError::Validation(
+            "Release target linking is only available for staging repositories".to_string(),
+        ));
+    }
+
+    match req.release_repository_key {
+        Some(release_key) => {
+            let release_repo = repo_service.get_by_key(&release_key).await.map_err(|_| {
+                AppError::Validation(format!("Release repository '{}' not found", release_key))
+            })?;
+
+            validate_release_target_link(&staging_repo, &release_repo)?;
+
+            // Store the link in repository_config
+            sqlx::query(
+                "INSERT INTO repository_config (repository_id, key, value) \
+                 VALUES ($1, 'release_repository_id', $2) \
+                 ON CONFLICT (repository_id, key) DO UPDATE SET value = $2, updated_at = NOW()",
+            )
+            .bind(staging_repo.id)
+            .bind(release_repo.id.to_string())
+            .execute(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            tracing::info!(
+                staging_repo = %repo_key,
+                release_repo = %release_key,
+                "Linked staging repository to release target"
+            );
+
+            Ok(Json(ReleaseTargetResponse {
+                linked: true,
+                release_repository_key: Some(release_key),
+                release_repository_id: Some(release_repo.id),
+            }))
+        }
+        None => {
+            // Remove the link
+            sqlx::query(
+                "DELETE FROM repository_config WHERE repository_id = $1 AND key = 'release_repository_id'",
+            )
+            .bind(staging_repo.id)
+            .execute(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            tracing::info!(
+                staging_repo = %repo_key,
+                "Removed release target link from staging repository"
+            );
+
+            Ok(Json(ReleaseTargetResponse {
+                linked: false,
+                release_repository_key: None,
+                release_repository_id: None,
+            }))
+        }
+    }
+}
+
+/// Validate that a release repository is a valid target for a staging repo link.
+pub fn validate_release_target_link(
+    staging: &crate::models::repository::Repository,
+    release: &crate::models::repository::Repository,
+) -> Result<()> {
+    if release.repo_type != RepositoryType::Local {
+        return Err(AppError::Validation(
+            "Release target must be a local repository".to_string(),
+        ));
+    }
+    if staging.format != release.format {
+        return Err(AppError::Validation(format!(
+            "Format mismatch: staging repository is {:?}, release repository is {:?}. \
+             Both must use the same package format.",
+            staging.format, release.format
+        )));
+    }
+    if staging.id == release.id {
+        return Err(AppError::Validation(
+            "A staging repository cannot be linked to itself".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(OpenApi)]
 #[openapi(
     paths(
@@ -805,6 +1132,8 @@ pub async fn promotion_history(
         promote_artifacts_bulk,
         reject_artifact,
         promotion_history,
+        get_release_target,
+        set_release_target,
     ),
     components(schemas(
         PromoteArtifactRequest,
@@ -817,6 +1146,8 @@ pub async fn promotion_history(
         PromotionHistoryQuery,
         PromotionHistoryEntry,
         PromotionHistoryResponse,
+        ReleaseTargetResponse,
+        SetReleaseTargetRequest,
     ))
 )]
 pub struct PromotionApiDoc;
@@ -1418,7 +1749,7 @@ mod tests {
             "notes": "Promoted after review"
         });
         let req: PromoteArtifactRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.target_repository, "release-maven");
+        assert_eq!(req.target_repository, Some("release-maven".to_string()));
         assert!(!req.skip_policy_check);
         assert_eq!(req.notes, Some("Promoted after review".to_string()));
     }
@@ -1435,6 +1766,16 @@ mod tests {
     }
 
     #[test]
+    fn test_promote_artifact_request_no_target() {
+        let json = serde_json::json!({
+            "skip_policy_check": false
+        });
+        let req: PromoteArtifactRequest = serde_json::from_value(json).unwrap();
+        assert!(req.target_repository.is_none());
+        assert!(!req.skip_policy_check);
+    }
+
+    #[test]
     fn test_bulk_promote_request_deserialization() {
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();
@@ -1444,10 +1785,21 @@ mod tests {
             "notes": "Bulk promotion"
         });
         let req: BulkPromoteRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.target_repository, "releases");
+        assert_eq!(req.target_repository, Some("releases".to_string()));
         assert_eq!(req.artifact_ids.len(), 2);
         assert!(!req.skip_policy_check);
         assert_eq!(req.notes, Some("Bulk promotion".to_string()));
+    }
+
+    #[test]
+    fn test_bulk_promote_request_no_target() {
+        let id1 = Uuid::new_v4();
+        let json = serde_json::json!({
+            "artifact_ids": [id1]
+        });
+        let req: BulkPromoteRequest = serde_json::from_value(json).unwrap();
+        assert!(req.target_repository.is_none());
+        assert_eq!(req.artifact_ids.len(), 1);
     }
 
     #[test]
@@ -1493,5 +1845,154 @@ mod tests {
         assert_eq!(query.per_page, Some(50));
         assert_eq!(query.artifact_id, Some(art_id));
         assert_eq!(query.status, Some("promoted".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_release_target_link
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_release_target_link_valid() {
+        let staging = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Maven,
+        );
+        let release = make_repo(
+            RepositoryType::Local,
+            crate::models::repository::RepositoryFormat::Maven,
+        );
+        assert!(validate_release_target_link(&staging, &release).is_ok());
+    }
+
+    #[test]
+    fn test_validate_release_target_link_target_not_local() {
+        let staging = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Maven,
+        );
+        let remote = make_repo(
+            RepositoryType::Remote,
+            crate::models::repository::RepositoryFormat::Maven,
+        );
+        let err = validate_release_target_link(&staging, &remote).unwrap_err();
+        assert!(err.to_string().contains("local"));
+    }
+
+    #[test]
+    fn test_validate_release_target_link_target_staging() {
+        let staging1 = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Npm,
+        );
+        let staging2 = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Npm,
+        );
+        let err = validate_release_target_link(&staging1, &staging2).unwrap_err();
+        assert!(err.to_string().contains("local"));
+    }
+
+    #[test]
+    fn test_validate_release_target_link_format_mismatch() {
+        let staging = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Maven,
+        );
+        let release = make_repo(
+            RepositoryType::Local,
+            crate::models::repository::RepositoryFormat::Npm,
+        );
+        let err = validate_release_target_link(&staging, &release).unwrap_err();
+        assert!(err.to_string().contains("Format mismatch"));
+    }
+
+    #[test]
+    fn test_validate_release_target_link_same_repo() {
+        let staging = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Pypi,
+        );
+        let mut release = staging.clone();
+        release.repo_type = RepositoryType::Local;
+        // They share the same ID because release was cloned from staging.
+        let err = validate_release_target_link(&staging, &release).unwrap_err();
+        assert!(err.to_string().contains("itself"));
+    }
+
+    #[test]
+    fn test_validate_release_target_link_virtual_target() {
+        let staging = make_repo(
+            RepositoryType::Staging,
+            crate::models::repository::RepositoryFormat::Docker,
+        );
+        let virtual_repo = make_repo(
+            RepositoryType::Virtual,
+            crate::models::repository::RepositoryFormat::Docker,
+        );
+        let err = validate_release_target_link(&staging, &virtual_repo).unwrap_err();
+        assert!(err.to_string().contains("local"));
+    }
+
+    // -----------------------------------------------------------------------
+    // ReleaseTargetResponse serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_release_target_response_linked() {
+        let id = Uuid::new_v4();
+        let resp = ReleaseTargetResponse {
+            linked: true,
+            release_repository_key: Some("release-maven".to_string()),
+            release_repository_id: Some(id),
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["linked"], true);
+        assert_eq!(json["release_repository_key"], "release-maven");
+        assert_eq!(json["release_repository_id"], id.to_string());
+    }
+
+    #[test]
+    fn test_release_target_response_not_linked() {
+        let resp = ReleaseTargetResponse {
+            linked: false,
+            release_repository_key: None,
+            release_repository_id: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["linked"], false);
+        assert!(json["release_repository_key"].is_null());
+        assert!(json["release_repository_id"].is_null());
+    }
+
+    // -----------------------------------------------------------------------
+    // SetReleaseTargetRequest deserialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_set_release_target_request_with_key() {
+        let json = serde_json::json!({
+            "release_repository_key": "releases-maven"
+        });
+        let req: SetReleaseTargetRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            req.release_repository_key,
+            Some("releases-maven".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_release_target_request_null_key() {
+        let json = serde_json::json!({
+            "release_repository_key": null
+        });
+        let req: SetReleaseTargetRequest = serde_json::from_value(json).unwrap();
+        assert!(req.release_repository_key.is_none());
+    }
+
+    #[test]
+    fn test_set_release_target_request_empty() {
+        let json = serde_json::json!({});
+        let req: SetReleaseTargetRequest = serde_json::from_value(json).unwrap();
+        assert!(req.release_repository_key.is_none());
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -231,6 +231,12 @@ pub struct UpdateRepositoryRequest {
     /// Quarantine hold duration in minutes for this repository.
     /// Stored in `repository_config` under `quarantine_duration_minutes`.
     pub quarantine_duration_minutes: Option<i64>,
+    /// Link this staging repository to a release (local) repository.
+    /// Promotions from this staging repo will default to the linked release repo,
+    /// and promotions to any other repo will be rejected.
+    /// Pass an empty string to remove the link.
+    /// Stored in `repository_config` under `release_repository_id`.
+    pub release_repository_key: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -839,6 +845,40 @@ pub async fn update_repository(
             &duration.to_string(),
         )
         .await?;
+    }
+
+    // Handle release repository linking for staging repos
+    if let Some(ref release_key) = payload.release_repository_key {
+        if release_key.is_empty() {
+            // Remove the link
+            sqlx::query(
+                "DELETE FROM repository_config WHERE repository_id = $1 AND key = 'release_repository_id'",
+            )
+            .bind(repo.id)
+            .execute(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        } else {
+            if repo.repo_type != RepositoryType::Staging {
+                return Err(AppError::Validation(
+                    "Release target linking is only available for staging repositories".to_string(),
+                ));
+            }
+
+            let release_repo = service.get_by_key(release_key).await.map_err(|_| {
+                AppError::Validation(format!("Release repository '{}' not found", release_key))
+            })?;
+
+            super::promotion::validate_release_target_link(&repo, &release_repo)?;
+
+            upsert_repo_config(
+                &state.db,
+                repo.id,
+                "release_repository_id",
+                &release_repo.id.to_string(),
+            )
+            .await?;
+        }
     }
 
     let storage_used = service.get_storage_usage(repo.id).await?;
@@ -2978,6 +3018,24 @@ mod tests {
         assert!(req.description.is_none());
         assert!(req.is_public.is_none());
         assert!(req.quota_bytes.is_none());
+        assert!(req.release_repository_key.is_none());
+    }
+
+    #[test]
+    fn test_update_repository_request_with_release_key() {
+        let json = r#"{"release_repository_key": "release-maven"}"#;
+        let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            req.release_repository_key,
+            Some("release-maven".to_string())
+        );
+    }
+
+    #[test]
+    fn test_update_repository_request_clear_release_key() {
+        let json = r#"{"release_repository_key": ""}"#;
+        let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.release_repository_key, Some(String::new()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Introduces explicit linkage between staging and release repositories, addressing #685. Once a staging repository is linked to a release (local) repository, promotions default to the linked target. Promotions to any other repository are rejected when a link is configured, preventing accidental promotion to the wrong destination.

**Key changes:**
- New API endpoints: `PUT` and `GET` on `/api/v1/promotion/repositories/{key}/release-target` to set and view the release target link
- The link is stored as `release_repository_id` in the `repository_config` table (key-value config per repository)
- `target_repository` on `PromoteArtifactRequest` and `BulkPromoteRequest` is now optional; when omitted, the linked release target is used
- Enforcement: when a link exists, promotions to any other repository are rejected with a clear error
- `UpdateRepositoryRequest` gains a `release_repository_key` field, so the link can also be set via `PATCH /api/v1/repositories/{key}`
- Validation: the release repo must exist, be type Local, share the same package format, and not be the staging repo itself

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes