### PR TITLE
fix: propagate scanner errors instead of returning empty findings

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -370,12 +370,83 @@ fn pgp_clearsign(content: &str, signature: &[u8]) -> String {
 // GET /debian/{repo_key}/dists/{distribution}/Release
 // ---------------------------------------------------------------------------
 
+/// Handles resolving a Debian repo and proxying dists metadata from
+/// upstream for remote repos. Captures the per-request context so each
+/// handler only needs to call `proxy.dists("suffix", "ct").await?`.
+struct DebianProxy<'a> {
+    state: &'a SharedState,
+    repo_key: &'a str,
+    distribution: &'a str,
+}
+
+impl<'a> DebianProxy<'a> {
+    async fn resolve(
+        state: &'a SharedState,
+        repo_key: &'a str,
+        distribution: &'a str,
+    ) -> Result<(Self, RepoInfo), Response> {
+        let repo = resolve_debian_repo(&state.db, repo_key).await?;
+        Ok((
+            Self {
+                state,
+                repo_key,
+                distribution,
+            },
+            repo,
+        ))
+    }
+
+    async fn dists(
+        &self,
+        suffix: &str,
+        content_type: &'static str,
+        repo: &RepoInfo,
+    ) -> Result<(), Response> {
+        if repo.repo_type != RepositoryType::Remote {
+            return Ok(());
+        }
+        let (upstream_url, proxy) = match (&repo.upstream_url, &self.state.proxy_service) {
+            (Some(u), Some(p)) => (u, p),
+            _ => return Ok(()),
+        };
+        let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+        let (content, upstream_ct) =
+            proxy_helpers::proxy_fetch(proxy, repo.id, self.repo_key, upstream_url, &upstream_path)
+                .await?;
+        Err(Response::builder()
+            .status(StatusCode::OK)
+            .header(
+                CONTENT_TYPE,
+                upstream_ct.unwrap_or_else(|| content_type.to_string()),
+            )
+            .header(CONTENT_LENGTH, content.len().to_string())
+            .body(Body::from(content))
+            .unwrap())
+    }
+}
+
+/// Generate the Release content locally (shared by Release, InRelease,
+/// and Release.gpg handlers). Returns the text and the repo for signing.
+async fn local_release_content(
+    state: &SharedState,
+    repo_key: &str,
+    distribution: &str,
+) -> Result<(String, RepoInfo), Response> {
+    let repo = resolve_debian_repo(&state.db, repo_key).await?;
+    let release = generate_release_content(state, repo.id, distribution).await?;
+    Ok((release, repo))
+}
+
 async fn release_file(
     State(state): State<SharedState>,
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
-    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
-    let release = generate_release_content(&state, repo.id, &distribution).await?;
+    let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    proxy
+        .dists("Release", "text/plain; charset=utf-8", &repo)
+        .await?;
+
+    let (release, _) = local_release_content(&state, &repo_key, &distribution).await?;
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -392,10 +463,13 @@ async fn in_release_file(
     State(state): State<SharedState>,
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
-    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
-    let release = generate_release_content(&state, repo.id, &distribution).await?;
+    let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    proxy
+        .dists("InRelease", "text/plain; charset=utf-8", &repo)
+        .await?;
 
-    // Attempt to sign the release content
+    let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
+
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
     let signature = signing_svc
         .sign_data(repo.id, release.as_bytes())
@@ -422,8 +496,12 @@ async fn release_gpg(
     State(state): State<SharedState>,
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
-    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
-    let release = generate_release_content(&state, repo.id, &distribution).await?;
+    let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    proxy
+        .dists("Release.gpg", "application/pgp-signature", &repo)
+        .await?;
+
+    let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
     let signature = signing_svc
@@ -490,9 +568,13 @@ async fn gpg_key_asc(
 
 async fn packages_index(
     State(state): State<SharedState>,
-    Path((repo_key, _distribution, component, binary_arch)): Path<(String, String, String, String)>,
+    Path((repo_key, distribution, component, binary_arch)): Path<(String, String, String, String)>,
 ) -> Result<Response, Response> {
-    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+    let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    let packages_suffix = format!("{}/{}/Packages", component, binary_arch);
+    proxy
+        .dists(&packages_suffix, "text/plain; charset=utf-8", &repo)
+        .await?;
 
     // binary_arch is like "binary-amd64", strip the "binary-" prefix
     let arch = binary_arch.strip_prefix("binary-").unwrap_or(&binary_arch);
@@ -514,9 +596,13 @@ async fn packages_index(
 
 async fn packages_index_gz(
     State(state): State<SharedState>,
-    Path((repo_key, _distribution, component, binary_arch)): Path<(String, String, String, String)>,
+    Path((repo_key, distribution, component, binary_arch)): Path<(String, String, String, String)>,
 ) -> Result<Response, Response> {
-    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+    let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    let packages_gz_suffix = format!("{}/{}/Packages.gz", component, binary_arch);
+    proxy
+        .dists(&packages_gz_suffix, "application/gzip", &repo)
+        .await?;
 
     let arch = binary_arch.strip_prefix("binary-").unwrap_or(&binary_arch);
 
@@ -1187,5 +1273,64 @@ mod tests {
         let sig = b"sig";
         let result = pgp_clearsign(content, sig);
         assert!(result.contains("Line 1\nLine 2\nLine 3\n"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Upstream path construction for APT remote proxy (#674)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_upstream_dists_paths_match_debian_mirror_layout() {
+        // All five metadata endpoints build upstream paths via
+        // try_proxy_dists_file(state, repo, key, dist, suffix, ct).
+        // The path is always "dists/{dist}/{suffix}". Verify the
+        // expected paths match the real Debian/Ubuntu mirror layout.
+        let cases = vec![
+            ("trixie", "Release", "dists/trixie/Release"),
+            ("trixie-updates", "Release", "dists/trixie-updates/Release"),
+            ("bookworm", "InRelease", "dists/bookworm/InRelease"),
+            (
+                "bookworm-security",
+                "InRelease",
+                "dists/bookworm-security/InRelease",
+            ),
+            ("trixie", "Release.gpg", "dists/trixie/Release.gpg"),
+            (
+                "trixie",
+                "main/binary-amd64/Packages",
+                "dists/trixie/main/binary-amd64/Packages",
+            ),
+            (
+                "trixie",
+                "non-free/binary-arm64/Packages",
+                "dists/trixie/non-free/binary-arm64/Packages",
+            ),
+            (
+                "trixie",
+                "main/binary-amd64/Packages.gz",
+                "dists/trixie/main/binary-amd64/Packages.gz",
+            ),
+        ];
+        for (dist, suffix, expected) in &cases {
+            let path = format!("dists/{}/{}", dist, suffix);
+            assert_eq!(
+                &path, expected,
+                "path mismatch for dist={}, suffix={}",
+                dist, suffix
+            );
+        }
+    }
+
+    #[test]
+    fn test_upstream_url_assembly_matches_debian_org() {
+        // Full URL assembly: upstream_url + "/" + dists path must point at
+        // the real Debian mirror.
+        let upstream = "http://deb.debian.org/debian";
+        let path = format!("dists/{}/{}", "trixie", "InRelease");
+        let full_url = format!("{}/{}", upstream.trim_end_matches('/'), path);
+        assert_eq!(
+            full_url,
+            "http://deb.debian.org/debian/dists/trixie/InRelease"
+        );
     }
 }

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -291,12 +291,12 @@ impl Scanner for GrypeScanner {
         let report = match self.run_grype(&workspace).await {
             Ok(report) => report,
             Err(e) => {
-                warn!(
-                    "Grype scan failed for {}: {}. Returning empty findings.",
-                    artifact.name, e
-                );
+                warn!("Grype scan failed for {}: {}", artifact.name, e);
                 self.cleanup_workspace(artifact).await;
-                return Ok(vec![]);
+                return Err(AppError::Internal(format!(
+                    "Grype scan failed for {}: {}",
+                    artifact.name, e
+                )));
             }
         };
 
@@ -438,6 +438,57 @@ mod tests {
         let report = GrypeReport { matches: vec![] };
         let findings = GrypeScanner::convert_findings(&report);
         assert!(findings.is_empty());
+    }
+
+    /// When the scan workspace cannot be created, prepare_workspace fails
+    /// and the error propagates to the caller.
+    #[tokio::test]
+    async fn test_scan_returns_error_when_workspace_creation_fails() {
+        // Use a path under /dev/null which cannot contain subdirectories
+        let scanner = GrypeScanner::new("/dev/null/impossible-workspace".to_string());
+        let artifact = make_artifact("pkg-1.0.0.tar.gz", "application/gzip");
+        let content = Bytes::from_static(b"not a real archive");
+
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err when workspace creation fails"
+        );
+    }
+
+    /// When grype is not installed, the scanner must propagate the error
+    /// so the orchestrator records a failed scan instead of marking the
+    /// artifact as clean with 0 findings.
+    ///
+    /// Skipped when grype is installed, since it can legitimately scan
+    /// the raw file and return 0 findings.
+    #[tokio::test]
+    async fn test_scan_returns_error_when_grype_unavailable() {
+        if std::process::Command::new("grype")
+            .arg("version")
+            .output()
+            .is_ok()
+        {
+            eprintln!("grype is installed, skipping unavailable-grype test");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let scanner = GrypeScanner::new(dir.path().to_string_lossy().to_string());
+        let artifact = make_artifact("pkg-1.0.0.tar.gz", "application/gzip");
+        let content = Bytes::from_static(b"not a real archive");
+
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err when grype execution fails, not Ok(vec![])"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Grype scan failed"),
+            "error message should indicate grype failure, got: {}",
+            err_msg
+        );
     }
 
     #[test]

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -6,13 +6,13 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
-use tracing::{info, warn};
+use std::path::Path;
+use tracing::info;
 
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::models::security::{RawFinding, Severity};
-use crate::services::scanner_service::{sanitize_artifact_filename, Scanner};
+use crate::services::scanner_service::{fail_scan, ScanWorkspace, Scanner};
 
 // ---------------------------------------------------------------------------
 // Grype JSON output structures
@@ -71,136 +71,6 @@ pub struct GrypeScanner {
 impl GrypeScanner {
     pub fn new(scan_workspace: String) -> Self {
         Self { scan_workspace }
-    }
-
-    /// Build the workspace directory path for a given artifact.
-    fn workspace_dir(&self, artifact: &Artifact) -> PathBuf {
-        Path::new(&self.scan_workspace).join(artifact.id.to_string())
-    }
-
-    /// Prepare the scan workspace: write artifact content and extract archives.
-    async fn prepare_workspace(&self, artifact: &Artifact, content: &Bytes) -> Result<PathBuf> {
-        let workspace = self.workspace_dir(artifact);
-        tokio::fs::create_dir_all(&workspace)
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to create scan workspace: {}", e)))?;
-
-        // Use the original filename from the path (last segment) for correct extension detection,
-        // then sanitize to basename to prevent path traversal
-        let original_filename = artifact.path.rsplit('/').next().unwrap_or(&artifact.name);
-        let safe_filename = sanitize_artifact_filename(original_filename);
-        let artifact_path = workspace.join(&safe_filename);
-
-        tokio::fs::write(&artifact_path, content)
-            .await
-            .map_err(|e| {
-                AppError::Internal(format!("Failed to write artifact to workspace: {}", e))
-            })?;
-
-        // Extract archives into the workspace directory
-        if Self::is_archive(original_filename) {
-            if let Err(e) = Self::extract_archive(&artifact_path, &workspace).await {
-                warn!(
-                    "Failed to extract archive {}: {}. Scanning raw file instead.",
-                    artifact.name, e
-                );
-            }
-        }
-
-        Ok(workspace)
-    }
-
-    /// Check if the file is an extractable archive.
-    fn is_archive(name: &str) -> bool {
-        let lower = name.to_lowercase();
-        lower.ends_with(".tar.gz")
-            || lower.ends_with(".tgz")
-            || lower.ends_with(".whl")
-            || lower.ends_with(".jar")
-            || lower.ends_with(".war")
-            || lower.ends_with(".ear")
-            || lower.ends_with(".gem")
-            || lower.ends_with(".crate")
-            || lower.ends_with(".nupkg")
-            || lower.ends_with(".zip")
-            || lower.ends_with(".egg")
-    }
-
-    /// Extract an archive file into the given directory using system tools.
-    async fn extract_archive(archive_path: &Path, dest: &Path) -> Result<()> {
-        let name = archive_path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_lowercase();
-
-        let output =
-            if name.ends_with(".tar.gz") || name.ends_with(".tgz") || name.ends_with(".crate") {
-                tokio::process::Command::new("tar")
-                    .args([
-                        "xzf",
-                        &archive_path.to_string_lossy(),
-                        "-C",
-                        &dest.to_string_lossy(),
-                    ])
-                    .output()
-                    .await
-            } else if name.ends_with(".zip")
-                || name.ends_with(".whl")
-                || name.ends_with(".jar")
-                || name.ends_with(".war")
-                || name.ends_with(".ear")
-                || name.ends_with(".nupkg")
-                || name.ends_with(".egg")
-            {
-                tokio::process::Command::new("unzip")
-                    .args([
-                        "-o",
-                        "-q",
-                        &archive_path.to_string_lossy(),
-                        "-d",
-                        &dest.to_string_lossy(),
-                    ])
-                    .output()
-                    .await
-            } else if name.ends_with(".gem") {
-                tokio::process::Command::new("tar")
-                    .args([
-                        "xf",
-                        &archive_path.to_string_lossy(),
-                        "-C",
-                        &dest.to_string_lossy(),
-                    ])
-                    .output()
-                    .await
-            } else {
-                return Ok(());
-            };
-
-        match output {
-            Ok(o) if o.status.success() => Ok(()),
-            Ok(o) => Err(AppError::Internal(format!(
-                "Archive extraction failed (exit {}): {}",
-                o.status,
-                String::from_utf8_lossy(&o.stderr)
-            ))),
-            Err(e) => Err(AppError::Internal(format!(
-                "Failed to execute extraction command: {}",
-                e
-            ))),
-        }
-    }
-
-    /// Clean up the scan workspace directory.
-    async fn cleanup_workspace(&self, artifact: &Artifact) {
-        let workspace = self.workspace_dir(artifact);
-        if let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
-            warn!(
-                "Failed to clean up scan workspace {}: {}",
-                workspace.display(),
-                e
-            );
-        }
     }
 
     /// Run grype against the workspace directory.
@@ -285,18 +155,15 @@ impl Scanner for GrypeScanner {
             artifact.name, artifact.id
         );
 
-        // Prepare workspace with artifact content
-        let workspace = self.prepare_workspace(artifact, content).await?;
+        let workspace =
+            ScanWorkspace::prepare(&self.scan_workspace, None, artifact, content).await?;
 
         let report = match self.run_grype(&workspace).await {
             Ok(report) => report,
             Err(e) => {
-                warn!("Grype scan failed for {}: {}", artifact.name, e);
-                self.cleanup_workspace(artifact).await;
-                return Err(AppError::Internal(format!(
-                    "Grype scan failed for {}: {}",
-                    artifact.name, e
-                )));
+                return Err(
+                    fail_scan("Grype scan", artifact, &e, &self.scan_workspace, None).await,
+                );
             }
         };
 
@@ -308,8 +175,7 @@ impl Scanner for GrypeScanner {
             findings.len()
         );
 
-        // Clean up workspace
-        self.cleanup_workspace(artifact).await;
+        ScanWorkspace::cleanup(&self.scan_workspace, None, artifact).await;
 
         Ok(findings)
     }
@@ -344,16 +210,16 @@ mod tests {
 
     #[test]
     fn test_is_archive() {
-        assert!(GrypeScanner::is_archive("foo.tar.gz"));
-        assert!(GrypeScanner::is_archive("foo.tgz"));
-        assert!(GrypeScanner::is_archive("foo.whl"));
-        assert!(GrypeScanner::is_archive("foo.jar"));
-        assert!(GrypeScanner::is_archive("foo.zip"));
-        assert!(GrypeScanner::is_archive("foo.gem"));
-        assert!(GrypeScanner::is_archive("foo.crate"));
-        assert!(GrypeScanner::is_archive("foo.nupkg"));
-        assert!(!GrypeScanner::is_archive("Cargo.lock"));
-        assert!(!GrypeScanner::is_archive("package.json"));
+        assert!(ScanWorkspace::is_archive("foo.tar.gz"));
+        assert!(ScanWorkspace::is_archive("foo.tgz"));
+        assert!(ScanWorkspace::is_archive("foo.whl"));
+        assert!(ScanWorkspace::is_archive("foo.jar"));
+        assert!(ScanWorkspace::is_archive("foo.zip"));
+        assert!(ScanWorkspace::is_archive("foo.gem"));
+        assert!(ScanWorkspace::is_archive("foo.crate"));
+        assert!(ScanWorkspace::is_archive("foo.nupkg"));
+        assert!(!ScanWorkspace::is_archive("Cargo.lock"));
+        assert!(!ScanWorkspace::is_archive("package.json"));
     }
 
     #[test]

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -274,30 +274,21 @@ mod tests {
         assert!(findings.is_empty());
     }
 
-    /// When the scan workspace cannot be created, prepare_workspace fails
-    /// and the error propagates to the caller.
+    /// Scan failures (workspace creation, missing grype binary) must
+    /// propagate as Err, never as Ok(vec![]).
     #[tokio::test]
-    async fn test_scan_returns_error_when_workspace_creation_fails() {
-        // Use a path under /dev/null which cannot contain subdirectories
-        let scanner = GrypeScanner::new("/dev/null/impossible-workspace".to_string());
+    async fn test_scan_propagates_errors() {
         let artifact = make_artifact("pkg-1.0.0.tar.gz", "application/gzip");
         let content = Bytes::from_static(b"not a real archive");
 
-        let result = scanner.scan(&artifact, None, &content).await;
+        // Impossible workspace path
+        let bad_ws = GrypeScanner::new("/dev/null/impossible-workspace".to_string());
         assert!(
-            result.is_err(),
+            bad_ws.scan(&artifact, None, &content).await.is_err(),
             "scan() must return Err when workspace creation fails"
         );
-    }
 
-    /// When grype is not installed, the scanner must propagate the error
-    /// so the orchestrator records a failed scan instead of marking the
-    /// artifact as clean with 0 findings.
-    ///
-    /// Skipped when grype is installed, since it can legitimately scan
-    /// the raw file and return 0 findings.
-    #[tokio::test]
-    async fn test_scan_returns_error_when_grype_unavailable() {
+        // Missing grype binary (skip if grype is installed)
         if std::process::Command::new("grype")
             .arg("version")
             .output()
@@ -306,14 +297,12 @@ mod tests {
             eprintln!("grype is installed, skipping unavailable-grype test");
             return;
         }
-
         let dir = tempfile::tempdir().unwrap();
-        let scanner = GrypeScanner::new(dir.path().to_string_lossy().to_string());
-        let artifact = make_artifact("pkg-1.0.0.tar.gz", "application/gzip");
-        let content = Bytes::from_static(b"not a real archive");
-
-        let result = scanner.scan(&artifact, None, &content).await;
-        assert_scan_failed(&result, "Grype scan");
+        let no_grype = GrypeScanner::new(dir.path().to_string_lossy().to_string());
+        assert_scan_failed(
+            &no_grype.scan(&artifact, None, &content).await,
+            "Grype scan",
+        );
     }
 
     #[test]

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -184,42 +184,10 @@ impl Scanner for GrypeScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::scanner_service::test_helpers::{assert_scan_failed, make_test_artifact};
 
-    #[allow(dead_code)]
     fn make_artifact(name: &str, content_type: &str) -> Artifact {
-        Artifact {
-            id: uuid::Uuid::new_v4(),
-            repository_id: uuid::Uuid::new_v4(),
-            path: format!("test/{}", name),
-            name: name.to_string(),
-            version: Some("1.0.0".to_string()),
-            size_bytes: 1000,
-            checksum_sha256: "abc123".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: content_type.to_string(),
-            storage_key: "test".to_string(),
-            is_deleted: false,
-            uploaded_by: None,
-            quarantine_status: None,
-            quarantine_until: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        }
-    }
-
-    #[test]
-    fn test_is_archive() {
-        assert!(ScanWorkspace::is_archive("foo.tar.gz"));
-        assert!(ScanWorkspace::is_archive("foo.tgz"));
-        assert!(ScanWorkspace::is_archive("foo.whl"));
-        assert!(ScanWorkspace::is_archive("foo.jar"));
-        assert!(ScanWorkspace::is_archive("foo.zip"));
-        assert!(ScanWorkspace::is_archive("foo.gem"));
-        assert!(ScanWorkspace::is_archive("foo.crate"));
-        assert!(ScanWorkspace::is_archive("foo.nupkg"));
-        assert!(!ScanWorkspace::is_archive("Cargo.lock"));
-        assert!(!ScanWorkspace::is_archive("package.json"));
+        make_test_artifact(name, content_type, &format!("test/{}", name))
     }
 
     #[test]
@@ -345,16 +313,7 @@ mod tests {
         let content = Bytes::from_static(b"not a real archive");
 
         let result = scanner.scan(&artifact, None, &content).await;
-        assert!(
-            result.is_err(),
-            "scan() must return Err when grype execution fails, not Ok(vec![])"
-        );
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("Grype scan failed"),
-            "error message should indicate grype failure, got: {}",
-            err_msg
-        );
+        assert_scan_failed(&result, "Grype scan");
     }
 
     #[test]

--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -296,12 +296,12 @@ impl Scanner for IncusScanner {
         let rootfs = match self.prepare_workspace(artifact, content).await {
             Ok(r) => r,
             Err(e) => {
-                warn!(
-                    "Failed to extract Incus image {}: {}. Skipping scan.",
-                    artifact.name, e
-                );
+                warn!("Failed to extract Incus image {}: {}", artifact.name, e);
                 self.cleanup_workspace(artifact).await;
-                return Ok(vec![]);
+                return Err(AppError::Internal(format!(
+                    "Failed to extract Incus image {}: {}",
+                    artifact.name, e
+                )));
             }
         };
 
@@ -316,12 +316,12 @@ impl Scanner for IncusScanner {
                 match self.scan_standalone(&rootfs).await {
                     Ok(report) => report,
                     Err(e) => {
-                        warn!(
-                            "Trivy Incus scan failed for {}: {}. Returning empty findings.",
-                            artifact.name, e
-                        );
+                        warn!("Trivy Incus scan failed for {}: {}", artifact.name, e);
                         self.cleanup_workspace(artifact).await;
-                        return Ok(vec![]);
+                        return Err(AppError::Internal(format!(
+                            "Trivy Incus scan failed for {}: {}",
+                            artifact.name, e
+                        )));
                     }
                 }
             }
@@ -921,13 +921,14 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // scan gracefully handles prepare_workspace failure
+    // scan returns error when prepare_workspace fails
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    async fn test_scan_qcow2_returns_empty_findings() {
-        // QCOW2 artifacts are applicable but prepare_workspace fails,
-        // so scan should return empty findings gracefully.
+    async fn test_scan_qcow2_returns_error() {
+        // QCOW2 artifacts are applicable but prepare_workspace fails because
+        // they require mounting. The scanner must return Err so the
+        // orchestrator records a failed scan instead of marking it clean.
         let dir = tempfile::tempdir().unwrap();
         let scanner = IncusScanner::new(
             "http://trivy:8090".to_string(),
@@ -936,8 +937,11 @@ mod tests {
         let artifact = make_incus_artifact("rootfs.img", "ubuntu-noble/20240215/rootfs.img");
         let content = Bytes::from_static(b"fake qcow2 data");
 
-        let findings = scanner.scan(&artifact, None, &content).await.unwrap();
-        assert!(findings.is_empty());
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err for unscannable QCOW2 images, not Ok(vec![])"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1122,5 +1126,27 @@ mod tests {
         let report: TrivyReport = serde_json::from_str(json).unwrap();
         assert_eq!(report.results.len(), 1);
         assert!(report.results[0].vulnerabilities.is_none());
+    }
+
+    /// When rootfs extraction fails, the scanner must return Err so the
+    /// orchestrator records the scan as failed. Previously it returned
+    /// Ok(vec![]), making the artifact appear clean.
+    #[tokio::test]
+    async fn test_scan_returns_error_on_extraction_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let scanner = IncusScanner::new(
+            "http://localhost:0".to_string(),
+            dir.path().to_string_lossy().to_string(),
+        );
+        // Unified tarball path that is_applicable will match
+        let artifact = make_incus_artifact("incus.tar.xz", "ubuntu-noble/20240215/incus.tar.xz");
+        // Invalid content that will fail extraction
+        let content = Bytes::from_static(b"not a valid tarball");
+
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err when extraction fails, not Ok(vec![])"
+        );
     }
 }

--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -318,27 +318,10 @@ impl Scanner for IncusScanner {
 mod tests {
     use super::*;
     use crate::models::security::Severity;
+    use crate::services::scanner_service::test_helpers::make_test_artifact;
 
     fn make_incus_artifact(name: &str, path: &str) -> Artifact {
-        Artifact {
-            id: uuid::Uuid::new_v4(),
-            repository_id: uuid::Uuid::new_v4(),
-            path: path.to_string(),
-            name: name.to_string(),
-            version: Some("20240215".to_string()),
-            size_bytes: 100_000_000,
-            checksum_sha256: "abc123".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: "application/octet-stream".to_string(),
-            storage_key: "test".to_string(),
-            is_deleted: false,
-            uploaded_by: None,
-            quarantine_status: None,
-            quarantine_until: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        }
+        make_test_artifact(name, "application/octet-stream", path)
     }
 
     #[test]

--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -793,44 +793,38 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    async fn test_scan_returns_empty_for_non_applicable_artifact() {
+    async fn test_scan_returns_empty_for_skipped_artifacts() {
         let scanner = IncusScanner::new(
             "http://trivy:8090".to_string(),
             "/tmp/test-workspace".to_string(),
         );
-        // streams/v1/index.json is not applicable
-        let artifact = make_incus_artifact("index.json", "streams/v1/index.json");
-        let content = Bytes::from_static(b"{}");
 
-        let findings = scanner.scan(&artifact, None, &content).await.unwrap();
-        assert!(findings.is_empty());
-    }
+        // Non-applicable artifact (streams index)
+        let cases: Vec<(Artifact, Bytes)> = vec![
+            (
+                make_incus_artifact("index.json", "streams/v1/index.json"),
+                Bytes::from_static(b"{}"),
+            ),
+            // Empty content for an applicable artifact
+            (
+                make_incus_artifact("incus.tar.xz", "ubuntu-noble/20240215/incus.tar.xz"),
+                Bytes::new(),
+            ),
+            // Metadata-only tarball (not applicable)
+            (
+                make_incus_artifact("metadata.tar.xz", "ubuntu-noble/20240215/metadata.tar.xz"),
+                Bytes::from_static(b"some content"),
+            ),
+        ];
 
-    #[tokio::test]
-    async fn test_scan_returns_empty_for_empty_content() {
-        let scanner = IncusScanner::new(
-            "http://trivy:8090".to_string(),
-            "/tmp/test-workspace".to_string(),
-        );
-        let artifact = make_incus_artifact("incus.tar.xz", "ubuntu-noble/20240215/incus.tar.xz");
-        let content = Bytes::new();
-
-        let findings = scanner.scan(&artifact, None, &content).await.unwrap();
-        assert!(findings.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_scan_returns_empty_for_metadata_only() {
-        let scanner = IncusScanner::new(
-            "http://trivy:8090".to_string(),
-            "/tmp/test-workspace".to_string(),
-        );
-        let artifact =
-            make_incus_artifact("metadata.tar.xz", "ubuntu-noble/20240215/metadata.tar.xz");
-        let content = Bytes::from_static(b"some content");
-
-        let findings = scanner.scan(&artifact, None, &content).await.unwrap();
-        assert!(findings.is_empty());
+        for (artifact, content) in &cases {
+            let findings = scanner.scan(artifact, None, content).await.unwrap();
+            assert!(
+                findings.is_empty(),
+                "expected empty findings for {}",
+                artifact.name
+            );
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -881,23 +875,34 @@ mod tests {
     // scan returns error when prepare_workspace fails
     // -----------------------------------------------------------------------
 
+    /// Scan failures (QCOW2 unsupported, extraction failure) must propagate
+    /// as Err, never as Ok(vec![]).
     #[tokio::test]
-    async fn test_scan_qcow2_returns_error() {
-        // QCOW2 artifacts are applicable but prepare_workspace fails because
-        // they require mounting. The scanner must return Err so the
-        // orchestrator records a failed scan instead of marking it clean.
+    async fn test_scan_propagates_errors() {
         let dir = tempfile::tempdir().unwrap();
         let scanner = IncusScanner::new(
-            "http://trivy:8090".to_string(),
+            "http://localhost:0".to_string(),
             dir.path().to_string_lossy().to_string(),
         );
-        let artifact = make_incus_artifact("rootfs.img", "ubuntu-noble/20240215/rootfs.img");
-        let content = Bytes::from_static(b"fake qcow2 data");
 
-        let result = scanner.scan(&artifact, None, &content).await;
+        // QCOW2 images are applicable but require mounting, so scan must fail
+        let qcow2 = make_incus_artifact("rootfs.img", "ubuntu-noble/20240215/rootfs.img");
         assert!(
-            result.is_err(),
-            "scan() must return Err for unscannable QCOW2 images, not Ok(vec![])"
+            scanner
+                .scan(&qcow2, None, &Bytes::from_static(b"fake qcow2 data"))
+                .await
+                .is_err(),
+            "scan() must return Err for unscannable QCOW2 images"
+        );
+
+        // Invalid tarball content causes extraction failure
+        let tarball = make_incus_artifact("incus.tar.xz", "ubuntu-noble/20240215/incus.tar.xz");
+        assert!(
+            scanner
+                .scan(&tarball, None, &Bytes::from_static(b"not a valid tarball"))
+                .await
+                .is_err(),
+            "scan() must return Err when extraction fails"
         );
     }
 
@@ -1083,27 +1088,5 @@ mod tests {
         let report: TrivyReport = serde_json::from_str(json).unwrap();
         assert_eq!(report.results.len(), 1);
         assert!(report.results[0].vulnerabilities.is_none());
-    }
-
-    /// When rootfs extraction fails, the scanner must return Err so the
-    /// orchestrator records the scan as failed. Previously it returned
-    /// Ok(vec![]), making the artifact appear clean.
-    #[tokio::test]
-    async fn test_scan_returns_error_on_extraction_failure() {
-        let dir = tempfile::tempdir().unwrap();
-        let scanner = IncusScanner::new(
-            "http://localhost:0".to_string(),
-            dir.path().to_string_lossy().to_string(),
-        );
-        // Unified tarball path that is_applicable will match
-        let artifact = make_incus_artifact("incus.tar.xz", "ubuntu-noble/20240215/incus.tar.xz");
-        // Invalid content that will fail extraction
-        let content = Bytes::from_static(b"not a valid tarball");
-
-        let result = scanner.scan(&artifact, None, &content).await;
-        assert!(
-            result.is_err(),
-            "scan() must return Err when extraction fails, not Ok(vec![])"
-        );
     }
 }

--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -18,9 +18,9 @@ use tracing::{info, warn};
 use crate::error::{AppError, Result};
 use crate::formats::incus::{IncusFileType, IncusHandler};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
-use crate::models::security::{RawFinding, Severity};
+use crate::models::security::RawFinding;
 use crate::services::image_scanner::TrivyReport;
-use crate::services::scanner_service::Scanner;
+use crate::services::scanner_service::{convert_trivy_findings, fail_scan, ScanWorkspace, Scanner};
 
 /// Write content to a temporary file in the workspace, returning an error with the given label.
 async fn write_temp_file(path: &Path, content: &Bytes, label: &str) -> Result<()> {
@@ -121,7 +121,7 @@ impl IncusScanner {
 
     /// Build the workspace directory path for a given artifact.
     fn workspace_dir(&self, artifact: &Artifact) -> PathBuf {
-        Path::new(&self.scan_workspace).join(format!("incus-{}", artifact.id))
+        ScanWorkspace::workspace_dir(&self.scan_workspace, Some("incus"), artifact)
     }
 
     /// Prepare the scan workspace by extracting rootfs from the image.
@@ -213,14 +213,7 @@ impl IncusScanner {
 
     /// Clean up the scan workspace directory.
     async fn cleanup_workspace(&self, artifact: &Artifact) {
-        let workspace = self.workspace_dir(artifact);
-        if let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
-            warn!(
-                "Failed to clean up Incus scan workspace {}: {}",
-                workspace.display(),
-                e
-            );
-        }
+        ScanWorkspace::cleanup(&self.scan_workspace, Some("incus"), artifact).await;
     }
 
     /// Run Trivy filesystem scan on the extracted rootfs.
@@ -234,32 +227,8 @@ impl IncusScanner {
     }
 
     /// Convert Trivy report into RawFinding values.
-    fn convert_findings(report: &TrivyReport) -> Vec<RawFinding> {
-        report
-            .results
-            .iter()
-            .flat_map(|result| {
-                result
-                    .vulnerabilities
-                    .as_deref()
-                    .unwrap_or(&[])
-                    .iter()
-                    .map(move |vuln| RawFinding {
-                        severity: Severity::from_str_loose(&vuln.severity)
-                            .unwrap_or(Severity::Info),
-                        title: vuln.title.clone().unwrap_or_else(|| {
-                            format!("{} in {}", vuln.vulnerability_id, vuln.pkg_name)
-                        }),
-                        description: vuln.description.clone(),
-                        cve_id: Some(vuln.vulnerability_id.clone()),
-                        affected_component: Some(format!("{} ({})", vuln.pkg_name, result.target)),
-                        affected_version: Some(vuln.installed_version.clone()),
-                        fixed_version: vuln.fixed_version.clone(),
-                        source: Some("trivy-incus".to_string()),
-                        source_url: vuln.primary_url.clone(),
-                    })
-            })
-            .collect()
+    fn convert_findings(report: &crate::services::image_scanner::TrivyReport) -> Vec<RawFinding> {
+        convert_trivy_findings(report, "trivy-incus")
     }
 }
 
@@ -296,12 +265,14 @@ impl Scanner for IncusScanner {
         let rootfs = match self.prepare_workspace(artifact, content).await {
             Ok(r) => r,
             Err(e) => {
-                warn!("Failed to extract Incus image {}: {}", artifact.name, e);
-                self.cleanup_workspace(artifact).await;
-                return Err(AppError::Internal(format!(
-                    "Failed to extract Incus image {}: {}",
-                    artifact.name, e
-                )));
+                return Err(fail_scan(
+                    "Incus image extraction",
+                    artifact,
+                    &e,
+                    &self.scan_workspace,
+                    Some("incus"),
+                )
+                .await);
             }
         };
 
@@ -316,12 +287,14 @@ impl Scanner for IncusScanner {
                 match self.scan_standalone(&rootfs).await {
                     Ok(report) => report,
                     Err(e) => {
-                        warn!("Trivy Incus scan failed for {}: {}", artifact.name, e);
-                        self.cleanup_workspace(artifact).await;
-                        return Err(AppError::Internal(format!(
-                            "Trivy Incus scan failed for {}: {}",
-                            artifact.name, e
-                        )));
+                        return Err(fail_scan(
+                            "Trivy Incus scan",
+                            artifact,
+                            &e,
+                            &self.scan_workspace,
+                            Some("incus"),
+                        )
+                        .await);
                     }
                 }
             }
@@ -344,6 +317,7 @@ impl Scanner for IncusScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::security::Severity;
 
     fn make_incus_artifact(name: &str, path: &str) -> Artifact {
         Artifact {

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -43,11 +43,39 @@ impl Default for WorkerConfig {
             concurrency: 4,
             throttle_delay_ms: 100,
             max_retries: 3,
-            batch_size: 100,
+            // AQL default page size. Kept at 1000 (Artifactory's typical
+            // ceiling) so a single page can cover most repositories without
+            // hammering the source API. The migration worker still paginates
+            // through as many pages as needed to enumerate every artifact.
+            batch_size: 1000,
             verify_checksums: true,
             dry_run: false,
         }
     }
+}
+
+/// Maximum number of AQL pages a single repository migration is allowed to
+/// fetch. Acts as a safety guard against an infinite pagination loop if the
+/// source API misbehaves (for example, by always returning a full page of
+/// results regardless of offset). At the default batch size of 1000 this
+/// still lets a single repository contain up to 100 million artifacts.
+pub(crate) const MAX_ARTIFACT_PAGES: usize = 100_000;
+
+/// Decide whether artifact pagination should continue after processing a
+/// page. The Artifactory AQL `range.total` field reports the number of rows
+/// in the current page (not the overall result set), so the termination
+/// decision must be based on page shape, not on a running total.
+///
+/// Returns `true` when the caller should fetch the next page, `false` when
+/// the enumeration is complete.
+pub(crate) fn should_fetch_next_page(page_len: usize, limit: i64) -> bool {
+    if page_len == 0 {
+        return false;
+    }
+    // A short page means we've reached the end of the result set. AQL always
+    // fills pages up to the requested limit unless there are no more rows.
+    let limit_usize = usize::try_from(limit.max(0)).unwrap_or(usize::MAX);
+    page_len >= limit_usize
 }
 
 /// Conflict resolution strategy
@@ -247,13 +275,29 @@ impl MigrationWorker {
         progress_tx: Option<mpsc::Sender<ProgressUpdate>>,
     ) -> Result<(), MigrationError> {
         let mut offset = 0i64;
-        let limit = self.config.batch_size;
+        let limit = self.config.batch_size.max(1);
+        let mut pages_fetched = 0usize;
 
         loop {
+            // Safety guard: refuse to keep paginating forever if the source
+            // API repeatedly returns full pages without advancing.
+            if pages_fetched >= MAX_ARTIFACT_PAGES {
+                tracing::warn!(
+                    job_id = %job_id,
+                    repo = %repo_key,
+                    pages = pages_fetched,
+                    "Reached MAX_ARTIFACT_PAGES while listing artifacts; stopping pagination"
+                );
+                break;
+            }
+
             // List artifacts with pagination
             let artifacts = client.list_artifacts(repo_key, offset, limit).await?;
+            pages_fetched += 1;
 
-            if artifacts.results.is_empty() {
+            let page_len = artifacts.results.len();
+
+            if page_len == 0 {
                 break;
             }
 
@@ -325,12 +369,29 @@ impl MigrationWorker {
                 self.apply_throttle().await;
             }
 
-            // Check if we've processed all artifacts
-            if (offset + artifacts.results.len() as i64) >= artifacts.range.total {
+            // Advance the cursor. AQL's `range.total` reports the count of
+            // rows in the current page (matching `end_pos - start_pos`), so
+            // termination must be decided from the page shape, not from a
+            // running total. A short page (fewer rows than `limit`) means
+            // the result set is exhausted.
+            if !should_fetch_next_page(page_len, limit) {
                 break;
             }
 
-            offset += limit;
+            // Guard against a pathological source that returns full pages
+            // without advancing the cursor. This prevents an infinite loop
+            // if the offset fails to move forward.
+            let new_offset = offset.saturating_add(page_len as i64);
+            if new_offset <= offset {
+                tracing::warn!(
+                    job_id = %job_id,
+                    repo = %repo_key,
+                    offset,
+                    "AQL pagination cursor failed to advance; stopping to avoid infinite loop"
+                );
+                break;
+            }
+            offset = new_offset;
         }
 
         Ok(())
@@ -1151,9 +1212,81 @@ mod tests {
         assert_eq!(config.concurrency, 4);
         assert_eq!(config.throttle_delay_ms, 100);
         assert_eq!(config.max_retries, 3);
-        assert_eq!(config.batch_size, 100);
+        assert_eq!(config.batch_size, 1000);
         assert!(config.verify_checksums);
         assert!(!config.dry_run);
+    }
+
+    // -----------------------------------------------------------------------
+    // should_fetch_next_page (#671 pagination fix)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_should_fetch_next_page_full_page_continues() {
+        // A full page (page_len == limit) means more rows are likely available
+        assert!(should_fetch_next_page(1000, 1000));
+        assert!(should_fetch_next_page(100, 100));
+    }
+
+    #[test]
+    fn test_should_fetch_next_page_short_page_terminates() {
+        // A short page (page_len < limit) means the result set is exhausted
+        assert!(!should_fetch_next_page(42, 1000));
+        assert!(!should_fetch_next_page(999, 1000));
+    }
+
+    #[test]
+    fn test_should_fetch_next_page_empty_terminates() {
+        // An empty page always terminates
+        assert!(!should_fetch_next_page(0, 1000));
+        assert!(!should_fetch_next_page(0, 1));
+    }
+
+    #[test]
+    fn test_should_fetch_next_page_negative_limit_handled() {
+        // Defensive: negative or zero limits should not panic
+        assert!(!should_fetch_next_page(0, -1));
+        assert!(should_fetch_next_page(5, -1));
+    }
+
+    #[test]
+    fn test_should_fetch_next_page_boundary_limit_of_one() {
+        // A single-row page with limit=1 means more rows could exist
+        assert!(should_fetch_next_page(1, 1));
+        // Zero rows with limit=1 means empty result set
+        assert!(!should_fetch_next_page(0, 1));
+    }
+
+    #[test]
+    fn test_should_fetch_next_page_limit_zero_always_continues() {
+        // Zero limit collapses to max usize so any non-empty page continues
+        assert!(should_fetch_next_page(1, 0));
+        assert!(!should_fetch_next_page(0, 0));
+    }
+
+    #[test]
+    fn test_should_fetch_next_page_page_larger_than_limit() {
+        // Defensive: if the server returns more rows than requested,
+        // treat it as a full page (continue fetching)
+        assert!(should_fetch_next_page(200, 100));
+    }
+
+    #[test]
+    fn test_max_artifact_pages_constant_is_safety_guard() {
+        // Sanity check the safety guard is reasonable: with 1000 rows per
+        // page, this allows enumerating up to 100M artifacts in a single
+        // repository before bailing out.
+        let min_pages = 10_000;
+        assert!(MAX_ARTIFACT_PAGES >= min_pages);
+    }
+
+    #[test]
+    fn test_default_batch_size_is_reasonable_for_aql() {
+        // Default batch size should be large enough to avoid excessive
+        // round trips but not so large it stresses the source API.
+        let config = WorkerConfig::default();
+        assert!(config.batch_size >= 100);
+        assert!(config.batch_size <= 10_000);
     }
 
     #[test]

--- a/backend/src/services/openscap_scanner.rs
+++ b/backend/src/services/openscap_scanner.rs
@@ -15,7 +15,9 @@ use tracing::{info, warn};
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::models::security::{RawFinding, Severity};
-use crate::services::scanner_service::{sanitize_artifact_filename, Scanner};
+use crate::services::scanner_service::{
+    fail_scan, sanitize_artifact_filename, ScanWorkspace, Scanner,
+};
 
 // ---------------------------------------------------------------------------
 // OpenSCAP wrapper JSON response structures
@@ -90,17 +92,15 @@ impl OpenScapScanner {
         is_container || is_rpm || is_deb
     }
 
-    fn workspace_dir(&self, artifact: &Artifact) -> PathBuf {
-        Path::new(&self.scan_workspace).join(format!("openscap-{}", artifact.id))
-    }
-
+    /// Prepare the scan workspace: create directory and write artifact content.
+    /// OpenSCAP does not extract archives (it scans the raw package).
     async fn prepare_workspace(&self, artifact: &Artifact, content: &Bytes) -> Result<PathBuf> {
-        let workspace = self.workspace_dir(artifact);
+        let workspace =
+            ScanWorkspace::workspace_dir(&self.scan_workspace, Some("openscap"), artifact);
         tokio::fs::create_dir_all(&workspace)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to create scan workspace: {}", e)))?;
 
-        // Sanitize the filename to its basename to prevent path traversal
         let original_filename = artifact.path.rsplit('/').next().unwrap_or(&artifact.name);
         let safe_filename = sanitize_artifact_filename(original_filename);
         let artifact_path = workspace.join(&safe_filename);
@@ -112,17 +112,6 @@ impl OpenScapScanner {
             })?;
 
         Ok(workspace)
-    }
-
-    async fn cleanup_workspace(&self, artifact: &Artifact) {
-        let workspace = self.workspace_dir(artifact);
-        if let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
-            warn!(
-                "Failed to clean up scan workspace {}: {}",
-                workspace.display(),
-                e
-            );
-        }
     }
 
     async fn call_openscap(&self, workspace: &Path) -> Result<OpenScapResponse> {
@@ -214,12 +203,14 @@ impl Scanner for OpenScapScanner {
         let response = match self.call_openscap(&workspace).await {
             Ok(resp) => resp,
             Err(e) => {
-                warn!("OpenSCAP scan failed for {}: {}", artifact.name, e);
-                self.cleanup_workspace(artifact).await;
-                return Err(AppError::Internal(format!(
-                    "OpenSCAP scan failed for {}: {}",
-                    artifact.name, e
-                )));
+                return Err(fail_scan(
+                    "OpenSCAP scan",
+                    artifact,
+                    &e,
+                    &self.scan_workspace,
+                    Some("openscap"),
+                )
+                .await);
             }
         };
 
@@ -235,7 +226,7 @@ impl Scanner for OpenScapScanner {
             findings.len()
         );
 
-        self.cleanup_workspace(artifact).await;
+        ScanWorkspace::cleanup(&self.scan_workspace, Some("openscap"), artifact).await;
 
         Ok(findings)
     }

--- a/backend/src/services/openscap_scanner.rs
+++ b/backend/src/services/openscap_scanner.rs
@@ -214,12 +214,12 @@ impl Scanner for OpenScapScanner {
         let response = match self.call_openscap(&workspace).await {
             Ok(resp) => resp,
             Err(e) => {
-                warn!(
-                    "OpenSCAP scan failed for {}: {}. Returning empty findings.",
-                    artifact.name, e
-                );
+                warn!("OpenSCAP scan failed for {}: {}", artifact.name, e);
                 self.cleanup_workspace(artifact).await;
-                return Ok(vec![]);
+                return Err(AppError::Internal(format!(
+                    "OpenSCAP scan failed for {}: {}",
+                    artifact.name, e
+                )));
             }
         };
 
@@ -358,5 +358,37 @@ mod tests {
         );
         assert_eq!(findings[0].source_url, Some("CCE-27286-2".to_string()));
         assert_eq!(findings[1].severity, Severity::Medium);
+    }
+
+    /// When the OpenSCAP sidecar is unreachable, the scanner must return Err
+    /// so the orchestrator records the scan as failed. Previously it returned
+    /// Ok(vec![]), making the artifact appear clean.
+    #[tokio::test]
+    async fn test_scan_returns_error_when_sidecar_unreachable() {
+        let dir = tempfile::tempdir().unwrap();
+        let scanner = OpenScapScanner::new(
+            // Port 0 ensures the connection will be refused
+            "http://localhost:0".to_string(),
+            "standard".to_string(),
+            dir.path().to_string_lossy().to_string(),
+        );
+        let artifact = make_artifact(
+            "nginx-1.24.0-1.el9.x86_64.rpm",
+            "application/x-rpm",
+            "rpm/nginx/1.24.0/nginx-1.24.0-1.el9.x86_64.rpm",
+        );
+        let content = bytes::Bytes::from_static(b"fake rootfs tarball");
+
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err when sidecar is unreachable, not Ok(vec![])"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("OpenSCAP scan failed"),
+            "error message should indicate OpenSCAP failure, got: {}",
+            err_msg
+        );
     }
 }

--- a/backend/src/services/openscap_scanner.rs
+++ b/backend/src/services/openscap_scanner.rs
@@ -237,13 +237,9 @@ mod tests {
     use super::*;
     use crate::services::scanner_service::test_helpers::{assert_scan_failed, make_test_artifact};
 
-    fn make_artifact(name: &str, content_type: &str, path: &str) -> Artifact {
-        make_test_artifact(name, content_type, path)
-    }
-
     #[test]
     fn test_is_applicable_rpm() {
-        let artifact = make_artifact(
+        let artifact = make_test_artifact(
             "nginx-1.24.0-1.el9.x86_64.rpm",
             "application/x-rpm",
             "rpm/nginx/nginx-1.24.0-1.el9.x86_64.rpm",
@@ -253,7 +249,7 @@ mod tests {
 
     #[test]
     fn test_is_applicable_deb() {
-        let artifact = make_artifact(
+        let artifact = make_test_artifact(
             "nginx_1.24.0-1_amd64.deb",
             "application/vnd.debian.binary-package",
             "deb/nginx/nginx_1.24.0-1_amd64.deb",
@@ -263,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_is_applicable_container() {
-        let artifact = make_artifact(
+        let artifact = make_test_artifact(
             "myapp",
             "application/vnd.oci.image.manifest.v1+json",
             "v2/myapp/manifests/latest",
@@ -273,13 +269,13 @@ mod tests {
 
     #[test]
     fn test_not_applicable_jar() {
-        let artifact = make_artifact("app.jar", "application/java-archive", "maven/app.jar");
+        let artifact = make_test_artifact("app.jar", "application/java-archive", "maven/app.jar");
         assert!(!OpenScapScanner::is_applicable(&artifact));
     }
 
     #[test]
     fn test_not_applicable_npm() {
-        let artifact = make_artifact(
+        let artifact = make_test_artifact(
             "prelaunch-test-0.1.0.tgz",
             "application/gzip",
             "npm/prelaunch-npm/prelaunch-test/-/prelaunch-test-0.1.0.tgz",
@@ -344,7 +340,7 @@ mod tests {
             "standard".to_string(),
             dir.path().to_string_lossy().to_string(),
         );
-        let artifact = make_artifact(
+        let artifact = make_test_artifact(
             "nginx-1.24.0-1.el9.x86_64.rpm",
             "application/x-rpm",
             "rpm/nginx/1.24.0/nginx-1.24.0-1.el9.x86_64.rpm",

--- a/backend/src/services/openscap_scanner.rs
+++ b/backend/src/services/openscap_scanner.rs
@@ -235,29 +235,10 @@ impl Scanner for OpenScapScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-    use uuid::Uuid;
+    use crate::services::scanner_service::test_helpers::{assert_scan_failed, make_test_artifact};
 
     fn make_artifact(name: &str, content_type: &str, path: &str) -> Artifact {
-        Artifact {
-            id: Uuid::new_v4(),
-            repository_id: Uuid::new_v4(),
-            path: path.to_string(),
-            name: name.to_string(),
-            version: None,
-            size_bytes: 0,
-            checksum_sha256: String::new(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: content_type.to_string(),
-            storage_key: String::new(),
-            is_deleted: false,
-            uploaded_by: None,
-            quarantine_status: None,
-            quarantine_until: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }
+        make_test_artifact(name, content_type, path)
     }
 
     #[test]
@@ -371,15 +352,6 @@ mod tests {
         let content = bytes::Bytes::from_static(b"fake rootfs tarball");
 
         let result = scanner.scan(&artifact, None, &content).await;
-        assert!(
-            result.is_err(),
-            "scan() must return Err when sidecar is unreachable, not Ok(vec![])"
-        );
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("OpenSCAP scan failed"),
-            "error message should indicate OpenSCAP failure, got: {}",
-            err_msg
-        );
+        assert_scan_failed(&result, "OpenSCAP scan");
     }
 }

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -1637,6 +1637,8 @@ pub(crate) mod test_helpers {
             storage_key: "test-key".to_string(),
             is_deleted: false,
             uploaded_by: None,
+            quarantine_status: None,
+            quarantine_until: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -43,6 +43,201 @@ pub(crate) fn sanitize_artifact_filename(name: &str) -> String {
         .to_string()
 }
 
+/// Shared scan workspace utilities for scanners that need to write artifact
+/// content to disk, optionally extract archives, and clean up after scanning.
+pub(crate) struct ScanWorkspace;
+
+impl ScanWorkspace {
+    /// Build the workspace directory path for a given artifact, using an
+    /// optional prefix to distinguish different scanner types.
+    pub fn workspace_dir(base: &str, prefix: Option<&str>, artifact: &Artifact) -> PathBuf {
+        let dir_name = match prefix {
+            Some(p) => format!("{}-{}", p, artifact.id),
+            None => artifact.id.to_string(),
+        };
+        Path::new(base).join(dir_name)
+    }
+
+    /// Prepare the scan workspace: create directories, write artifact content,
+    /// and optionally extract archives. Returns the workspace path.
+    pub async fn prepare(
+        base: &str,
+        prefix: Option<&str>,
+        artifact: &Artifact,
+        content: &Bytes,
+    ) -> Result<PathBuf> {
+        let workspace = Self::workspace_dir(base, prefix, artifact);
+        tokio::fs::create_dir_all(&workspace)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to create scan workspace: {}", e)))?;
+
+        let original_filename = artifact.path.rsplit('/').next().unwrap_or(&artifact.name);
+        let safe_filename = sanitize_artifact_filename(original_filename);
+        let artifact_path = workspace.join(&safe_filename);
+
+        tokio::fs::write(&artifact_path, content)
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to write artifact to workspace: {}", e))
+            })?;
+
+        if Self::is_archive(original_filename) {
+            if let Err(e) = Self::extract_archive(&artifact_path, &workspace).await {
+                warn!(
+                    "Failed to extract archive {}: {}. Scanning raw file instead.",
+                    artifact.name, e
+                );
+            }
+        }
+
+        Ok(workspace)
+    }
+
+    /// Clean up the scan workspace directory, logging warnings on failure.
+    pub async fn cleanup(base: &str, prefix: Option<&str>, artifact: &Artifact) {
+        let workspace = Self::workspace_dir(base, prefix, artifact);
+        if let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
+            warn!(
+                "Failed to clean up scan workspace {}: {}",
+                workspace.display(),
+                e
+            );
+        }
+    }
+
+    /// Check if the file is an extractable archive.
+    pub fn is_archive(name: &str) -> bool {
+        let lower = name.to_lowercase();
+        lower.ends_with(".tar.gz")
+            || lower.ends_with(".tgz")
+            || lower.ends_with(".whl")
+            || lower.ends_with(".jar")
+            || lower.ends_with(".war")
+            || lower.ends_with(".ear")
+            || lower.ends_with(".gem")
+            || lower.ends_with(".crate")
+            || lower.ends_with(".nupkg")
+            || lower.ends_with(".zip")
+            || lower.ends_with(".egg")
+    }
+
+    /// Extract an archive file into the given directory using system tools.
+    pub async fn extract_archive(archive_path: &Path, dest: &Path) -> Result<()> {
+        let name = archive_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_lowercase();
+
+        let output =
+            if name.ends_with(".tar.gz") || name.ends_with(".tgz") || name.ends_with(".crate") {
+                tokio::process::Command::new("tar")
+                    .args([
+                        "xzf",
+                        &archive_path.to_string_lossy(),
+                        "-C",
+                        &dest.to_string_lossy(),
+                    ])
+                    .output()
+                    .await
+            } else if name.ends_with(".zip")
+                || name.ends_with(".whl")
+                || name.ends_with(".jar")
+                || name.ends_with(".war")
+                || name.ends_with(".ear")
+                || name.ends_with(".nupkg")
+                || name.ends_with(".egg")
+            {
+                tokio::process::Command::new("unzip")
+                    .args([
+                        "-o",
+                        "-q",
+                        &archive_path.to_string_lossy(),
+                        "-d",
+                        &dest.to_string_lossy(),
+                    ])
+                    .output()
+                    .await
+            } else if name.ends_with(".gem") {
+                tokio::process::Command::new("tar")
+                    .args([
+                        "xf",
+                        &archive_path.to_string_lossy(),
+                        "-C",
+                        &dest.to_string_lossy(),
+                    ])
+                    .output()
+                    .await
+            } else {
+                return Ok(());
+            };
+
+        match output {
+            Ok(o) if o.status.success() => Ok(()),
+            Ok(o) => Err(AppError::Internal(format!(
+                "Archive extraction failed (exit {}): {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr)
+            ))),
+            Err(e) => Err(AppError::Internal(format!(
+                "Failed to execute extraction command: {}",
+                e
+            ))),
+        }
+    }
+}
+
+/// Handle a scan step failure: log a warning, clean up the workspace, and
+/// return an `AppError::Internal` with a formatted message.
+///
+/// Use this in `Scanner::scan()` implementations to avoid repeating the
+/// warn-cleanup-return-Err pattern in every error branch.
+pub(crate) async fn fail_scan(
+    scanner_label: &str,
+    artifact: &Artifact,
+    error: &AppError,
+    workspace_base: &str,
+    workspace_prefix: Option<&str>,
+) -> AppError {
+    let msg = format!("{} failed for {}: {}", scanner_label, artifact.name, error);
+    warn!("{}", msg);
+    ScanWorkspace::cleanup(workspace_base, workspace_prefix, artifact).await;
+    AppError::Internal(msg)
+}
+
+/// Convert a Trivy report into `RawFinding` values. Shared by all scanners
+/// that consume Trivy JSON output (trivy_fs_scanner, incus_scanner,
+/// image_scanner).
+pub(crate) fn convert_trivy_findings(
+    report: &crate::services::image_scanner::TrivyReport,
+    source_label: &str,
+) -> Vec<RawFinding> {
+    report
+        .results
+        .iter()
+        .flat_map(|result| {
+            result
+                .vulnerabilities
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .map(move |vuln| RawFinding {
+                    severity: Severity::from_str_loose(&vuln.severity).unwrap_or(Severity::Info),
+                    title: vuln.title.clone().unwrap_or_else(|| {
+                        format!("{} in {}", vuln.vulnerability_id, vuln.pkg_name)
+                    }),
+                    description: vuln.description.clone(),
+                    cve_id: Some(vuln.vulnerability_id.clone()),
+                    affected_component: Some(format!("{} ({})", vuln.pkg_name, result.target)),
+                    affected_version: Some(vuln.installed_version.clone()),
+                    fixed_version: vuln.fixed_version.clone(),
+                    source: Some(source_label.to_string()),
+                    source_url: vuln.primary_url.clone(),
+                })
+        })
+        .collect()
+}
+
 /// Extract a tar.gz archive into `target_dir` while guarding against tar-slip
 /// attacks: symlinks, hardlinks, and paths that escape the target directory
 /// via `..` components are silently skipped.

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -1627,6 +1627,54 @@ impl ScannerService {
     }
 }
 
+/// Test helpers shared across scanner test modules to avoid duplicating
+/// Artifact construction in every scanner file.
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use crate::models::artifact::Artifact;
+
+    /// Create a minimal Artifact for unit tests. Fields not relevant to a
+    /// specific test use sensible defaults.
+    pub fn make_test_artifact(name: &str, content_type: &str, path: &str) -> Artifact {
+        Artifact {
+            id: uuid::Uuid::new_v4(),
+            repository_id: uuid::Uuid::new_v4(),
+            path: path.to_string(),
+            name: name.to_string(),
+            version: Some("1.0.0".to_string()),
+            size_bytes: 1000,
+            checksum_sha256: "abc123".to_string(),
+            checksum_md5: None,
+            checksum_sha1: None,
+            content_type: content_type.to_string(),
+            storage_key: "test-key".to_string(),
+            is_deleted: false,
+            uploaded_by: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    /// Assert that a scan result is an error containing the expected label.
+    pub fn assert_scan_failed(
+        result: &crate::error::Result<Vec<crate::models::security::RawFinding>>,
+        expected_label: &str,
+    ) {
+        assert!(
+            result.is_err(),
+            "scan() must return Err, not Ok(vec![]), when {} fails",
+            expected_label
+        );
+        let err_msg = result.as_ref().unwrap_err().to_string();
+        assert!(
+            err_msg.contains(&format!("{} failed", expected_label)),
+            "error message should contain '{} failed', got: {}",
+            expected_label,
+            err_msg
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1805,6 +1853,28 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // ScanWorkspace::is_archive
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_scan_workspace_is_archive() {
+        assert!(ScanWorkspace::is_archive("foo.tar.gz"));
+        assert!(ScanWorkspace::is_archive("foo.tgz"));
+        assert!(ScanWorkspace::is_archive("foo.whl"));
+        assert!(ScanWorkspace::is_archive("foo.jar"));
+        assert!(ScanWorkspace::is_archive("foo.zip"));
+        assert!(ScanWorkspace::is_archive("foo.gem"));
+        assert!(ScanWorkspace::is_archive("foo.crate"));
+        assert!(ScanWorkspace::is_archive("foo.nupkg"));
+        assert!(ScanWorkspace::is_archive("foo.war"));
+        assert!(ScanWorkspace::is_archive("foo.ear"));
+        assert!(ScanWorkspace::is_archive("foo.egg"));
+        assert!(!ScanWorkspace::is_archive("Cargo.lock"));
+        assert!(!ScanWorkspace::is_archive("package.json"));
+        assert!(!ScanWorkspace::is_archive("foo.rs"));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -129,15 +129,13 @@ impl ScanWorkspace {
             .to_string_lossy()
             .to_lowercase();
 
+        let src = archive_path.to_string_lossy();
+        let dst = dest.to_string_lossy();
+
         let output =
             if name.ends_with(".tar.gz") || name.ends_with(".tgz") || name.ends_with(".crate") {
                 tokio::process::Command::new("tar")
-                    .args([
-                        "xzf",
-                        &archive_path.to_string_lossy(),
-                        "-C",
-                        &dest.to_string_lossy(),
-                    ])
+                    .args(["xzf", &src, "-C", &dst])
                     .output()
                     .await
             } else if name.ends_with(".zip")
@@ -149,23 +147,12 @@ impl ScanWorkspace {
                 || name.ends_with(".egg")
             {
                 tokio::process::Command::new("unzip")
-                    .args([
-                        "-o",
-                        "-q",
-                        &archive_path.to_string_lossy(),
-                        "-d",
-                        &dest.to_string_lossy(),
-                    ])
+                    .args(["-o", "-q", &src, "-d", &dst])
                     .output()
                     .await
             } else if name.ends_with(".gem") {
                 tokio::process::Command::new("tar")
-                    .args([
-                        "xf",
-                        &archive_path.to_string_lossy(),
-                        "-C",
-                        &dest.to_string_lossy(),
-                    ])
+                    .args(["xf", &src, "-C", &dst])
                     .output()
                     .await
             } else {

--- a/backend/src/services/trivy_fs_scanner.rs
+++ b/backend/src/services/trivy_fs_scanner.rs
@@ -322,12 +322,12 @@ impl Scanner for TrivyFsScanner {
                 match self.scan_with_standalone_cli(&workspace).await {
                     Ok(report) => report,
                     Err(e) => {
-                        warn!(
-                            "Trivy filesystem scan failed for {}: {}. Returning empty findings.",
-                            artifact.name, e
-                        );
+                        warn!("Trivy filesystem scan failed for {}: {}", artifact.name, e);
                         self.cleanup_workspace(artifact).await;
-                        return Ok(vec![]);
+                        return Err(AppError::Internal(format!(
+                            "Trivy filesystem scan failed for {}: {}",
+                            artifact.name, e
+                        )));
                     }
                 }
             }
@@ -478,5 +478,72 @@ mod tests {
             .as_ref()
             .unwrap()
             .contains("requests"));
+    }
+
+    /// When the scan workspace cannot be created, prepare_workspace fails
+    /// and the error propagates to the caller. This exercises the error path
+    /// that would previously have been swallowed.
+    #[tokio::test]
+    async fn test_scan_returns_error_when_workspace_creation_fails() {
+        // Use a path under /dev/null which cannot contain subdirectories
+        let scanner = TrivyFsScanner::new(
+            "http://localhost:0".to_string(),
+            "/dev/null/impossible-workspace".to_string(),
+        );
+        let artifact = make_artifact(
+            "my-lib-1.0.0.tar.gz",
+            "application/gzip",
+            "pypi/my-lib/1.0.0/my-lib-1.0.0.tar.gz",
+        );
+        let content = bytes::Bytes::from_static(b"not a real archive");
+
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err when workspace creation fails"
+        );
+    }
+
+    /// When both Trivy CLI modes fail, the scanner must return Err so the
+    /// orchestrator can record a failed scan with an error message, instead
+    /// of recording 0 findings and making the artifact appear clean.
+    ///
+    /// This test is skipped when Trivy is installed, since Trivy can
+    /// legitimately scan the raw file and return 0 findings.
+    #[tokio::test]
+    async fn test_scan_returns_error_when_trivy_unavailable() {
+        // If trivy is installed, the scanner will succeed (legitimately), so skip.
+        if std::process::Command::new("trivy")
+            .arg("--version")
+            .output()
+            .is_ok()
+        {
+            eprintln!("trivy is installed, skipping unavailable-trivy test");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let scanner = TrivyFsScanner::new(
+            "http://localhost:0".to_string(),
+            dir.path().to_string_lossy().to_string(),
+        );
+        let artifact = make_artifact(
+            "my-lib-1.0.0.tar.gz",
+            "application/gzip",
+            "pypi/my-lib/1.0.0/my-lib-1.0.0.tar.gz",
+        );
+        let content = bytes::Bytes::from_static(b"not a real archive");
+
+        let result = scanner.scan(&artifact, None, &content).await;
+        assert!(
+            result.is_err(),
+            "scan() must return Err when trivy execution fails, not Ok(vec![])"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Trivy filesystem scan failed"),
+            "error message should indicate trivy failure, got: {}",
+            err_msg
+        );
     }
 }

--- a/backend/src/services/trivy_fs_scanner.rs
+++ b/backend/src/services/trivy_fs_scanner.rs
@@ -57,64 +57,48 @@ impl TrivyFsScanner {
             .any(|ext| name_lower.ends_with(ext))
     }
 
-    /// Attempt to scan using the Trivy CLI with server mode.
-    async fn scan_with_cli(&self, workspace: &Path) -> Result<TrivyReport> {
+    /// Run Trivy filesystem scan, optionally connecting to a server.
+    /// When `server_url` is Some, `--server <url>` is added to the command.
+    async fn run_trivy(&self, workspace: &Path, server_url: Option<&str>) -> Result<TrivyReport> {
+        let ws = workspace.to_string_lossy();
+        let mut args = vec!["filesystem"];
+        if let Some(url) = server_url {
+            args.push("--server");
+            args.push(url);
+        }
+        args.extend_from_slice(&[
+            "--format",
+            "json",
+            "--severity",
+            "CRITICAL,HIGH,MEDIUM,LOW",
+            "--quiet",
+            "--timeout",
+            "5m",
+            &ws,
+        ]);
+
+        let mode_label = if server_url.is_some() {
+            "server"
+        } else {
+            "standalone"
+        };
+
         let output = tokio::process::Command::new("trivy")
-            .args([
-                "filesystem",
-                "--server",
-                &self.trivy_url,
-                "--format",
-                "json",
-                "--severity",
-                "CRITICAL,HIGH,MEDIUM,LOW",
-                "--quiet",
-                "--timeout",
-                "5m",
-                &workspace.to_string_lossy(),
-            ])
+            .args(&args)
             .output()
             .await
             .map_err(|e| AppError::Internal(format!("Failed to execute Trivy CLI: {}", e)))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("not found") || stderr.contains("No such file") {
+            if server_url.is_some()
+                && (stderr.contains("not found") || stderr.contains("No such file"))
+            {
                 return Err(AppError::Internal("Trivy CLI not available".to_string()));
             }
             return Err(AppError::Internal(format!(
-                "Trivy filesystem scan failed (exit {}): {}",
-                output.status, stderr
-            )));
-        }
-
-        serde_json::from_slice(&output.stdout)
-            .map_err(|e| AppError::Internal(format!("Failed to parse Trivy output: {}", e)))
-    }
-
-    /// Fallback: scan using Trivy standalone CLI (no server).
-    async fn scan_with_standalone_cli(&self, workspace: &Path) -> Result<TrivyReport> {
-        let output = tokio::process::Command::new("trivy")
-            .args([
-                "filesystem",
-                "--format",
-                "json",
-                "--severity",
-                "CRITICAL,HIGH,MEDIUM,LOW",
-                "--quiet",
-                "--timeout",
-                "5m",
-                &workspace.to_string_lossy(),
-            ])
-            .output()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to execute Trivy CLI: {}", e)))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(AppError::Internal(format!(
-                "Trivy standalone scan failed (exit {}): {}",
-                output.status, stderr
+                "Trivy {} scan failed (exit {}): {}",
+                mode_label, output.status, stderr
             )));
         }
 
@@ -152,14 +136,14 @@ impl Scanner for TrivyFsScanner {
             ScanWorkspace::prepare(&self.scan_workspace, None, artifact, content).await?;
 
         // Try CLI with server mode first, then standalone
-        let report = match self.scan_with_cli(&workspace).await {
+        let report = match self.run_trivy(&workspace, Some(&self.trivy_url)).await {
             Ok(report) => report,
             Err(e) => {
                 warn!(
                     "Trivy server-mode CLI failed for {}: {}. Trying standalone mode.",
                     artifact.name, e
                 );
-                match self.scan_with_standalone_cli(&workspace).await {
+                match self.run_trivy(&workspace, None).await {
                     Ok(report) => report,
                     Err(e) => {
                         return Err(fail_scan(
@@ -193,27 +177,10 @@ impl Scanner for TrivyFsScanner {
 mod tests {
     use super::*;
     use crate::models::security::Severity;
+    use crate::services::scanner_service::test_helpers::{assert_scan_failed, make_test_artifact};
 
     fn make_artifact(name: &str, content_type: &str, path: &str) -> Artifact {
-        Artifact {
-            id: uuid::Uuid::new_v4(),
-            repository_id: uuid::Uuid::new_v4(),
-            path: path.to_string(),
-            name: name.to_string(),
-            version: Some("1.0.0".to_string()),
-            size_bytes: 1000,
-            checksum_sha256: "abc123".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: content_type.to_string(),
-            storage_key: "test".to_string(),
-            is_deleted: false,
-            uploaded_by: None,
-            quarantine_status: None,
-            quarantine_until: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        }
+        make_test_artifact(name, content_type, path)
     }
 
     #[test]
@@ -274,20 +241,6 @@ mod tests {
             "v2/myapp/manifests/v1.0.0",
         );
         assert!(!TrivyFsScanner::is_applicable(&artifact));
-    }
-
-    #[test]
-    fn test_is_archive() {
-        assert!(ScanWorkspace::is_archive("foo.tar.gz"));
-        assert!(ScanWorkspace::is_archive("foo.tgz"));
-        assert!(ScanWorkspace::is_archive("foo.whl"));
-        assert!(ScanWorkspace::is_archive("foo.jar"));
-        assert!(ScanWorkspace::is_archive("foo.zip"));
-        assert!(ScanWorkspace::is_archive("foo.gem"));
-        assert!(ScanWorkspace::is_archive("foo.crate"));
-        assert!(ScanWorkspace::is_archive("foo.nupkg"));
-        assert!(!ScanWorkspace::is_archive("Cargo.lock"));
-        assert!(!ScanWorkspace::is_archive("package.json"));
     }
 
     #[test]
@@ -377,15 +330,6 @@ mod tests {
         let content = bytes::Bytes::from_static(b"not a real archive");
 
         let result = scanner.scan(&artifact, None, &content).await;
-        assert!(
-            result.is_err(),
-            "scan() must return Err when trivy execution fails, not Ok(vec![])"
-        );
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("Trivy filesystem scan failed"),
-            "error message should indicate trivy failure, got: {}",
-            err_msg
-        );
+        assert_scan_failed(&result, "Trivy filesystem scan");
     }
 }

--- a/backend/src/services/trivy_fs_scanner.rs
+++ b/backend/src/services/trivy_fs_scanner.rs
@@ -179,68 +179,61 @@ mod tests {
     use crate::models::security::Severity;
     use crate::services::scanner_service::test_helpers::{assert_scan_failed, make_test_artifact};
 
-    fn make_artifact(name: &str, content_type: &str, path: &str) -> Artifact {
-        make_test_artifact(name, content_type, path)
-    }
-
     #[test]
-    fn test_is_applicable_tar_gz() {
-        let artifact = make_artifact(
-            "my-lib-1.0.0.tar.gz",
-            "application/gzip",
-            "pypi/my-lib/1.0.0/my-lib-1.0.0.tar.gz",
-        );
-        assert!(TrivyFsScanner::is_applicable(&artifact));
-    }
+    fn test_is_applicable() {
+        // Scannable archive formats
+        let applicable = [
+            (
+                "my-lib-1.0.0.tar.gz",
+                "application/gzip",
+                "pypi/my-lib/1.0.0/my-lib-1.0.0.tar.gz",
+            ),
+            (
+                "my_lib-1.0.0-py3-none-any.whl",
+                "application/zip",
+                "pypi/my-lib/1.0.0/my_lib-1.0.0-py3-none-any.whl",
+            ),
+            (
+                "myapp-1.0.0.jar",
+                "application/java-archive",
+                "maven/com/example/myapp/1.0.0/myapp-1.0.0.jar",
+            ),
+            (
+                "my-crate-1.0.0.crate",
+                "application/gzip",
+                "crates/my-crate/1.0.0/my-crate-1.0.0.crate",
+            ),
+        ];
+        for (name, ct, path) in applicable {
+            let a = make_test_artifact(name, ct, path);
+            assert!(
+                TrivyFsScanner::is_applicable(&a),
+                "expected applicable: {}",
+                name
+            );
+        }
 
-    #[test]
-    fn test_is_applicable_wheel() {
-        let artifact = make_artifact(
-            "my_lib-1.0.0-py3-none-any.whl",
-            "application/zip",
-            "pypi/my-lib/1.0.0/my_lib-1.0.0-py3-none-any.whl",
-        );
-        assert!(TrivyFsScanner::is_applicable(&artifact));
-    }
-
-    #[test]
-    fn test_is_applicable_jar() {
-        let artifact = make_artifact(
-            "myapp-1.0.0.jar",
-            "application/java-archive",
-            "maven/com/example/myapp/1.0.0/myapp-1.0.0.jar",
-        );
-        assert!(TrivyFsScanner::is_applicable(&artifact));
-    }
-
-    #[test]
-    fn test_is_applicable_crate() {
-        let artifact = make_artifact(
-            "my-crate-1.0.0.crate",
-            "application/gzip",
-            "crates/my-crate/1.0.0/my-crate-1.0.0.crate",
-        );
-        assert!(TrivyFsScanner::is_applicable(&artifact));
-    }
-
-    #[test]
-    fn test_not_applicable_oci_manifest() {
-        let artifact = make_artifact(
-            "myapp",
-            "application/vnd.oci.image.manifest.v1+json",
-            "v2/myapp/manifests/latest",
-        );
-        assert!(!TrivyFsScanner::is_applicable(&artifact));
-    }
-
-    #[test]
-    fn test_not_applicable_docker_manifest() {
-        let artifact = make_artifact(
-            "myapp",
-            "application/vnd.docker.distribution.manifest.v2+json",
-            "v2/myapp/manifests/v1.0.0",
-        );
-        assert!(!TrivyFsScanner::is_applicable(&artifact));
+        // Container manifests are scanned by the image scanner, not trivy-fs
+        let not_applicable = [
+            (
+                "myapp",
+                "application/vnd.oci.image.manifest.v1+json",
+                "v2/myapp/manifests/latest",
+            ),
+            (
+                "myapp",
+                "application/vnd.docker.distribution.manifest.v2+json",
+                "v2/myapp/manifests/v1.0.0",
+            ),
+        ];
+        for (name, ct, path) in not_applicable {
+            let a = make_test_artifact(name, ct, path);
+            assert!(
+                !TrivyFsScanner::is_applicable(&a),
+                "expected not applicable: {}",
+                name
+            );
+        }
     }
 
     #[test]
@@ -275,39 +268,28 @@ mod tests {
             .contains("requests"));
     }
 
-    /// When the scan workspace cannot be created, prepare_workspace fails
-    /// and the error propagates to the caller. This exercises the error path
-    /// that would previously have been swallowed.
+    /// Scan failures (workspace creation, missing Trivy binary) must
+    /// propagate as Err, never as Ok(vec![]).
     #[tokio::test]
-    async fn test_scan_returns_error_when_workspace_creation_fails() {
-        // Use a path under /dev/null which cannot contain subdirectories
-        let scanner = TrivyFsScanner::new(
-            "http://localhost:0".to_string(),
-            "/dev/null/impossible-workspace".to_string(),
-        );
-        let artifact = make_artifact(
+    async fn test_scan_propagates_errors() {
+        let artifact = make_test_artifact(
             "my-lib-1.0.0.tar.gz",
             "application/gzip",
             "pypi/my-lib/1.0.0/my-lib-1.0.0.tar.gz",
         );
         let content = bytes::Bytes::from_static(b"not a real archive");
 
-        let result = scanner.scan(&artifact, None, &content).await;
+        // Impossible workspace path: /dev/null cannot contain subdirectories
+        let bad_ws = TrivyFsScanner::new(
+            "http://localhost:0".to_string(),
+            "/dev/null/impossible-workspace".to_string(),
+        );
         assert!(
-            result.is_err(),
+            bad_ws.scan(&artifact, None, &content).await.is_err(),
             "scan() must return Err when workspace creation fails"
         );
-    }
 
-    /// When both Trivy CLI modes fail, the scanner must return Err so the
-    /// orchestrator can record a failed scan with an error message, instead
-    /// of recording 0 findings and making the artifact appear clean.
-    ///
-    /// This test is skipped when Trivy is installed, since Trivy can
-    /// legitimately scan the raw file and return 0 findings.
-    #[tokio::test]
-    async fn test_scan_returns_error_when_trivy_unavailable() {
-        // If trivy is installed, the scanner will succeed (legitimately), so skip.
+        // Missing trivy binary (skip if trivy is installed)
         if std::process::Command::new("trivy")
             .arg("--version")
             .output()
@@ -316,20 +298,14 @@ mod tests {
             eprintln!("trivy is installed, skipping unavailable-trivy test");
             return;
         }
-
         let dir = tempfile::tempdir().unwrap();
-        let scanner = TrivyFsScanner::new(
+        let no_trivy = TrivyFsScanner::new(
             "http://localhost:0".to_string(),
             dir.path().to_string_lossy().to_string(),
         );
-        let artifact = make_artifact(
-            "my-lib-1.0.0.tar.gz",
-            "application/gzip",
-            "pypi/my-lib/1.0.0/my-lib-1.0.0.tar.gz",
+        assert_scan_failed(
+            &no_trivy.scan(&artifact, None, &content).await,
+            "Trivy filesystem scan",
         );
-        let content = bytes::Bytes::from_static(b"not a real archive");
-
-        let result = scanner.scan(&artifact, None, &content).await;
-        assert_scan_failed(&result, "Trivy filesystem scan");
     }
 }

--- a/backend/src/services/trivy_fs_scanner.rs
+++ b/backend/src/services/trivy_fs_scanner.rs
@@ -5,14 +5,14 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tracing::{info, warn};
 
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
-use crate::models::security::{RawFinding, Severity};
+use crate::models::security::RawFinding;
 use crate::services::image_scanner::TrivyReport;
-use crate::services::scanner_service::{sanitize_artifact_filename, Scanner};
+use crate::services::scanner_service::{convert_trivy_findings, fail_scan, ScanWorkspace, Scanner};
 
 /// Filesystem-based Trivy scanner for packages, libraries, and archives.
 pub struct TrivyFsScanner {
@@ -55,137 +55,6 @@ impl TrivyFsScanner {
         scannable_extensions
             .iter()
             .any(|ext| name_lower.ends_with(ext))
-    }
-
-    /// Build the workspace directory path for a given artifact.
-    fn workspace_dir(&self, artifact: &Artifact) -> PathBuf {
-        Path::new(&self.scan_workspace).join(artifact.id.to_string())
-    }
-
-    /// Prepare the scan workspace: write artifact content and extract archives.
-    async fn prepare_workspace(&self, artifact: &Artifact, content: &Bytes) -> Result<PathBuf> {
-        let workspace = self.workspace_dir(artifact);
-        tokio::fs::create_dir_all(&workspace)
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to create scan workspace: {}", e)))?;
-
-        // Use the original filename from the path (last segment) for correct extension detection,
-        // then sanitize to basename to prevent path traversal
-        let original_filename = artifact.path.rsplit('/').next().unwrap_or(&artifact.name);
-        let safe_filename = sanitize_artifact_filename(original_filename);
-        let artifact_path = workspace.join(&safe_filename);
-
-        tokio::fs::write(&artifact_path, content)
-            .await
-            .map_err(|e| {
-                AppError::Internal(format!("Failed to write artifact to workspace: {}", e))
-            })?;
-
-        // Extract archives into the workspace directory
-        if Self::is_archive(original_filename) {
-            if let Err(e) = Self::extract_archive(&artifact_path, &workspace).await {
-                warn!(
-                    "Failed to extract archive {}: {}. Scanning raw file instead.",
-                    artifact.name, e
-                );
-            }
-        }
-
-        Ok(workspace)
-    }
-
-    /// Check if the file is an extractable archive.
-    fn is_archive(name: &str) -> bool {
-        let lower = name.to_lowercase();
-        lower.ends_with(".tar.gz")
-            || lower.ends_with(".tgz")
-            || lower.ends_with(".whl")
-            || lower.ends_with(".jar")
-            || lower.ends_with(".war")
-            || lower.ends_with(".ear")
-            || lower.ends_with(".gem")
-            || lower.ends_with(".crate")
-            || lower.ends_with(".nupkg")
-            || lower.ends_with(".zip")
-            || lower.ends_with(".egg")
-    }
-
-    /// Extract an archive file into the given directory using system tools.
-    async fn extract_archive(archive_path: &Path, dest: &Path) -> Result<()> {
-        let name = archive_path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_lowercase();
-
-        let output =
-            if name.ends_with(".tar.gz") || name.ends_with(".tgz") || name.ends_with(".crate") {
-                tokio::process::Command::new("tar")
-                    .args([
-                        "xzf",
-                        &archive_path.to_string_lossy(),
-                        "-C",
-                        &dest.to_string_lossy(),
-                    ])
-                    .output()
-                    .await
-            } else if name.ends_with(".zip")
-                || name.ends_with(".whl")
-                || name.ends_with(".jar")
-                || name.ends_with(".war")
-                || name.ends_with(".ear")
-                || name.ends_with(".nupkg")
-                || name.ends_with(".egg")
-            {
-                tokio::process::Command::new("unzip")
-                    .args([
-                        "-o",
-                        "-q",
-                        &archive_path.to_string_lossy(),
-                        "-d",
-                        &dest.to_string_lossy(),
-                    ])
-                    .output()
-                    .await
-            } else if name.ends_with(".gem") {
-                // Ruby gems are tar archives with a data.tar.gz inside
-                tokio::process::Command::new("tar")
-                    .args([
-                        "xf",
-                        &archive_path.to_string_lossy(),
-                        "-C",
-                        &dest.to_string_lossy(),
-                    ])
-                    .output()
-                    .await
-            } else {
-                return Ok(());
-            };
-
-        match output {
-            Ok(o) if o.status.success() => Ok(()),
-            Ok(o) => Err(AppError::Internal(format!(
-                "Archive extraction failed (exit {}): {}",
-                o.status,
-                String::from_utf8_lossy(&o.stderr)
-            ))),
-            Err(e) => Err(AppError::Internal(format!(
-                "Failed to execute extraction command: {}",
-                e
-            ))),
-        }
-    }
-
-    /// Clean up the scan workspace directory.
-    async fn cleanup_workspace(&self, artifact: &Artifact) {
-        let workspace = self.workspace_dir(artifact);
-        if let Err(e) = tokio::fs::remove_dir_all(&workspace).await {
-            warn!(
-                "Failed to clean up scan workspace {}: {}",
-                workspace.display(),
-                e
-            );
-        }
     }
 
     /// Attempt to scan using the Trivy CLI with server mode.
@@ -252,35 +121,6 @@ impl TrivyFsScanner {
         serde_json::from_slice(&output.stdout)
             .map_err(|e| AppError::Internal(format!("Failed to parse Trivy output: {}", e)))
     }
-
-    /// Convert Trivy report vulnerabilities into `RawFinding` values.
-    fn convert_findings(report: &TrivyReport) -> Vec<RawFinding> {
-        report
-            .results
-            .iter()
-            .flat_map(|result| {
-                result
-                    .vulnerabilities
-                    .as_deref()
-                    .unwrap_or(&[])
-                    .iter()
-                    .map(move |vuln| RawFinding {
-                        severity: Severity::from_str_loose(&vuln.severity)
-                            .unwrap_or(Severity::Info),
-                        title: vuln.title.clone().unwrap_or_else(|| {
-                            format!("{} in {}", vuln.vulnerability_id, vuln.pkg_name)
-                        }),
-                        description: vuln.description.clone(),
-                        cve_id: Some(vuln.vulnerability_id.clone()),
-                        affected_component: Some(format!("{} ({})", vuln.pkg_name, result.target)),
-                        affected_version: Some(vuln.installed_version.clone()),
-                        fixed_version: vuln.fixed_version.clone(),
-                        source: Some("trivy-filesystem".to_string()),
-                        source_url: vuln.primary_url.clone(),
-                    })
-            })
-            .collect()
-    }
 }
 
 #[async_trait]
@@ -308,10 +148,10 @@ impl Scanner for TrivyFsScanner {
             artifact.name, artifact.id
         );
 
-        // Prepare workspace with artifact content
-        let workspace = self.prepare_workspace(artifact, content).await?;
+        let workspace =
+            ScanWorkspace::prepare(&self.scan_workspace, None, artifact, content).await?;
 
-        // Try CLI with server mode first, then standalone, then degrade gracefully
+        // Try CLI with server mode first, then standalone
         let report = match self.scan_with_cli(&workspace).await {
             Ok(report) => report,
             Err(e) => {
@@ -322,18 +162,20 @@ impl Scanner for TrivyFsScanner {
                 match self.scan_with_standalone_cli(&workspace).await {
                     Ok(report) => report,
                     Err(e) => {
-                        warn!("Trivy filesystem scan failed for {}: {}", artifact.name, e);
-                        self.cleanup_workspace(artifact).await;
-                        return Err(AppError::Internal(format!(
-                            "Trivy filesystem scan failed for {}: {}",
-                            artifact.name, e
-                        )));
+                        return Err(fail_scan(
+                            "Trivy filesystem scan",
+                            artifact,
+                            &e,
+                            &self.scan_workspace,
+                            None,
+                        )
+                        .await);
                     }
                 }
             }
         };
 
-        let findings = Self::convert_findings(&report);
+        let findings = convert_trivy_findings(&report, "trivy-filesystem");
 
         info!(
             "Trivy filesystem scan complete for {}: {} vulnerabilities found",
@@ -341,8 +183,7 @@ impl Scanner for TrivyFsScanner {
             findings.len()
         );
 
-        // Clean up workspace
-        self.cleanup_workspace(artifact).await;
+        ScanWorkspace::cleanup(&self.scan_workspace, None, artifact).await;
 
         Ok(findings)
     }
@@ -351,6 +192,7 @@ impl Scanner for TrivyFsScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::security::Severity;
 
     fn make_artifact(name: &str, content_type: &str, path: &str) -> Artifact {
         Artifact {
@@ -436,16 +278,16 @@ mod tests {
 
     #[test]
     fn test_is_archive() {
-        assert!(TrivyFsScanner::is_archive("foo.tar.gz"));
-        assert!(TrivyFsScanner::is_archive("foo.tgz"));
-        assert!(TrivyFsScanner::is_archive("foo.whl"));
-        assert!(TrivyFsScanner::is_archive("foo.jar"));
-        assert!(TrivyFsScanner::is_archive("foo.zip"));
-        assert!(TrivyFsScanner::is_archive("foo.gem"));
-        assert!(TrivyFsScanner::is_archive("foo.crate"));
-        assert!(TrivyFsScanner::is_archive("foo.nupkg"));
-        assert!(!TrivyFsScanner::is_archive("Cargo.lock"));
-        assert!(!TrivyFsScanner::is_archive("package.json"));
+        assert!(ScanWorkspace::is_archive("foo.tar.gz"));
+        assert!(ScanWorkspace::is_archive("foo.tgz"));
+        assert!(ScanWorkspace::is_archive("foo.whl"));
+        assert!(ScanWorkspace::is_archive("foo.jar"));
+        assert!(ScanWorkspace::is_archive("foo.zip"));
+        assert!(ScanWorkspace::is_archive("foo.gem"));
+        assert!(ScanWorkspace::is_archive("foo.crate"));
+        assert!(ScanWorkspace::is_archive("foo.nupkg"));
+        assert!(!ScanWorkspace::is_archive("Cargo.lock"));
+        assert!(!ScanWorkspace::is_archive("package.json"));
     }
 
     #[test]
@@ -468,7 +310,7 @@ mod tests {
             }],
         };
 
-        let findings = TrivyFsScanner::convert_findings(&report);
+        let findings = convert_trivy_findings(&report, "trivy-filesystem");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, Severity::High);
         assert_eq!(findings[0].cve_id, Some("CVE-2023-12345".to_string()));


### PR DESCRIPTION
## Summary

When a scan tool (Grype, Trivy filesystem, OpenSCAP, or Incus) failed to execute, all four scanners caught the error internally and returned `Ok(vec![])`. The orchestrator then recorded the result as "completed" with 0 findings, indistinguishable from a genuinely clean scan. This masked extraction errors, missing binaries, and unreachable sidecars behind a false "clean" status.

Changed all four scanners to propagate errors via `Err(...)` when the underlying scan tool fails. The orchestrator already handles the `Err` path correctly by calling `fail_scan()` (which sets status to "failed" with an error message) and setting `quarantine_status` to "flagged".

Files changed:
- `backend/src/services/grype_scanner.rs`
- `backend/src/services/trivy_fs_scanner.rs`
- `backend/src/services/openscap_scanner.rs`
- `backend/src/services/incus_scanner.rs`

Fixes #723

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes