### PR TITLE
feat: add get_stream/put_stream to StorageBackend trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4071,7 +4071,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4785,9 +4785,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -2,12 +2,20 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tokio::fs;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio_util::io::ReaderStream;
+use uuid::Uuid;
 
-use super::StorageBackend;
+use super::{PutStreamResult, StorageBackend};
 use crate::error::{AppError, Result};
+
+/// Chunk size for streaming reads (256 KB).
+const STREAM_CHUNK_SIZE: usize = 256 * 1024;
 
 /// Filesystem-based storage backend
 pub struct FilesystemStorage {
@@ -85,6 +93,80 @@ impl StorageBackend for FilesystemStorage {
             .await
             .map_err(|e| AppError::Storage(format!("Failed to copy file to {}: {}", key, e)))?;
         Ok(())
+    }
+
+    async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
+        let path = self.key_to_path(key);
+        let file = fs::File::open(&path)
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to open {}: {}", key, e)))?;
+
+        let reader = BufReader::new(file);
+        let stream = ReaderStream::with_capacity(reader, STREAM_CHUNK_SIZE);
+
+        // Map tokio io errors to our Result type
+        let mapped = stream
+            .map(|result| result.map_err(|e| AppError::Storage(format!("Read error: {}", e))));
+
+        Ok(Box::pin(mapped))
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        stream: BoxStream<'static, Result<Bytes>>,
+    ) -> Result<PutStreamResult> {
+        let dest = self.key_to_path(key);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+
+        // Write to a temp file in the same directory so rename is atomic
+        // (same filesystem guarantees atomic rename on POSIX).
+        let temp_path = dest.with_extension(format!("tmp.{}", Uuid::new_v4()));
+        let mut file = fs::File::create(&temp_path)
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to create temp file: {}", e)))?;
+
+        let mut hasher = Sha256::new();
+        let mut total: u64 = 0;
+
+        tokio::pin!(stream);
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(data) => {
+                    hasher.update(&data);
+                    total += data.len() as u64;
+                    if let Err(e) = file.write_all(&data).await {
+                        let _ = fs::remove_file(&temp_path).await;
+                        return Err(AppError::Storage(format!("Write error: {}", e)));
+                    }
+                }
+                Err(e) => {
+                    let _ = fs::remove_file(&temp_path).await;
+                    return Err(e);
+                }
+            }
+        }
+
+        // Flush and sync to disk before renaming
+        if let Err(e) = file.sync_all().await {
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(AppError::Storage(format!("Sync error: {}", e)));
+        }
+        drop(file);
+
+        // Atomic rename
+        fs::rename(&temp_path, &dest).await.map_err(|e| {
+            // Best-effort cleanup; the temp file may already be gone
+            let _ = std::fs::remove_file(&temp_path);
+            AppError::Storage(format!("Rename error: {}", e))
+        })?;
+
+        Ok(PutStreamResult {
+            checksum_sha256: format!("{:x}", hasher.finalize()),
+            bytes_written: total,
+        })
     }
 }
 
@@ -284,5 +366,217 @@ mod tests {
 
         let retrieved = storage.get(key).await.unwrap();
         assert_eq!(retrieved, Bytes::from_static(b"updated"));
+    }
+
+    // --- get_stream tests ---
+
+    #[tokio::test]
+    async fn test_get_stream_returns_correct_content() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let content = Bytes::from_static(b"streaming content here");
+        storage.put(key, content.clone()).await.unwrap();
+
+        let mut stream = storage.get_stream(key).await.unwrap();
+        let mut collected = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(collected, content.as_ref());
+    }
+
+    #[tokio::test]
+    async fn test_get_stream_large_file_produces_multiple_chunks() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        // Create content larger than STREAM_CHUNK_SIZE (256 KB)
+        let size = STREAM_CHUNK_SIZE * 3 + 100;
+        let content = Bytes::from(vec![0xABu8; size]);
+        storage.put(key, content.clone()).await.unwrap();
+
+        let mut stream = storage.get_stream(key).await.unwrap();
+        let mut chunk_count = 0u64;
+        let mut total_bytes = 0usize;
+        while let Some(chunk) = stream.next().await {
+            let data = chunk.unwrap();
+            total_bytes += data.len();
+            chunk_count += 1;
+        }
+        assert_eq!(total_bytes, size);
+        // Multiple chunks expected for a file > STREAM_CHUNK_SIZE
+        assert!(
+            chunk_count > 1,
+            "expected multiple chunks, got {}",
+            chunk_count
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_stream_nonexistent_key_returns_error() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let result = storage.get_stream("nonexistent-key1234").await;
+        assert!(result.is_err());
+    }
+
+    // --- put_stream tests ---
+
+    #[tokio::test]
+    async fn test_put_stream_writes_correct_content() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let chunks: Vec<Result<Bytes>> = vec![
+            Ok(Bytes::from_static(b"chunk1-")),
+            Ok(Bytes::from_static(b"chunk2-")),
+            Ok(Bytes::from_static(b"chunk3")),
+        ];
+        let stream = Box::pin(futures::stream::iter(chunks)) as BoxStream<'static, Result<Bytes>>;
+
+        let result = storage.put_stream(key, stream).await.unwrap();
+        assert_eq!(result.bytes_written, 20);
+
+        // Verify content was written correctly
+        let retrieved = storage.get(key).await.unwrap();
+        assert_eq!(retrieved.as_ref(), b"chunk1-chunk2-chunk3");
+    }
+
+    #[tokio::test]
+    async fn test_put_stream_computes_correct_sha256() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let data = Bytes::from_static(b"hello world");
+        let stream = Box::pin(futures::stream::once(async { Ok(data) }))
+            as BoxStream<'static, Result<Bytes>>;
+
+        let result = storage.put_stream(key, stream).await.unwrap();
+        assert_eq!(
+            result.checksum_sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_put_stream_atomic_rename_no_temp_file_left() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let data = Bytes::from_static(b"test data");
+        let stream = Box::pin(futures::stream::once(async { Ok(data) }))
+            as BoxStream<'static, Result<Bytes>>;
+
+        storage.put_stream(key, stream).await.unwrap();
+
+        // Walk the storage directory and verify no .tmp files remain
+        let mut entries = fs::read_dir(temp_dir.path()).await.unwrap();
+        let mut tmp_files = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            collect_tmp_files(entry.path(), &mut tmp_files).await;
+        }
+        assert!(
+            tmp_files.is_empty(),
+            "temp files should be cleaned up after put_stream, found: {:?}",
+            tmp_files
+        );
+    }
+
+    /// Recursively collect .tmp files under a path.
+    async fn collect_tmp_files(path: PathBuf, out: &mut Vec<PathBuf>) {
+        if path.is_dir() {
+            let mut entries = fs::read_dir(&path).await.unwrap();
+            while let Some(entry) = entries.next_entry().await.unwrap() {
+                Box::pin(collect_tmp_files(entry.path(), out)).await;
+            }
+        } else if path
+            .extension()
+            .map(|e| e.to_string_lossy().starts_with("tmp."))
+            .unwrap_or(false)
+        {
+            out.push(path);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_put_stream_cleans_temp_on_stream_error() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let chunks: Vec<Result<Bytes>> = vec![
+            Ok(Bytes::from_static(b"good data")),
+            Err(AppError::Storage("simulated stream error".into())),
+        ];
+        let stream = Box::pin(futures::stream::iter(chunks)) as BoxStream<'static, Result<Bytes>>;
+
+        let result = storage.put_stream(key, stream).await;
+        assert!(result.is_err());
+
+        // Verify no temp files or final files remain
+        let mut tmp_files = Vec::new();
+        let mut entries = fs::read_dir(temp_dir.path()).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            collect_tmp_files(entry.path(), &mut tmp_files).await;
+        }
+        assert!(
+            tmp_files.is_empty(),
+            "temp files should be cleaned up on error, found: {:?}",
+            tmp_files
+        );
+
+        // The final file should not exist either
+        assert!(!storage.exists(key).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_put_stream_empty_stream() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let stream = Box::pin(futures::stream::empty()) as BoxStream<'static, Result<Bytes>>;
+
+        let result = storage.put_stream(key, stream).await.unwrap();
+        assert_eq!(result.bytes_written, 0);
+        // SHA-256 of empty input
+        assert_eq!(
+            result.checksum_sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+
+        // Verify the file exists and is empty
+        let content = storage.get(key).await.unwrap();
+        assert!(content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_put_stream_roundtrip_with_get_stream() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "abcdef1234567890";
+        let original = b"roundtrip content for streaming test";
+        let data = Bytes::from_static(original);
+        let stream = Box::pin(futures::stream::once(async { Ok(data) }))
+            as BoxStream<'static, Result<Bytes>>;
+
+        let put_result = storage.put_stream(key, stream).await.unwrap();
+        assert_eq!(put_result.bytes_written, original.len() as u64);
+
+        // Read back via get_stream and verify
+        let mut read_stream = storage.get_stream(key).await.unwrap();
+        let mut collected = Vec::new();
+        while let Some(chunk) = read_stream.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(collected, original);
     }
 }

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -12,9 +12,19 @@ pub use registry::{StorageLocation, StorageRegistry};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::BoxStream;
 use std::time::Duration;
 
 use crate::error::Result;
+
+/// Result of a streaming put operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutStreamResult {
+    /// SHA-256 checksum computed incrementally during the write.
+    pub checksum_sha256: String,
+    /// Total bytes written.
+    pub bytes_written: u64,
+}
 
 /// Result of a presigned URL request
 #[derive(Debug, Clone)]
@@ -78,6 +88,44 @@ pub trait StorageBackend: Send + Sync {
     async fn put_file(&self, key: &str, path: &std::path::Path) -> Result<()> {
         let content = tokio::fs::read(path).await?;
         self.put(key, content.into()).await
+    }
+
+    /// Retrieve content as a byte stream instead of loading the full object
+    /// into memory. The default implementation wraps `get()` in a single-item
+    /// stream.
+    async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
+        let content = self.get(key).await?;
+        Ok(Box::pin(futures::stream::once(async { Ok(content) })))
+    }
+
+    /// Store content from a byte stream, computing a SHA-256 checksum
+    /// incrementally as data arrives. The default implementation collects
+    /// the stream into memory and delegates to `put()`.
+    async fn put_stream(
+        &self,
+        key: &str,
+        stream: BoxStream<'static, Result<Bytes>>,
+    ) -> Result<PutStreamResult> {
+        use futures::StreamExt;
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        let mut buf = Vec::new();
+        let mut total: u64 = 0;
+
+        tokio::pin!(stream);
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            hasher.update(&chunk);
+            total += chunk.len() as u64;
+            buf.extend_from_slice(&chunk);
+        }
+
+        self.put(key, Bytes::from(buf)).await?;
+        Ok(PutStreamResult {
+            checksum_sha256: format!("{:x}", hasher.finalize()),
+            bytes_written: total,
+        })
     }
 
     /// Perform a lightweight connectivity probe against the storage backend.
