### PR TITLE
feat: add notification subscriptions for repository events

### DIFF
--- a/backend/migrations/078_notification_subscriptions.sql
+++ b/backend/migrations/078_notification_subscriptions.sql
@@ -1,0 +1,16 @@
+-- Notification subscriptions for repository-scoped and global event notifications.
+-- Supports email and webhook delivery channels with configurable event type filters.
+CREATE TABLE notification_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repository_id UUID REFERENCES repositories(id) ON DELETE CASCADE,
+    channel VARCHAR(50) NOT NULL CHECK (channel IN ('email', 'webhook')),
+    event_types TEXT[] NOT NULL DEFAULT '{}',
+    config JSONB NOT NULL DEFAULT '{}',
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_notification_subs_repo ON notification_subscriptions(repository_id) WHERE repository_id IS NOT NULL;
+CREATE INDEX idx_notification_subs_enabled ON notification_subscriptions(enabled) WHERE enabled = true;

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -53,6 +53,7 @@ pub mod lifecycle;
 pub mod maven;
 pub mod migration;
 pub mod monitoring;
+pub mod notifications;
 pub mod npm;
 pub mod nuget;
 pub mod oci_v2;

--- a/backend/src/api/handlers/notifications.rs
+++ b/backend/src/api/handlers/notifications.rs
@@ -1,0 +1,614 @@
+//! Repository notification subscription handlers.
+//!
+//! Allows repository administrators to create, list, and delete notification
+//! subscriptions scoped to a repository. Each subscription specifies a delivery
+//! channel (email or webhook), a set of event types to listen for, and
+//! channel-specific configuration (recipient addresses, webhook URLs, etc.).
+
+use axum::{
+    extract::{Path, State},
+    routing::get,
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use utoipa::{OpenApi, ToSchema};
+use uuid::Uuid;
+
+use crate::api::middleware::auth::AuthExtension;
+use crate::api::SharedState;
+use crate::error::{AppError, Result};
+use crate::services::repository_service::RepositoryService;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/// Routes nested under /api/v1/repositories/:key/notifications
+pub fn repo_notifications_router() -> Router<SharedState> {
+    Router::new()
+        .route(
+            "/:key/notifications",
+            get(list_subscriptions).post(create_subscription),
+        )
+        .route(
+            "/:key/notifications/:subscription_id",
+            axum::routing::delete(delete_subscription),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+/// Supported notification delivery channels.
+pub const VALID_CHANNELS: &[&str] = &["email", "webhook"];
+
+/// Event types that can trigger notifications.
+pub const VALID_EVENT_TYPES: &[&str] = &[
+    "artifact.uploaded",
+    "artifact.deleted",
+    "scan.completed",
+    "scan.vulnerability_found",
+    "repository.updated",
+    "repository.deleted",
+    "build.completed",
+    "build.failed",
+];
+
+/// Request to create a notification subscription on a repository.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateNotificationSubscriptionRequest {
+    /// Delivery channel: "email" or "webhook".
+    pub channel: String,
+    /// Event types that trigger this notification (e.g. "artifact.uploaded").
+    pub event_types: Vec<String>,
+    /// Channel-specific configuration.
+    /// For email: `{"recipients": ["admin@example.com"]}`.
+    /// For webhook: `{"url": "https://hooks.example.com/notify", "secret": "..."}`.
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+}
+
+/// A notification subscription record.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct NotificationSubscriptionResponse {
+    pub id: Uuid,
+    pub repository_id: Option<Uuid>,
+    pub channel: String,
+    pub event_types: Vec<String>,
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+    pub enabled: bool,
+    pub created_by: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// List of notification subscriptions on a repository.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct NotificationSubscriptionListResponse {
+    pub items: Vec<NotificationSubscriptionResponse>,
+}
+
+// ---------------------------------------------------------------------------
+// Pure validation helpers
+// ---------------------------------------------------------------------------
+
+/// Validate that the channel is one of the supported values.
+pub(crate) fn validate_channel(channel: &str) -> Result<()> {
+    if VALID_CHANNELS.contains(&channel) {
+        Ok(())
+    } else {
+        Err(AppError::Validation(format!(
+            "Invalid channel '{}'. Must be one of: {}",
+            channel,
+            VALID_CHANNELS.join(", ")
+        )))
+    }
+}
+
+/// Validate that all event types are recognized.
+pub(crate) fn validate_event_types(event_types: &[String]) -> Result<()> {
+    if event_types.is_empty() {
+        return Err(AppError::Validation(
+            "At least one event type is required".to_string(),
+        ));
+    }
+    for et in event_types {
+        if !VALID_EVENT_TYPES.contains(&et.as_str()) {
+            return Err(AppError::Validation(format!(
+                "Unknown event type '{}'. Valid types: {}",
+                et,
+                VALID_EVENT_TYPES.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate channel-specific config fields.
+pub(crate) fn validate_config(channel: &str, config: &serde_json::Value) -> Result<()> {
+    match channel {
+        "email" => {
+            let recipients = config
+                .get("recipients")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| {
+                    AppError::Validation(
+                        "Email config must include a 'recipients' array".to_string(),
+                    )
+                })?;
+            if recipients.is_empty() {
+                return Err(AppError::Validation(
+                    "At least one email recipient is required".to_string(),
+                ));
+            }
+            for r in recipients {
+                if r.as_str().map_or(true, |s| !s.contains('@')) {
+                    return Err(AppError::Validation(format!(
+                        "Invalid email recipient: {}",
+                        r
+                    )));
+                }
+            }
+            Ok(())
+        }
+        "webhook" => {
+            let url = config.get("url").and_then(|v| v.as_str()).ok_or_else(|| {
+                AppError::Validation("Webhook config must include a 'url' string".to_string())
+            })?;
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                return Err(AppError::Validation(
+                    "Webhook URL must start with http:// or https://".to_string(),
+                ));
+            }
+            Ok(())
+        }
+        _ => Err(AppError::Validation(format!(
+            "Unknown channel '{}'",
+            channel
+        ))),
+    }
+}
+
+/// Require that the request is authenticated with write access or admin.
+fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
+    let auth =
+        auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
+    if auth.is_admin {
+        return Ok(auth);
+    }
+    auth.require_scope("write:repositories")?;
+    Ok(auth)
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// List notification subscriptions for a repository.
+#[utoipa::path(
+    get,
+    path = "/{key}/notifications",
+    context_path = "/api/v1/repositories",
+    tag = "notifications",
+    params(("key" = String, Path, description = "Repository key")),
+    responses(
+        (status = 200, description = "List of notification subscriptions", body = NotificationSubscriptionListResponse),
+        (status = 401, description = "Not authenticated"),
+        (status = 404, description = "Repository not found"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_subscriptions(
+    State(state): State<SharedState>,
+    auth: Option<axum::extract::Extension<AuthExtension>>,
+    Path(key): Path<String>,
+) -> Result<Json<NotificationSubscriptionListResponse>> {
+    let _auth = require_repo_write(auth.map(|e| e.0))?;
+
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+
+    let rows = sqlx::query(
+        r#"
+        SELECT id, repository_id, channel, event_types, config, enabled,
+               created_by, created_at, updated_at
+        FROM notification_subscriptions
+        WHERE repository_id = $1
+        ORDER BY created_at DESC
+        "#,
+    )
+    .bind(repo.id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let items = rows
+        .into_iter()
+        .map(|row| NotificationSubscriptionResponse {
+            id: row.get("id"),
+            repository_id: row.get("repository_id"),
+            channel: row.get("channel"),
+            event_types: row.get("event_types"),
+            config: row.get("config"),
+            enabled: row.get("enabled"),
+            created_by: row.get("created_by"),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        })
+        .collect();
+
+    Ok(Json(NotificationSubscriptionListResponse { items }))
+}
+
+/// Create a notification subscription on a repository.
+#[utoipa::path(
+    post,
+    path = "/{key}/notifications",
+    context_path = "/api/v1/repositories",
+    tag = "notifications",
+    params(("key" = String, Path, description = "Repository key")),
+    request_body = CreateNotificationSubscriptionRequest,
+    responses(
+        (status = 201, description = "Subscription created", body = NotificationSubscriptionResponse),
+        (status = 400, description = "Validation error"),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 404, description = "Repository not found"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn create_subscription(
+    State(state): State<SharedState>,
+    auth: Option<axum::extract::Extension<AuthExtension>>,
+    Path(key): Path<String>,
+    Json(req): Json<CreateNotificationSubscriptionRequest>,
+) -> Result<(
+    axum::http::StatusCode,
+    Json<NotificationSubscriptionResponse>,
+)> {
+    let auth = require_repo_write(auth.map(|e| e.0))?;
+
+    validate_channel(&req.channel)?;
+    validate_event_types(&req.event_types)?;
+    validate_config(&req.channel, &req.config)?;
+
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+
+    sqlx::query(
+        r#"
+        INSERT INTO notification_subscriptions
+            (id, repository_id, channel, event_types, config, enabled, created_by, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, true, $6, $7, $7)
+        "#,
+    )
+    .bind(id)
+    .bind(repo.id)
+    .bind(&req.channel)
+    .bind(&req.event_types)
+    .bind(&req.config)
+    .bind(auth.user_id)
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let response = NotificationSubscriptionResponse {
+        id,
+        repository_id: Some(repo.id),
+        channel: req.channel,
+        event_types: req.event_types,
+        config: req.config,
+        enabled: true,
+        created_by: auth.user_id,
+        created_at: now,
+        updated_at: now,
+    };
+
+    Ok((axum::http::StatusCode::CREATED, Json(response)))
+}
+
+/// Delete a notification subscription from a repository.
+#[utoipa::path(
+    delete,
+    path = "/{key}/notifications/{subscription_id}",
+    context_path = "/api/v1/repositories",
+    tag = "notifications",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+        ("subscription_id" = Uuid, Path, description = "Subscription ID"),
+    ),
+    responses(
+        (status = 204, description = "Subscription deleted"),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 404, description = "Subscription or repository not found"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn delete_subscription(
+    State(state): State<SharedState>,
+    auth: Option<axum::extract::Extension<AuthExtension>>,
+    Path((key, subscription_id)): Path<(String, Uuid)>,
+) -> Result<axum::http::StatusCode> {
+    let _auth = require_repo_write(auth.map(|e| e.0))?;
+
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+
+    let result =
+        sqlx::query("DELETE FROM notification_subscriptions WHERE id = $1 AND repository_id = $2")
+            .bind(subscription_id)
+            .bind(repo.id)
+            .execute(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(
+            "Notification subscription not found".to_string(),
+        ));
+    }
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// OpenAPI
+// ---------------------------------------------------------------------------
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        list_subscriptions,
+        create_subscription,
+        delete_subscription,
+    ),
+    components(schemas(
+        CreateNotificationSubscriptionRequest,
+        NotificationSubscriptionResponse,
+        NotificationSubscriptionListResponse,
+    )),
+    tags(
+        (name = "notifications", description = "Repository notification subscription management"),
+    )
+)]
+pub struct NotificationsApiDoc;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // validate_channel
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_channel_email() {
+        assert!(validate_channel("email").is_ok());
+    }
+
+    #[test]
+    fn test_validate_channel_webhook() {
+        assert!(validate_channel("webhook").is_ok());
+    }
+
+    #[test]
+    fn test_validate_channel_invalid() {
+        let err = validate_channel("sms").unwrap_err();
+        assert!(err.to_string().contains("Invalid channel"));
+    }
+
+    #[test]
+    fn test_validate_channel_empty() {
+        assert!(validate_channel("").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_event_types
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_event_types_valid() {
+        let types = vec![
+            "artifact.uploaded".to_string(),
+            "scan.completed".to_string(),
+        ];
+        assert!(validate_event_types(&types).is_ok());
+    }
+
+    #[test]
+    fn test_validate_event_types_empty() {
+        let err = validate_event_types(&[]).unwrap_err();
+        assert!(err.to_string().contains("At least one event type"));
+    }
+
+    #[test]
+    fn test_validate_event_types_unknown() {
+        let types = vec!["artifact.uploaded".to_string(), "unknown.event".to_string()];
+        let err = validate_event_types(&types).unwrap_err();
+        assert!(err.to_string().contains("Unknown event type"));
+    }
+
+    #[test]
+    fn test_validate_event_types_all_valid() {
+        let types: Vec<String> = VALID_EVENT_TYPES.iter().map(|s| s.to_string()).collect();
+        assert!(validate_event_types(&types).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_config - email
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_config_email_valid() {
+        let config = serde_json::json!({"recipients": ["admin@example.com"]});
+        assert!(validate_config("email", &config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_email_multiple_recipients() {
+        let config = serde_json::json!({"recipients": ["a@b.com", "c@d.com"]});
+        assert!(validate_config("email", &config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_email_missing_recipients() {
+        let config = serde_json::json!({});
+        let err = validate_config("email", &config).unwrap_err();
+        assert!(err.to_string().contains("recipients"));
+    }
+
+    #[test]
+    fn test_validate_config_email_empty_recipients() {
+        let config = serde_json::json!({"recipients": []});
+        let err = validate_config("email", &config).unwrap_err();
+        assert!(err.to_string().contains("At least one email recipient"));
+    }
+
+    #[test]
+    fn test_validate_config_email_invalid_address() {
+        let config = serde_json::json!({"recipients": ["not-an-email"]});
+        let err = validate_config("email", &config).unwrap_err();
+        assert!(err.to_string().contains("Invalid email recipient"));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_config - webhook
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_config_webhook_valid_https() {
+        let config = serde_json::json!({"url": "https://hooks.example.com/notify"});
+        assert!(validate_config("webhook", &config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_webhook_valid_http() {
+        let config = serde_json::json!({"url": "http://internal.example.com/hook"});
+        assert!(validate_config("webhook", &config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_webhook_missing_url() {
+        let config = serde_json::json!({});
+        let err = validate_config("webhook", &config).unwrap_err();
+        assert!(err.to_string().contains("url"));
+    }
+
+    #[test]
+    fn test_validate_config_webhook_invalid_url() {
+        let config = serde_json::json!({"url": "ftp://invalid.com"});
+        let err = validate_config("webhook", &config).unwrap_err();
+        assert!(err.to_string().contains("http://"));
+    }
+
+    #[test]
+    fn test_validate_config_webhook_with_secret() {
+        let config = serde_json::json!({
+            "url": "https://hooks.example.com/notify",
+            "secret": "my-secret-value"
+        });
+        assert!(validate_config("webhook", &config).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_config - unknown channel
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_config_unknown_channel() {
+        let config = serde_json::json!({});
+        assert!(validate_config("sms", &config).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Constants coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_valid_channels_contains_expected() {
+        assert!(VALID_CHANNELS.contains(&"email"));
+        assert!(VALID_CHANNELS.contains(&"webhook"));
+        assert_eq!(VALID_CHANNELS.len(), 2);
+    }
+
+    #[test]
+    fn test_valid_event_types_not_empty() {
+        assert!(!VALID_EVENT_TYPES.is_empty());
+        assert!(VALID_EVENT_TYPES.len() >= 8);
+    }
+
+    #[test]
+    fn test_valid_event_types_contain_core_events() {
+        assert!(VALID_EVENT_TYPES.contains(&"artifact.uploaded"));
+        assert!(VALID_EVENT_TYPES.contains(&"artifact.deleted"));
+        assert!(VALID_EVENT_TYPES.contains(&"scan.completed"));
+        assert!(VALID_EVENT_TYPES.contains(&"scan.vulnerability_found"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Response serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_subscription_response_serializes() {
+        let resp = NotificationSubscriptionResponse {
+            id: Uuid::nil(),
+            repository_id: Some(Uuid::nil()),
+            channel: "email".to_string(),
+            event_types: vec!["artifact.uploaded".to_string()],
+            config: serde_json::json!({"recipients": ["admin@example.com"]}),
+            enabled: true,
+            created_by: Uuid::nil(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("email"));
+        assert!(json.contains("artifact.uploaded"));
+        assert!(json.contains("admin@example.com"));
+    }
+
+    #[test]
+    fn test_list_response_serializes() {
+        let list = NotificationSubscriptionListResponse { items: vec![] };
+        let json = serde_json::to_string(&list).unwrap();
+        assert!(json.contains("items"));
+    }
+
+    #[test]
+    fn test_create_request_deserializes() {
+        let json = r#"{
+            "channel": "email",
+            "event_types": ["artifact.uploaded"],
+            "config": {"recipients": ["user@example.com"]}
+        }"#;
+        let req: CreateNotificationSubscriptionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.channel, "email");
+        assert_eq!(req.event_types.len(), 1);
+    }
+
+    #[test]
+    fn test_create_request_webhook_deserializes() {
+        let json = r#"{
+            "channel": "webhook",
+            "event_types": ["build.completed", "build.failed"],
+            "config": {"url": "https://hooks.example.com/notify"}
+        }"#;
+        let req: CreateNotificationSubscriptionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.channel, "webhook");
+        assert_eq!(req.event_types.len(), 2);
+    }
+}

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -159,6 +159,8 @@ pub fn router() -> Router<SharedState> {
         .merge(super::repository_labels::repo_labels_router())
         // Token management routes nested under repository
         .merge(super::repo_tokens::repo_tokens_router())
+        // Notification subscription routes nested under repository
+        .merge(super::notifications::repo_notifications_router())
 }
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -51,6 +51,7 @@ use utoipa::{Modify, OpenApi};
         (name = "service_accounts", description = "Service account management"),
         (name = "health", description = "Health and readiness checks"),
         (name = "system", description = "Public system configuration"),
+        (name = "notifications", description = "Repository notification subscriptions"),
     ),
     components(schemas(ErrorResponse))
 )]
@@ -136,6 +137,7 @@ pub fn build_openapi() -> utoipa::openapi::OpenApi {
     doc.merge(super::handlers::system_config::SystemConfigApiDoc::openapi());
     doc.merge(super::handlers::repo_tokens::RepoTokensApiDoc::openapi());
     doc.merge(super::handlers::smtp::SmtpApiDoc::openapi());
+    doc.merge(super::handlers::notifications::NotificationsApiDoc::openapi());
 
     doc
 }
@@ -395,6 +397,7 @@ mod tests {
                     include_str!("handlers/repository_labels.rs"),
                     include_str!("handlers/security.rs"),
                     include_str!("handlers/repo_tokens.rs"),
+                    include_str!("handlers/notifications.rs"),
                 ],
             ),
             (

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -393,6 +393,14 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         }
     }
 
+    // Start notification dispatcher (subscribes to EventBus for email/webhook delivery)
+    artifact_keeper_backend::services::notification_dispatcher::start_dispatcher(
+        app_state.event_bus.clone(),
+        app_state.db.clone(),
+        app_state.smtp_service.clone(),
+    );
+    tracing::info!("Notification dispatcher started");
+
     app_state
         .setup_required
         .store(setup_required, std::sync::atomic::Ordering::Relaxed);

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -23,6 +23,7 @@ pub mod metadata_checker;
 pub mod migration_service;
 pub mod migration_worker;
 pub mod nexus_client;
+pub mod notification_dispatcher;
 pub mod oidc_service;
 pub mod openscap_scanner;
 pub mod package_service;

--- a/backend/src/services/notification_dispatcher.rs
+++ b/backend/src/services/notification_dispatcher.rs
@@ -1,0 +1,352 @@
+//! Notification dispatcher service.
+//!
+//! Subscribes to the EventBus and dispatches matching notifications to the
+//! configured delivery channels (email via SmtpService, webhook via HTTP POST).
+//! Each incoming domain event is compared against the notification_subscriptions
+//! table. Subscriptions whose event_types array contains the event type (and
+//! whose repository_id matches, if set) trigger a delivery attempt.
+
+use std::sync::Arc;
+
+use sqlx::{PgPool, Row};
+use tokio::sync::broadcast;
+
+use crate::services::event_bus::{DomainEvent, EventBus};
+use crate::services::smtp_service::SmtpService;
+
+/// Maps a domain event type (e.g. "artifact.created") to the notification
+/// event type used in subscription filters (e.g. "artifact.uploaded").
+///
+/// The EventBus uses short-form event types while the notification system
+/// uses a slightly different naming convention. This function bridges
+/// between the two. Unrecognized event types are passed through unchanged.
+pub fn map_event_type(event_type: &str) -> &str {
+    match event_type {
+        "artifact.created" => "artifact.uploaded",
+        "artifact.uploaded" => "artifact.uploaded",
+        "artifact.deleted" => "artifact.deleted",
+        "scan.completed" => "scan.completed",
+        "scan.vulnerability_found" => "scan.vulnerability_found",
+        "repository.updated" => "repository.updated",
+        "repository.deleted" => "repository.deleted",
+        "build.completed" => "build.completed",
+        "build.failed" => "build.failed",
+        other => other,
+    }
+}
+
+/// Row type for notification subscription lookups.
+#[derive(Debug)]
+struct SubscriptionRow {
+    id: uuid::Uuid,
+    channel: String,
+    config: serde_json::Value,
+}
+
+/// Start the notification dispatcher background task.
+///
+/// This function spawns a tokio task that listens on the EventBus and, for
+/// each received event, queries matching subscriptions and delivers
+/// notifications. The task runs until the broadcast channel is closed (i.e.
+/// the EventBus is dropped).
+pub fn start_dispatcher(
+    event_bus: Arc<EventBus>,
+    db: PgPool,
+    smtp_service: Option<Arc<SmtpService>>,
+) {
+    let mut rx = event_bus.subscribe();
+
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if let Err(e) = dispatch_event(&db, &smtp_service, &event).await {
+                        tracing::warn!(
+                            event_type = %event.event_type,
+                            error = %e,
+                            "Failed to dispatch notification"
+                        );
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        skipped = n,
+                        "Notification dispatcher lagged, some events were dropped"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("EventBus closed, notification dispatcher shutting down");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Dispatch notifications for a single domain event.
+///
+/// Queries matching subscriptions (where event_types contains the mapped event
+/// type and the repository_id matches) and delivers via the appropriate channel.
+async fn dispatch_event(
+    db: &PgPool,
+    smtp_service: &Option<Arc<SmtpService>>,
+    event: &DomainEvent,
+) -> std::result::Result<(), String> {
+    let notification_event = map_event_type(&event.event_type);
+
+    // Try to parse entity_id as a UUID (repository ID). If it is not a valid
+    // UUID, the event does not carry a repository context and we only match
+    // global subscriptions (repository_id IS NULL).
+    let repo_id: Option<uuid::Uuid> = uuid::Uuid::parse_str(&event.entity_id).ok();
+
+    let rows = sqlx::query(
+        r#"
+        SELECT id, channel, config
+        FROM notification_subscriptions
+        WHERE enabled = true
+          AND $1 = ANY(event_types)
+          AND (repository_id IS NULL OR repository_id = $2)
+        "#,
+    )
+    .bind(notification_event)
+    .bind(repo_id)
+    .fetch_all(db)
+    .await
+    .map_err(|e| format!("Failed to query notification subscriptions: {}", e))?;
+
+    let subscriptions: Vec<SubscriptionRow> = rows
+        .into_iter()
+        .map(|row| SubscriptionRow {
+            id: row.get("id"),
+            channel: row.get("channel"),
+            config: row.get("config"),
+        })
+        .collect();
+
+    for sub in &subscriptions {
+        match sub.channel.as_str() {
+            "email" => {
+                deliver_email(smtp_service, event, &sub.config, sub.id).await;
+            }
+            "webhook" => {
+                deliver_webhook(event, &sub.config, sub.id).await;
+            }
+            other => {
+                tracing::warn!(
+                    subscription_id = %sub.id,
+                    channel = other,
+                    "Unknown notification channel, skipping"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Deliver a notification via email.
+async fn deliver_email(
+    smtp_service: &Option<Arc<SmtpService>>,
+    event: &DomainEvent,
+    config: &serde_json::Value,
+    subscription_id: uuid::Uuid,
+) {
+    let smtp = match smtp_service {
+        Some(s) if s.is_configured() => s,
+        _ => {
+            tracing::debug!(
+                subscription_id = %subscription_id,
+                "SMTP not configured, skipping email notification"
+            );
+            return;
+        }
+    };
+
+    let recipients = match config.get("recipients").and_then(|v| v.as_array()) {
+        Some(r) => r,
+        None => {
+            tracing::warn!(
+                subscription_id = %subscription_id,
+                "Email subscription has no recipients configured"
+            );
+            return;
+        }
+    };
+
+    let subject = format!(
+        "Artifact Keeper: {} ({})",
+        event.event_type, event.entity_id
+    );
+    let body_text = format!(
+        "Event: {}\nEntity: {}\nActor: {}\nTime: {}",
+        event.event_type,
+        event.entity_id,
+        event.actor.as_deref().unwrap_or("system"),
+        event.timestamp,
+    );
+    let body_html = format!(
+        "<h2>Artifact Keeper Notification</h2>\
+         <p><strong>Event:</strong> {}</p>\
+         <p><strong>Entity:</strong> {}</p>\
+         <p><strong>Actor:</strong> {}</p>\
+         <p><strong>Time:</strong> {}</p>",
+        event.event_type,
+        event.entity_id,
+        event.actor.as_deref().unwrap_or("system"),
+        event.timestamp,
+    );
+
+    for recipient_value in recipients {
+        if let Some(to) = recipient_value.as_str() {
+            if let Err(e) = smtp.send_email(to, &subject, &body_html, &body_text).await {
+                tracing::warn!(
+                    subscription_id = %subscription_id,
+                    recipient = to,
+                    error = %e,
+                    "Failed to send email notification"
+                );
+            }
+        }
+    }
+}
+
+/// Deliver a notification via webhook HTTP POST.
+async fn deliver_webhook(
+    event: &DomainEvent,
+    config: &serde_json::Value,
+    subscription_id: uuid::Uuid,
+) {
+    let url = match config.get("url").and_then(|v| v.as_str()) {
+        Some(u) => u,
+        None => {
+            tracing::warn!(
+                subscription_id = %subscription_id,
+                "Webhook subscription has no URL configured"
+            );
+            return;
+        }
+    };
+
+    let payload = serde_json::json!({
+        "event": event.event_type,
+        "entity_id": event.entity_id,
+        "actor": event.actor,
+        "timestamp": event.timestamp,
+    });
+
+    let client = match crate::services::http_client::base_client_builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                subscription_id = %subscription_id,
+                error = %e,
+                "Failed to build HTTP client for webhook delivery"
+            );
+            return;
+        }
+    };
+
+    let mut request = client.post(url).json(&payload);
+
+    // Add HMAC signature header if a secret is configured
+    if let Some(secret) = config.get("secret").and_then(|v| v.as_str()) {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        if let Ok(payload_bytes) = serde_json::to_vec(&payload) {
+            if let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) {
+                mac.update(&payload_bytes);
+                let signature = hex::encode(mac.finalize().into_bytes());
+                request = request.header("X-Signature-256", format!("sha256={}", signature));
+            }
+        }
+    }
+
+    match request.send().await {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            if !(200..300).contains(&status) {
+                tracing::warn!(
+                    subscription_id = %subscription_id,
+                    url = url,
+                    status = status,
+                    "Webhook notification delivery returned non-2xx status"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                subscription_id = %subscription_id,
+                url = url,
+                error = %e,
+                "Webhook notification delivery failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_event_type_artifact_created() {
+        assert_eq!(map_event_type("artifact.created"), "artifact.uploaded");
+    }
+
+    #[test]
+    fn test_map_event_type_artifact_uploaded() {
+        assert_eq!(map_event_type("artifact.uploaded"), "artifact.uploaded");
+    }
+
+    #[test]
+    fn test_map_event_type_artifact_deleted() {
+        assert_eq!(map_event_type("artifact.deleted"), "artifact.deleted");
+    }
+
+    #[test]
+    fn test_map_event_type_scan_completed() {
+        assert_eq!(map_event_type("scan.completed"), "scan.completed");
+    }
+
+    #[test]
+    fn test_map_event_type_scan_vulnerability() {
+        assert_eq!(
+            map_event_type("scan.vulnerability_found"),
+            "scan.vulnerability_found"
+        );
+    }
+
+    #[test]
+    fn test_map_event_type_repository_updated() {
+        assert_eq!(map_event_type("repository.updated"), "repository.updated");
+    }
+
+    #[test]
+    fn test_map_event_type_repository_deleted() {
+        assert_eq!(map_event_type("repository.deleted"), "repository.deleted");
+    }
+
+    #[test]
+    fn test_map_event_type_build_completed() {
+        assert_eq!(map_event_type("build.completed"), "build.completed");
+    }
+
+    #[test]
+    fn test_map_event_type_build_failed() {
+        assert_eq!(map_event_type("build.failed"), "build.failed");
+    }
+
+    #[test]
+    fn test_map_event_type_unknown_passthrough() {
+        assert_eq!(map_event_type("custom.event"), "custom.event");
+    }
+
+    #[test]
+    fn test_map_event_type_empty_string() {
+        assert_eq!(map_event_type(""), "");
+    }
+}

--- a/backend/src/services/notification_dispatcher.rs
+++ b/backend/src/services/notification_dispatcher.rs
@@ -144,6 +144,57 @@ async fn dispatch_event(
     Ok(())
 }
 
+/// Extract email recipient strings from subscription config.
+///
+/// Returns `None` if the config is missing a `recipients` array or if the
+/// array is empty. Non-string entries are silently skipped.
+pub fn parse_email_recipients(config: &serde_json::Value) -> Option<Vec<String>> {
+    let arr = config.get("recipients")?.as_array()?;
+    let recipients: Vec<String> = arr
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect();
+    if recipients.is_empty() {
+        None
+    } else {
+        Some(recipients)
+    }
+}
+
+/// Build the email subject line for a notification event.
+pub fn build_email_subject(event: &DomainEvent) -> String {
+    format!(
+        "Artifact Keeper: {} ({})",
+        event.event_type, event.entity_id
+    )
+}
+
+/// Build the plain-text email body for a notification event.
+pub fn build_email_body_text(event: &DomainEvent) -> String {
+    format!(
+        "Event: {}\nEntity: {}\nActor: {}\nTime: {}",
+        event.event_type,
+        event.entity_id,
+        event.actor.as_deref().unwrap_or("system"),
+        event.timestamp,
+    )
+}
+
+/// Build the HTML email body for a notification event.
+pub fn build_email_body_html(event: &DomainEvent) -> String {
+    format!(
+        "<h2>Artifact Keeper Notification</h2>\
+         <p><strong>Event:</strong> {}</p>\
+         <p><strong>Entity:</strong> {}</p>\
+         <p><strong>Actor:</strong> {}</p>\
+         <p><strong>Time:</strong> {}</p>",
+        event.event_type,
+        event.entity_id,
+        event.actor.as_deref().unwrap_or("system"),
+        event.timestamp,
+    )
+}
+
 /// Deliver a notification via email.
 async fn deliver_email(
     smtp_service: &Option<Arc<SmtpService>>,
@@ -162,7 +213,7 @@ async fn deliver_email(
         }
     };
 
-    let recipients = match config.get("recipients").and_then(|v| v.as_array()) {
+    let recipients = match parse_email_recipients(config) {
         Some(r) => r,
         None => {
             tracing::warn!(
@@ -173,41 +224,59 @@ async fn deliver_email(
         }
     };
 
-    let subject = format!(
-        "Artifact Keeper: {} ({})",
-        event.event_type, event.entity_id
-    );
-    let body_text = format!(
-        "Event: {}\nEntity: {}\nActor: {}\nTime: {}",
-        event.event_type,
-        event.entity_id,
-        event.actor.as_deref().unwrap_or("system"),
-        event.timestamp,
-    );
-    let body_html = format!(
-        "<h2>Artifact Keeper Notification</h2>\
-         <p><strong>Event:</strong> {}</p>\
-         <p><strong>Entity:</strong> {}</p>\
-         <p><strong>Actor:</strong> {}</p>\
-         <p><strong>Time:</strong> {}</p>",
-        event.event_type,
-        event.entity_id,
-        event.actor.as_deref().unwrap_or("system"),
-        event.timestamp,
-    );
+    let subject = build_email_subject(event);
+    let body_text = build_email_body_text(event);
+    let body_html = build_email_body_html(event);
 
-    for recipient_value in recipients {
-        if let Some(to) = recipient_value.as_str() {
-            if let Err(e) = smtp.send_email(to, &subject, &body_html, &body_text).await {
-                tracing::warn!(
-                    subscription_id = %subscription_id,
-                    recipient = to,
-                    error = %e,
-                    "Failed to send email notification"
-                );
-            }
+    for to in &recipients {
+        if let Err(e) = smtp.send_email(to, &subject, &body_html, &body_text).await {
+            tracing::warn!(
+                subscription_id = %subscription_id,
+                recipient = %to,
+                error = %e,
+                "Failed to send email notification"
+            );
         }
     }
+}
+
+/// Extract the webhook URL from subscription config.
+///
+/// Returns `None` if the config has no `url` string field.
+pub fn parse_webhook_url(config: &serde_json::Value) -> Option<String> {
+    config.get("url").and_then(|v| v.as_str()).map(String::from)
+}
+
+/// Build the JSON payload sent to a webhook endpoint.
+pub fn build_webhook_payload(event: &DomainEvent) -> serde_json::Value {
+    serde_json::json!({
+        "event": event.event_type,
+        "entity_id": event.entity_id,
+        "actor": event.actor,
+        "timestamp": event.timestamp,
+    })
+}
+
+/// Compute an HMAC-SHA256 signature for a webhook payload.
+///
+/// Returns the hex-encoded signature prefixed with `sha256=`, matching the
+/// format expected by the `X-Signature-256` header. Returns `None` if the
+/// payload cannot be serialized.
+pub fn compute_webhook_signature(payload: &serde_json::Value, secret: &str) -> Option<String> {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let payload_bytes = serde_json::to_vec(payload).ok()?;
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+    mac.update(&payload_bytes);
+    let signature = hex::encode(mac.finalize().into_bytes());
+    Some(format!("sha256={}", signature))
+}
+
+/// Determine whether a subscription channel name is one we know how to
+/// deliver to.
+pub fn is_known_channel(channel: &str) -> bool {
+    matches!(channel, "email" | "webhook")
 }
 
 /// Deliver a notification via webhook HTTP POST.
@@ -216,7 +285,7 @@ async fn deliver_webhook(
     config: &serde_json::Value,
     subscription_id: uuid::Uuid,
 ) {
-    let url = match config.get("url").and_then(|v| v.as_str()) {
+    let url = match parse_webhook_url(config) {
         Some(u) => u,
         None => {
             tracing::warn!(
@@ -227,12 +296,7 @@ async fn deliver_webhook(
         }
     };
 
-    let payload = serde_json::json!({
-        "event": event.event_type,
-        "entity_id": event.entity_id,
-        "actor": event.actor,
-        "timestamp": event.timestamp,
-    });
+    let payload = build_webhook_payload(event);
 
     let client = match crate::services::http_client::base_client_builder()
         .timeout(std::time::Duration::from_secs(10))
@@ -249,19 +313,12 @@ async fn deliver_webhook(
         }
     };
 
-    let mut request = client.post(url).json(&payload);
+    let mut request = client.post(&url).json(&payload);
 
     // Add HMAC signature header if a secret is configured
     if let Some(secret) = config.get("secret").and_then(|v| v.as_str()) {
-        use hmac::{Hmac, Mac};
-        use sha2::Sha256;
-
-        if let Ok(payload_bytes) = serde_json::to_vec(&payload) {
-            if let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) {
-                mac.update(&payload_bytes);
-                let signature = hex::encode(mac.finalize().into_bytes());
-                request = request.header("X-Signature-256", format!("sha256={}", signature));
-            }
+        if let Some(sig) = compute_webhook_signature(&payload, secret) {
+            request = request.header("X-Signature-256", sig);
         }
     }
 
@@ -271,7 +328,7 @@ async fn deliver_webhook(
             if !(200..300).contains(&status) {
                 tracing::warn!(
                     subscription_id = %subscription_id,
-                    url = url,
+                    url = %url,
                     status = status,
                     "Webhook notification delivery returned non-2xx status"
                 );
@@ -280,7 +337,7 @@ async fn deliver_webhook(
         Err(e) => {
             tracing::warn!(
                 subscription_id = %subscription_id,
-                url = url,
+                url = %url,
                 error = %e,
                 "Webhook notification delivery failed"
             );
@@ -291,6 +348,30 @@ async fn deliver_webhook(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Helper to build a test DomainEvent with all fields populated.
+    fn sample_event() -> DomainEvent {
+        DomainEvent {
+            event_type: "artifact.created".into(),
+            entity_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            actor: Some("alice".into()),
+            timestamp: "2026-04-08T12:00:00Z".into(),
+        }
+    }
+
+    /// Helper to build a DomainEvent with no actor.
+    fn sample_event_no_actor() -> DomainEvent {
+        DomainEvent {
+            event_type: "scan.completed".into(),
+            entity_id: "repo-key-abc".into(),
+            actor: None,
+            timestamp: "2026-04-08T13:00:00Z".into(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // map_event_type
+    // -----------------------------------------------------------------------
 
     #[test]
     fn test_map_event_type_artifact_created() {
@@ -348,5 +429,428 @@ mod tests {
     #[test]
     fn test_map_event_type_empty_string() {
         assert_eq!(map_event_type(""), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_email_recipients
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_email_recipients_valid() {
+        let config = serde_json::json!({"recipients": ["a@b.com", "c@d.com"]});
+        let result = parse_email_recipients(&config).unwrap();
+        assert_eq!(result, vec!["a@b.com", "c@d.com"]);
+    }
+
+    #[test]
+    fn test_parse_email_recipients_single() {
+        let config = serde_json::json!({"recipients": ["admin@example.com"]});
+        let result = parse_email_recipients(&config).unwrap();
+        assert_eq!(result, vec!["admin@example.com"]);
+    }
+
+    #[test]
+    fn test_parse_email_recipients_missing_key() {
+        let config = serde_json::json!({});
+        assert!(parse_email_recipients(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_email_recipients_not_array() {
+        let config = serde_json::json!({"recipients": "admin@example.com"});
+        assert!(parse_email_recipients(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_email_recipients_empty_array() {
+        let config = serde_json::json!({"recipients": []});
+        assert!(parse_email_recipients(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_email_recipients_skips_non_strings() {
+        let config = serde_json::json!({"recipients": [42, "valid@email.com", null]});
+        let result = parse_email_recipients(&config).unwrap();
+        assert_eq!(result, vec!["valid@email.com"]);
+    }
+
+    #[test]
+    fn test_parse_email_recipients_all_non_strings() {
+        let config = serde_json::json!({"recipients": [42, true, null]});
+        assert!(parse_email_recipients(&config).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // build_email_subject
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_email_subject_with_actor() {
+        let event = sample_event();
+        let subject = build_email_subject(&event);
+        assert_eq!(
+            subject,
+            "Artifact Keeper: artifact.created (550e8400-e29b-41d4-a716-446655440000)"
+        );
+    }
+
+    #[test]
+    fn test_build_email_subject_no_actor() {
+        let event = sample_event_no_actor();
+        let subject = build_email_subject(&event);
+        assert!(subject.contains("scan.completed"));
+        assert!(subject.contains("repo-key-abc"));
+    }
+
+    #[test]
+    fn test_build_email_subject_format() {
+        let event = DomainEvent {
+            event_type: "build.failed".into(),
+            entity_id: "build-42".into(),
+            actor: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+        };
+        let subject = build_email_subject(&event);
+        assert_eq!(subject, "Artifact Keeper: build.failed (build-42)");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_email_body_text
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_email_body_text_with_actor() {
+        let event = sample_event();
+        let body = build_email_body_text(&event);
+        assert!(body.contains("Event: artifact.created"));
+        assert!(body.contains("Entity: 550e8400-e29b-41d4-a716-446655440000"));
+        assert!(body.contains("Actor: alice"));
+        assert!(body.contains("Time: 2026-04-08T12:00:00Z"));
+    }
+
+    #[test]
+    fn test_build_email_body_text_no_actor_shows_system() {
+        let event = sample_event_no_actor();
+        let body = build_email_body_text(&event);
+        assert!(body.contains("Actor: system"));
+    }
+
+    #[test]
+    fn test_build_email_body_text_contains_newlines() {
+        let event = sample_event();
+        let body = build_email_body_text(&event);
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert!(lines[0].starts_with("Event:"));
+        assert!(lines[1].starts_with("Entity:"));
+        assert!(lines[2].starts_with("Actor:"));
+        assert!(lines[3].starts_with("Time:"));
+    }
+
+    // -----------------------------------------------------------------------
+    // build_email_body_html
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_email_body_html_with_actor() {
+        let event = sample_event();
+        let html = build_email_body_html(&event);
+        assert!(html.contains("<h2>Artifact Keeper Notification</h2>"));
+        assert!(html.contains("<strong>Event:</strong> artifact.created"));
+        assert!(html.contains("<strong>Actor:</strong> alice"));
+    }
+
+    #[test]
+    fn test_build_email_body_html_no_actor_shows_system() {
+        let event = sample_event_no_actor();
+        let html = build_email_body_html(&event);
+        assert!(html.contains("<strong>Actor:</strong> system"));
+    }
+
+    #[test]
+    fn test_build_email_body_html_contains_entity() {
+        let event = sample_event();
+        let html = build_email_body_html(&event);
+        assert!(html.contains("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_build_email_body_html_contains_timestamp() {
+        let event = sample_event();
+        let html = build_email_body_html(&event);
+        assert!(html.contains("2026-04-08T12:00:00Z"));
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_webhook_url
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_webhook_url_valid_https() {
+        let config = serde_json::json!({"url": "https://hooks.example.com/notify"});
+        assert_eq!(
+            parse_webhook_url(&config).unwrap(),
+            "https://hooks.example.com/notify"
+        );
+    }
+
+    #[test]
+    fn test_parse_webhook_url_valid_http() {
+        let config = serde_json::json!({"url": "http://internal.example.com/hook"});
+        assert_eq!(
+            parse_webhook_url(&config).unwrap(),
+            "http://internal.example.com/hook"
+        );
+    }
+
+    #[test]
+    fn test_parse_webhook_url_missing() {
+        let config = serde_json::json!({});
+        assert!(parse_webhook_url(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_webhook_url_not_string() {
+        let config = serde_json::json!({"url": 42});
+        assert!(parse_webhook_url(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_webhook_url_null() {
+        let config = serde_json::json!({"url": null});
+        assert!(parse_webhook_url(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_webhook_url_with_extra_fields() {
+        let config = serde_json::json!({
+            "url": "https://hooks.example.com/x",
+            "secret": "my-secret"
+        });
+        assert_eq!(
+            parse_webhook_url(&config).unwrap(),
+            "https://hooks.example.com/x"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // build_webhook_payload
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_webhook_payload_structure() {
+        let event = sample_event();
+        let payload = build_webhook_payload(&event);
+        assert_eq!(payload["event"], "artifact.created");
+        assert_eq!(payload["entity_id"], "550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(payload["actor"], "alice");
+        assert_eq!(payload["timestamp"], "2026-04-08T12:00:00Z");
+    }
+
+    #[test]
+    fn test_build_webhook_payload_no_actor() {
+        let event = sample_event_no_actor();
+        let payload = build_webhook_payload(&event);
+        assert_eq!(payload["event"], "scan.completed");
+        assert!(payload["actor"].is_null());
+    }
+
+    #[test]
+    fn test_build_webhook_payload_is_valid_json() {
+        let event = sample_event();
+        let payload = build_webhook_payload(&event);
+        let serialized = serde_json::to_string(&payload).unwrap();
+        let reparsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(reparsed, payload);
+    }
+
+    #[test]
+    fn test_build_webhook_payload_has_four_fields() {
+        let event = sample_event();
+        let payload = build_webhook_payload(&event);
+        let obj = payload.as_object().unwrap();
+        assert_eq!(obj.len(), 4);
+        assert!(obj.contains_key("event"));
+        assert!(obj.contains_key("entity_id"));
+        assert!(obj.contains_key("actor"));
+        assert!(obj.contains_key("timestamp"));
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_webhook_signature
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_compute_webhook_signature_deterministic() {
+        let payload = serde_json::json!({"event": "test"});
+        let sig1 = compute_webhook_signature(&payload, "secret123").unwrap();
+        let sig2 = compute_webhook_signature(&payload, "secret123").unwrap();
+        assert_eq!(sig1, sig2);
+    }
+
+    #[test]
+    fn test_compute_webhook_signature_prefix() {
+        let payload = serde_json::json!({"event": "test"});
+        let sig = compute_webhook_signature(&payload, "key").unwrap();
+        assert!(sig.starts_with("sha256="));
+    }
+
+    #[test]
+    fn test_compute_webhook_signature_hex_length() {
+        let payload = serde_json::json!({"event": "test"});
+        let sig = compute_webhook_signature(&payload, "key").unwrap();
+        // "sha256=" (7 chars) + 64 hex chars (SHA-256 = 32 bytes = 64 hex)
+        assert_eq!(sig.len(), 7 + 64);
+    }
+
+    #[test]
+    fn test_compute_webhook_signature_different_secrets() {
+        let payload = serde_json::json!({"event": "test"});
+        let sig1 = compute_webhook_signature(&payload, "secret-a").unwrap();
+        let sig2 = compute_webhook_signature(&payload, "secret-b").unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn test_compute_webhook_signature_different_payloads() {
+        let p1 = serde_json::json!({"event": "a"});
+        let p2 = serde_json::json!({"event": "b"});
+        let sig1 = compute_webhook_signature(&p1, "same-key").unwrap();
+        let sig2 = compute_webhook_signature(&p2, "same-key").unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn test_compute_webhook_signature_empty_secret() {
+        let payload = serde_json::json!({"event": "test"});
+        // Empty secret should still work (HMAC accepts zero-length keys)
+        let sig = compute_webhook_signature(&payload, "");
+        assert!(sig.is_some());
+        assert!(sig.unwrap().starts_with("sha256="));
+    }
+
+    #[test]
+    fn test_compute_webhook_signature_complex_payload() {
+        let event = sample_event();
+        let payload = build_webhook_payload(&event);
+        let sig = compute_webhook_signature(&payload, "webhook-secret");
+        assert!(sig.is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // is_known_channel
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_known_channel_email() {
+        assert!(is_known_channel("email"));
+    }
+
+    #[test]
+    fn test_is_known_channel_webhook() {
+        assert!(is_known_channel("webhook"));
+    }
+
+    #[test]
+    fn test_is_known_channel_unknown() {
+        assert!(!is_known_channel("sms"));
+    }
+
+    #[test]
+    fn test_is_known_channel_empty() {
+        assert!(!is_known_channel(""));
+    }
+
+    #[test]
+    fn test_is_known_channel_case_sensitive() {
+        assert!(!is_known_channel("Email"));
+        assert!(!is_known_channel("WEBHOOK"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration: email body consistency
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_email_text_and_html_contain_same_data() {
+        let event = sample_event();
+        let text = build_email_body_text(&event);
+        let html = build_email_body_html(&event);
+
+        // Both should contain the same key fields
+        assert!(text.contains("artifact.created"));
+        assert!(html.contains("artifact.created"));
+
+        assert!(text.contains("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(html.contains("550e8400-e29b-41d4-a716-446655440000"));
+
+        assert!(text.contains("alice"));
+        assert!(html.contains("alice"));
+
+        assert!(text.contains("2026-04-08T12:00:00Z"));
+        assert!(html.contains("2026-04-08T12:00:00Z"));
+    }
+
+    #[test]
+    fn test_email_subject_and_body_reference_same_event() {
+        let event = sample_event();
+        let subject = build_email_subject(&event);
+        let body = build_email_body_text(&event);
+
+        // Subject and body should both reference the event type
+        assert!(subject.contains("artifact.created"));
+        assert!(body.contains("artifact.created"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration: webhook payload + signature round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_webhook_payload_and_signature_round_trip() {
+        let event = sample_event();
+        let payload = build_webhook_payload(&event);
+        let sig = compute_webhook_signature(&payload, "test-secret").unwrap();
+
+        // Verify the signature by recomputing it
+        let sig_again = compute_webhook_signature(&payload, "test-secret").unwrap();
+        assert_eq!(sig, sig_again);
+    }
+
+    #[test]
+    fn test_webhook_url_and_payload_for_sample_event() {
+        let config = serde_json::json!({
+            "url": "https://hooks.example.com/notify",
+            "secret": "my-secret"
+        });
+        let url = parse_webhook_url(&config).unwrap();
+        assert_eq!(url, "https://hooks.example.com/notify");
+
+        let event = sample_event();
+        let payload = build_webhook_payload(&event);
+        assert_eq!(payload["event"], "artifact.created");
+
+        let sig = compute_webhook_signature(&payload, "my-secret").unwrap();
+        assert!(sig.starts_with("sha256="));
+    }
+
+    // -----------------------------------------------------------------------
+    // map_event_type + payload integration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mapped_event_type_in_payload() {
+        let event = DomainEvent {
+            event_type: "artifact.created".into(),
+            entity_id: "abc".into(),
+            actor: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+        };
+        let mapped = map_event_type(&event.event_type);
+        assert_eq!(mapped, "artifact.uploaded");
+
+        // The payload uses the raw event type, not the mapped one
+        let payload = build_webhook_payload(&event);
+        assert_eq!(payload["event"], "artifact.created");
     }
 }


### PR DESCRIPTION
## Summary

Implements per-repository notification subscriptions (#686), allowing repository administrators to receive email or webhook notifications when events occur (artifact uploads, deletions, scan completions, etc.).

- **Migration 078**: Creates `notification_subscriptions` table with columns for `repository_id` (nullable FK for global subscriptions), `channel` (email/webhook), `event_types` (TEXT[]), `config` (JSONB), `enabled`, `created_by`, and timestamps. Includes indexes on repository_id and enabled.
- **CRUD endpoints**: `GET /api/v1/repositories/{key}/notifications`, `POST /api/v1/repositories/{key}/notifications`, `DELETE /api/v1/repositories/{key}/notifications/{subscription_id}`. Full input validation for channel, event types, and channel-specific config (email recipients, webhook URLs).
- **NotificationDispatcher service**: Background task that subscribes to the existing EventBus and dispatches matching notifications via SmtpService (email) or HTTP POST (webhook). Webhook deliveries include optional HMAC-SHA256 signatures when a secret is configured.
- **OpenAPI**: All endpoints annotated with utoipa, schemas registered, tag added, handler sources registered in the spec validation test.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)

Closes #686