@@ -212,5 +260,98 @@ mod tests {
         assert_eq!(debug_str, "S3");
         let debug_str = format!("{:?}", PresignedUrlSource::CloudFront);
         assert_eq!(debug_str, "CloudFront");
+    }
+
+    #[test]
+    fn test_put_stream_result_construction() {
+        let result = PutStreamResult {
+            checksum_sha256: "abc123".to_string(),
+            bytes_written: 1024,
+        };
+        assert_eq!(result.checksum_sha256, "abc123");
+        assert_eq!(result.bytes_written, 1024);
+    }
+
+    #[test]
+    fn test_put_stream_result_clone() {
+        let result = PutStreamResult {
+            checksum_sha256: "def456".to_string(),
+            bytes_written: 512,
+        };
+        let cloned = result.clone();
+        assert_eq!(result, cloned);
+    }
+
+    #[test]
+    fn test_put_stream_result_debug() {
+        let result = PutStreamResult {
+            checksum_sha256: "abc".to_string(),
+            bytes_written: 0,
+        };
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("PutStreamResult"));
+        assert!(debug_str.contains("abc"));
+    }
+
+    #[tokio::test]
+    async fn test_default_get_stream() {
+        use futures::StreamExt;
+
+        let backend = TestBackend;
+        let mut stream = backend.get_stream("any-key").await.unwrap();
+
+        let mut collected = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(collected, b"test");
+    }
+
+    #[tokio::test]
+    async fn test_default_put_stream() {
+        let backend = TestBackend;
+        let data = Bytes::from_static(b"hello world");
+        let stream = Box::pin(futures::stream::once(async { Ok(data) }))
+            as BoxStream<'static, Result<Bytes>>;
+
+        let result = backend.put_stream("test-key", stream).await.unwrap();
+        assert_eq!(result.bytes_written, 11);
+        // SHA-256 of "hello world"
+        assert_eq!(
+            result.checksum_sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_put_stream_multi_chunk() {
+        let backend = TestBackend;
+        let chunks: Vec<Result<Bytes>> = vec![
+            Ok(Bytes::from_static(b"hello ")),
+            Ok(Bytes::from_static(b"world")),
+        ];
+        let stream = Box::pin(futures::stream::iter(chunks)) as BoxStream<'static, Result<Bytes>>;
+
+        let result = backend.put_stream("test-key", stream).await.unwrap();
+        assert_eq!(result.bytes_written, 11);
+        // Same content as above, so same hash
+        assert_eq!(
+            result.checksum_sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_put_stream_empty() {
+        let backend = TestBackend;
+        let stream = Box::pin(futures::stream::empty()) as BoxStream<'static, Result<Bytes>>;
+
+        let result = backend.put_stream("test-key", stream).await.unwrap();
+        assert_eq!(result.bytes_written, 0);
+        // SHA-256 of empty input
+        assert_eq!(
+            result.checksum_sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
     }
 }

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -29,13 +29,15 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::TryStreamExt;
+use futures::stream::BoxStream;
+use futures::{StreamExt, TryStreamExt};
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path as ObjectPath;
-use object_store::{ObjectStore, ObjectStoreExt};
+use object_store::{ObjectStore, ObjectStoreExt, WriteMultipart};
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 
-use super::{PresignedUrl, PresignedUrlSource, StoragePathFormat};
+use super::{PresignedUrl, PresignedUrlSource, PutStreamResult, StoragePathFormat};
 use crate::error::{AppError, Result};
 
 /// S3 storage backend configuration
@@ -642,6 +644,74 @@ impl super::StorageBackend for S3Backend {
                 }
             }
         }
+    }
+
+    async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
+        let full_key = self.full_key(key);
+        let path: ObjectPath = full_key.into();
+        let key_owned = key.to_string();
+
+        let result = self.store.get(&path).await.map_err(|e| match e {
+            object_store::Error::NotFound { .. } => {
+                AppError::NotFound(format!("Storage key not found: {}", key_owned))
+            }
+            _ => AppError::Storage(format!("Failed to get object '{}': {}", key_owned, e)),
+        })?;
+
+        let stream = result
+            .into_stream()
+            .map(|r| r.map_err(|e| AppError::Storage(format!("Stream read error: {}", e))));
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        stream: BoxStream<'static, Result<Bytes>>,
+    ) -> Result<PutStreamResult> {
+        let full_key = self.full_key(key);
+        let path: ObjectPath = full_key.into();
+
+        let upload = self.store.put_multipart(&path).await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to start multipart upload for '{}': {}",
+                key, e
+            ))
+        })?;
+
+        let mut write = WriteMultipart::new(upload);
+        let mut hasher = Sha256::new();
+        let mut total: u64 = 0;
+
+        tokio::pin!(stream);
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(data) => {
+                    hasher.update(&data);
+                    total += data.len() as u64;
+                    write.put(data);
+                }
+                Err(e) => {
+                    // Abort the multipart upload on stream error to avoid
+                    // leaving partial objects in S3.
+                    let _ = write.abort().await;
+                    return Err(e);
+                }
+            }
+        }
+
+        write.finish().await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to complete multipart upload for '{}': {}",
+                key, e
+            ))
+        })?;
+
+        Ok(PutStreamResult {
+            checksum_sha256: format!("{:x}", hasher.finalize()),
+            bytes_written: total,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Add streaming methods (`get_stream`, `put_stream`) to the `StorageBackend` trait as Phase 1 of the streaming proxy architecture (#737). This lays the foundation for eliminating full-artifact memory buffering in the proxy service.

Both methods have default implementations that wrap the existing `get()`/`put()` methods, so all existing backends and consumers continue to work without changes. The `FilesystemStorage` and `S3Backend` override with proper streaming implementations:

- **FilesystemStorage** `get_stream`: opens the file and returns a `ReaderStream` with 256 KB chunks, avoiding loading the entire file into memory.
- **FilesystemStorage** `put_stream`: writes to a temp file in the same directory (guaranteeing same-filesystem atomic rename), computes SHA-256 incrementally, fsyncs, then renames. Temp files are cleaned up on any error.
- **S3Backend** `get_stream`: uses `GetResult::into_stream()` from `object_store` instead of `.bytes().await`.
- **S3Backend** `put_stream`: uses `WriteMultipart` from `object_store` (5 MB part buffering handled internally), with `abort()` on stream error to prevent partial S3 objects.

GCS and Azure backends use the default (collect-then-delegate) implementations for now, preserving their current memory profile until native streaming is added in a follow-up.

Introduces `PutStreamResult` with `checksum_sha256` and `bytes_written` fields, returned by `put_stream`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

16 new tests:
- 3 for `PutStreamResult` (construction, clone, debug)
- 4 for default trait implementations (get_stream, put_stream single/multi/empty)
- 9 for `FilesystemStorage` overrides (correct content, chunking, nonexistent key error, multi-chunk write, SHA-256 verification, atomic rename with no temp files left, temp cleanup on stream error, empty stream, roundtrip with get_stream)

All 7642 tests pass. `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib` all clean.

## API Changes
- [x] N/A - no API changes

This is a storage-layer-only change. No handler, proxy service, or HTTP API modifications.