### PR TITLE
fix: add proxy OOM safeguards (semaphore + size limit)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,6 +262,28 @@ JWT_EXPIRATION_SECS=86400
 # MAX_UPLOAD_SIZE=10737418240
 
 # -----------------------------------------------------------------------------
+# Proxy safeguards (backend)
+# -----------------------------------------------------------------------------
+# These settings bound peak memory consumption when the proxy service fetches
+# artifacts from upstream registries on behalf of remote/proxy repositories.
+
+# Maximum number of concurrent upstream fetches. Each fetch loads the full
+# artifact into memory, so this limits how many large downloads can overlap.
+# Default: 20. Lower this on memory-constrained hosts.
+# PROXY_MAX_CONCURRENT_FETCHES=20
+
+# Maximum artifact size (in bytes) the proxy will accept from upstream.
+# Artifacts larger than this are rejected with 502 Bad Gateway.
+# Default: 2147483648 (2 GB).
+# PROXY_MAX_ARTIFACT_SIZE_BYTES=2147483648
+
+# Seconds to wait for a proxy fetch permit before returning 503.
+# When all concurrent fetch slots are in use, new requests queue for up to
+# this duration before being rejected.
+# Default: 30.
+# PROXY_QUEUE_TIMEOUT_SECS=30
+
+# -----------------------------------------------------------------------------
 # Rate limiting (backend)
 # -----------------------------------------------------------------------------
 # The built-in rate limiter is per-instance (in-memory). For multi-instance

--- a/backend/src/api/handlers/events.rs
+++ b/backend/src/api/handlers/events.rs
@@ -110,6 +110,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         }
     }

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -729,6 +729,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         }
     }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -122,6 +122,17 @@ pub struct Config {
     /// recovery mechanism when SSO is misconfigured.
     pub allow_local_admin_login: bool,
 
+    /// Maximum concurrent upstream proxy fetches. Bounds peak memory from
+    /// parallel proxy downloads. Set to 0 to disable (not recommended).
+    pub proxy_max_concurrent_fetches: u32,
+
+    /// Maximum artifact size in bytes that the proxy will fetch from upstream.
+    /// Requests for artifacts larger than this are rejected with 502.
+    pub proxy_max_artifact_size_bytes: u64,
+
+    /// Seconds to wait for a proxy fetch permit before returning 503.
+    pub proxy_queue_timeout_secs: u64,
+
     /// Port for the unauthenticated Prometheus metrics-only listener.
     ///
     /// When set, a second TCP listener is started on this port serving only
@@ -172,6 +183,9 @@ redacted_debug!(Config {
     show lifecycle_check_interval_secs,
     show max_upload_size_bytes,
     show allow_local_admin_login,
+    show proxy_max_concurrent_fetches,
+    show proxy_max_artifact_size_bytes,
+    show proxy_queue_timeout_secs,
     show metrics_port,
 });
 
@@ -238,6 +252,12 @@ impl Config {
             gc_schedule: env::var("GC_SCHEDULE").unwrap_or_else(|_| "0 0 * * * *".into()),
             lifecycle_check_interval_secs: env_parse("LIFECYCLE_CHECK_INTERVAL_SECS", 60),
             max_upload_size_bytes: env_parse("MAX_UPLOAD_SIZE", 10_737_418_240_u64),
+            proxy_max_concurrent_fetches: env_parse("PROXY_MAX_CONCURRENT_FETCHES", 20),
+            proxy_max_artifact_size_bytes: env_parse(
+                "PROXY_MAX_ARTIFACT_SIZE_BYTES",
+                2_147_483_648_u64,
+            ),
+            proxy_queue_timeout_secs: env_parse("PROXY_QUEUE_TIMEOUT_SECS", 30),
             allow_local_admin_login: matches!(
                 env::var("ALLOW_LOCAL_ADMIN_LOGIN").as_deref(),
                 Ok("true" | "1")
@@ -979,6 +999,102 @@ mod tests {
             env::set_var("MAX_UPLOAD_SIZE", v);
         } else {
             env::remove_var("MAX_UPLOAD_SIZE");
+        }
+    }
+
+    #[test]
+    fn test_proxy_config_defaults() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_fetches = env::var("PROXY_MAX_CONCURRENT_FETCHES").ok();
+        let saved_size = env::var("PROXY_MAX_ARTIFACT_SIZE_BYTES").ok();
+        let saved_timeout = env::var("PROXY_QUEUE_TIMEOUT_SECS").ok();
+
+        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("JWT_SECRET", "secret");
+        env::remove_var("PROXY_MAX_CONCURRENT_FETCHES");
+        env::remove_var("PROXY_MAX_ARTIFACT_SIZE_BYTES");
+        env::remove_var("PROXY_QUEUE_TIMEOUT_SECS");
+
+        let config = Config::from_env().unwrap();
+        assert_eq!(config.proxy_max_concurrent_fetches, 20);
+        assert_eq!(config.proxy_max_artifact_size_bytes, 2_147_483_648);
+        assert_eq!(config.proxy_queue_timeout_secs, 30);
+
+        // Restore
+        if let Some(v) = saved_db {
+            env::set_var("DATABASE_URL", v);
+        } else {
+            env::remove_var("DATABASE_URL");
+        }
+        if let Some(v) = saved_jwt {
+            env::set_var("JWT_SECRET", v);
+        } else {
+            env::remove_var("JWT_SECRET");
+        }
+        if let Some(v) = saved_fetches {
+            env::set_var("PROXY_MAX_CONCURRENT_FETCHES", v);
+        } else {
+            env::remove_var("PROXY_MAX_CONCURRENT_FETCHES");
+        }
+        if let Some(v) = saved_size {
+            env::set_var("PROXY_MAX_ARTIFACT_SIZE_BYTES", v);
+        } else {
+            env::remove_var("PROXY_MAX_ARTIFACT_SIZE_BYTES");
+        }
+        if let Some(v) = saved_timeout {
+            env::set_var("PROXY_QUEUE_TIMEOUT_SECS", v);
+        } else {
+            env::remove_var("PROXY_QUEUE_TIMEOUT_SECS");
+        }
+    }
+
+    #[test]
+    fn test_proxy_config_custom_values() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_fetches = env::var("PROXY_MAX_CONCURRENT_FETCHES").ok();
+        let saved_size = env::var("PROXY_MAX_ARTIFACT_SIZE_BYTES").ok();
+        let saved_timeout = env::var("PROXY_QUEUE_TIMEOUT_SECS").ok();
+
+        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("JWT_SECRET", "secret");
+        env::set_var("PROXY_MAX_CONCURRENT_FETCHES", "5");
+        env::set_var("PROXY_MAX_ARTIFACT_SIZE_BYTES", "536870912");
+        env::set_var("PROXY_QUEUE_TIMEOUT_SECS", "10");
+
+        let config = Config::from_env().unwrap();
+        assert_eq!(config.proxy_max_concurrent_fetches, 5);
+        assert_eq!(config.proxy_max_artifact_size_bytes, 536_870_912);
+        assert_eq!(config.proxy_queue_timeout_secs, 10);
+
+        // Restore
+        if let Some(v) = saved_db {
+            env::set_var("DATABASE_URL", v);
+        } else {
+            env::remove_var("DATABASE_URL");
+        }
+        if let Some(v) = saved_jwt {
+            env::set_var("JWT_SECRET", v);
+        } else {
+            env::remove_var("JWT_SECRET");
+        }
+        if let Some(v) = saved_fetches {
+            env::set_var("PROXY_MAX_CONCURRENT_FETCHES", v);
+        } else {
+            env::remove_var("PROXY_MAX_CONCURRENT_FETCHES");
+        }
+        if let Some(v) = saved_size {
+            env::set_var("PROXY_MAX_ARTIFACT_SIZE_BYTES", v);
+        } else {
+            env::remove_var("PROXY_MAX_ARTIFACT_SIZE_BYTES");
+        }
+        if let Some(v) = saved_timeout {
+            env::set_var("PROXY_QUEUE_TIMEOUT_SECS", v);
+        } else {
+            env::remove_var("PROXY_QUEUE_TIMEOUT_SECS");
         }
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -72,6 +72,9 @@ pub enum AppError {
 
     #[error("Bad gateway: {0}")]
     BadGateway(String),
+
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
 }
 
 impl AppError {
@@ -98,6 +101,7 @@ impl AppError {
             Self::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR"),
             Self::Wasm(_) => (StatusCode::INTERNAL_SERVER_ERROR, "WASM_ERROR"),
             Self::BadGateway(_) => (StatusCode::BAD_GATEWAY, "BAD_GATEWAY"),
+            Self::ServiceUnavailable(_) => (StatusCode::SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE"),
         }
     }
 
@@ -125,7 +129,8 @@ impl AppError {
             | Self::Conflict(msg)
             | Self::Validation(msg)
             | Self::QuotaExceeded(msg)
-            | Self::BadGateway(msg) => msg.clone(),
+            | Self::BadGateway(msg)
+            | Self::ServiceUnavailable(msg) => msg.clone(),
             Self::Json(_) => "Invalid JSON".to_string(),
         }
     }
@@ -282,6 +287,25 @@ mod tests {
             AppError::BadGateway("x".into()).status_and_code().1,
             "BAD_GATEWAY"
         );
+    }
+
+    #[test]
+    fn test_service_unavailable_status_code() {
+        assert_eq!(
+            AppError::ServiceUnavailable("x".into()).status_and_code().0,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            AppError::ServiceUnavailable("x".into()).status_and_code().1,
+            "SERVICE_UNAVAILABLE"
+        );
+    }
+
+    #[test]
+    fn test_service_unavailable_message() {
+        let err = AppError::ServiceUnavailable("queue full".to_string());
+        assert_eq!(err.user_message(), "queue full");
+        assert_eq!(err.to_string(), "Service unavailable: queue full");
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -362,7 +362,11 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     // Initialize proxy service for remote repository caching
     match StorageService::from_config(&config).await {
         Ok(storage_svc) => {
-            let proxy_service = Arc::new(ProxyService::new(db_pool.clone(), Arc::new(storage_svc)));
+            let proxy_service = Arc::new(ProxyService::new(
+                db_pool.clone(),
+                Arc::new(storage_svc),
+                &config,
+            ));
             app_state.set_proxy_service(proxy_service);
             tracing::info!("Proxy service initialized for remote repositories");
         }

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -1253,6 +1253,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         })
     }

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -765,6 +765,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         }
     }

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -756,6 +756,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         };
 
@@ -803,6 +806,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         }
     }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -16,6 +16,9 @@ use sqlx::PgPool;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
+use metrics::gauge;
+
+use crate::config::Config;
 use crate::error::{AppError, Result};
 use crate::models::repository::{Repository, RepositoryFormat, RepositoryType};
 use crate::services::storage_service::StorageService;
@@ -66,22 +69,35 @@ pub struct ProxyService {
     /// In-memory cache for OCI registry bearer tokens.
     /// Key: "{realm}\0{service}\0{scope}", Value: (token, created_at, ttl_secs)
     token_cache: RwLock<HashMap<String, (String, Instant, u64)>>,
+    /// Limits the number of concurrent upstream fetches to bound peak memory.
+    fetch_semaphore: Arc<tokio::sync::Semaphore>,
+    /// How long to wait for a semaphore permit before returning 503.
+    queue_timeout: Duration,
+    /// Maximum artifact size in bytes that the proxy will fetch from upstream.
+    max_artifact_size: u64,
 }
 
 impl ProxyService {
     /// Create a new proxy service
-    pub fn new(db: PgPool, storage: Arc<StorageService>) -> Self {
+    pub fn new(db: PgPool, storage: Arc<StorageService>, config: &Config) -> Self {
         let http_client = crate::services::http_client::base_client_builder()
             .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
             .user_agent("artifact-keeper-proxy/1.0")
+            .pool_max_idle_per_host(50)
+            .pool_idle_timeout(Duration::from_secs(90))
             .build()
             .expect("Failed to create HTTP client");
+
+        let max_concurrent = config.proxy_max_concurrent_fetches as usize;
 
         Self {
             db,
             storage,
             http_client,
             token_cache: RwLock::new(HashMap::new()),
+            fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent)),
+            queue_timeout: Duration::from_secs(config.proxy_queue_timeout_secs),
+            max_artifact_size: config.proxy_max_artifact_size_bytes,
         }
     }
 
@@ -384,6 +400,36 @@ impl ProxyService {
         url: &str,
         repo_id: Uuid,
     ) -> Result<(Bytes, Option<String>, Option<String>, String)> {
+        let permit = tokio::time::timeout(self.queue_timeout, self.fetch_semaphore.acquire())
+            .await
+            .map_err(|_| {
+                tracing::warn!(
+                    url = %url,
+                    timeout_secs = self.queue_timeout.as_secs(),
+                    "Proxy fetch queue full, rejecting request"
+                );
+                AppError::ServiceUnavailable(
+                    "Proxy upstream fetch queue is full. Try again later.".into(),
+                )
+            })?
+            .map_err(|_| AppError::Internal("Fetch semaphore closed".into()))?;
+
+        gauge!("ak_proxy_fetches_in_flight").increment(1.0);
+
+        let result = self.fetch_from_upstream_inner(url, repo_id).await;
+
+        gauge!("ak_proxy_fetches_in_flight").decrement(1.0);
+        drop(permit);
+
+        result
+    }
+
+    /// Inner fetch logic, called after the semaphore permit is acquired.
+    async fn fetch_from_upstream_inner(
+        &self,
+        url: &str,
+        repo_id: Uuid,
+    ) -> Result<(Bytes, Option<String>, Option<String>, String)> {
         tracing::info!("Fetching artifact from upstream: {}", url);
 
         let upstream_auth =
@@ -443,7 +489,12 @@ impl ProxyService {
                         ))
                     })?;
 
-                    return Self::read_upstream_response(retry_response, url).await;
+                    return Self::read_upstream_response(
+                        retry_response,
+                        url,
+                        self.max_artifact_size,
+                    )
+                    .await;
                 }
             }
 
@@ -453,7 +504,7 @@ impl ProxyService {
             )));
         }
 
-        Self::read_upstream_response(response, url).await
+        Self::read_upstream_response(response, url, self.max_artifact_size).await
     }
 
     /// Extract content, content-type, etag, and effective URL from an upstream
@@ -461,6 +512,7 @@ impl ProxyService {
     async fn read_upstream_response(
         response: reqwest::Response,
         url: &str,
+        max_size: u64,
     ) -> Result<(Bytes, Option<String>, Option<String>, String)> {
         let status = response.status();
         let effective_url = response.url().to_string();
@@ -479,6 +531,22 @@ impl ProxyService {
             )));
         }
 
+        // Check Content-Length before reading the body
+        if let Some(content_length) = response.content_length() {
+            if content_length > max_size {
+                tracing::warn!(
+                    url = %url,
+                    content_length,
+                    max_size,
+                    "Upstream artifact exceeds size limit, rejecting"
+                );
+                return Err(AppError::BadGateway(format!(
+                    "Upstream artifact size ({} bytes) exceeds the configured limit ({} bytes)",
+                    content_length, max_size
+                )));
+            }
+        }
+
         let content_type = response
             .headers()
             .get(CONTENT_TYPE)
@@ -495,6 +563,21 @@ impl ProxyService {
             .bytes()
             .await
             .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?;
+
+        // Post-download size check (handles missing or inaccurate Content-Length)
+        if content.len() as u64 > max_size {
+            tracing::warn!(
+                url = %url,
+                actual_size = content.len(),
+                max_size,
+                "Upstream artifact body exceeds size limit after download"
+            );
+            return Err(AppError::BadGateway(format!(
+                "Upstream artifact size ({} bytes) exceeds the configured limit ({} bytes)",
+                content.len(),
+                max_size
+            )));
+        }
 
         tracing::info!(
             "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?})",
@@ -1976,5 +2059,178 @@ mod tests {
         assert_eq!(capped, 3600);
         let effective = capped.saturating_mul(9) / 10;
         assert_eq!(effective, 3240);
+    }
+
+    // =======================================================================
+    // Semaphore behavior tests
+    // =======================================================================
+
+    #[tokio::test]
+    async fn test_proxy_semaphore_limits_concurrent_fetches() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+
+        // Acquire two permits (fills semaphore)
+        let _p1 = semaphore.acquire().await.unwrap();
+        let _p2 = semaphore.acquire().await.unwrap();
+
+        // Third acquire should not succeed immediately
+        let result = tokio::time::timeout(Duration::from_millis(50), semaphore.acquire()).await;
+
+        assert!(
+            result.is_err(),
+            "Third acquire should time out when semaphore is full"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_semaphore_timeout_returns_503() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let queue_timeout = Duration::from_millis(50);
+
+        // Hold the only permit
+        let _permit = semaphore.acquire().await.unwrap();
+
+        // Attempt to acquire with timeout, simulating the fetch_from_upstream pattern
+        let result = tokio::time::timeout(queue_timeout, semaphore.acquire())
+            .await
+            .map_err(|_| {
+                AppError::ServiceUnavailable(
+                    "Proxy upstream fetch queue is full. Try again later.".into(),
+                )
+            });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match &err {
+            AppError::ServiceUnavailable(msg) => {
+                assert!(msg.contains("queue is full"));
+            }
+            other => panic!("Expected ServiceUnavailable, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proxy_semaphore_releases_on_drop() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+
+        // Acquire and drop in a scope
+        {
+            let _permit = semaphore.acquire().await.unwrap();
+            // permit drops here
+        }
+
+        // Should be able to acquire again
+        let result = tokio::time::timeout(Duration::from_millis(50), semaphore.acquire()).await;
+
+        assert!(
+            result.is_ok(),
+            "Semaphore should be available after permit is dropped"
+        );
+    }
+
+    // =======================================================================
+    // Size limit tests
+    // =======================================================================
+
+    #[tokio::test]
+    async fn test_proxy_rejects_oversized_content_length() {
+        // When reqwest::Response is built from http::Response<Bytes>, the
+        // content_length() method returns the actual body size, not the
+        // Content-Length header. So we test the pre-read check by providing
+        // a body whose actual size exceeds the configured limit.
+        let body = bytes::Bytes::from(vec![0u8; 2048]);
+        let http_response = http::Response::builder()
+            .status(200)
+            .header("content-type", "application/octet-stream")
+            .body(body)
+            .unwrap();
+
+        let response = reqwest::Response::from(http_response);
+        // content_length() should return Some(2048)
+        let max_size: u64 = 1024;
+
+        let result =
+            ProxyService::read_upstream_response(response, "https://example.com/big.tar", max_size)
+                .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            AppError::BadGateway(msg) => {
+                assert!(msg.contains("2048"));
+                assert!(msg.contains("1024"));
+            }
+            other => panic!("Expected BadGateway, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proxy_allows_content_length_within_limit() {
+        let body = bytes::Bytes::from_static(b"hello world");
+        let http_response = http::Response::builder()
+            .status(200)
+            .header("content-type", "text/plain")
+            .body(body)
+            .unwrap();
+
+        let response = reqwest::Response::from(http_response);
+        let max_size: u64 = 2_147_483_648;
+
+        let result = ProxyService::read_upstream_response(
+            response,
+            "https://example.com/small.txt",
+            max_size,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let (content, content_type, _etag, _url) = result.unwrap();
+        assert_eq!(&content[..], b"hello world");
+        assert_eq!(content_type.as_deref(), Some("text/plain"));
+    }
+
+    #[tokio::test]
+    async fn test_proxy_rejects_oversized_body_no_content_length() {
+        // Build a response without Content-Length whose body exceeds a small limit.
+        let large_body = bytes::Bytes::from(vec![0u8; 2048]);
+        let http_response = http::Response::builder()
+            .status(200)
+            .body(large_body)
+            .unwrap();
+
+        let response = reqwest::Response::from(http_response);
+        let max_size: u64 = 1024; // 1 KB limit
+
+        let result = ProxyService::read_upstream_response(
+            response,
+            "https://example.com/sneaky.bin",
+            max_size,
+        )
+        .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            AppError::BadGateway(msg) => {
+                assert!(msg.contains("2048"));
+                assert!(msg.contains("1024"));
+            }
+            other => panic!("Expected BadGateway, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proxy_allows_body_within_limit_no_content_length() {
+        let body = bytes::Bytes::from(vec![42u8; 512]);
+        let http_response = http::Response::builder().status(200).body(body).unwrap();
+
+        let response = reqwest::Response::from(http_response);
+        let max_size: u64 = 1024;
+
+        let result =
+            ProxyService::read_upstream_response(response, "https://example.com/ok.bin", max_size)
+                .await;
+
+        assert!(result.is_ok());
+        let (content, _ct, _etag, _url) = result.unwrap();
+        assert_eq!(content.len(), 512);
     }
 }

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -767,6 +767,9 @@ mod tests {
             lifecycle_check_interval_secs: 60,
             max_upload_size_bytes: 10_737_418_240,
             allow_local_admin_login: false,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
             metrics_port: None,
         }
     }

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -62,6 +62,9 @@ fn test_config(storage_path: &str) -> Config {
         lifecycle_check_interval_secs: 60,
         allow_local_admin_login: false,
         max_upload_size_bytes: 10_737_418_240,
+        proxy_max_concurrent_fetches: 20,
+        proxy_max_artifact_size_bytes: 2_147_483_648,
+        proxy_queue_timeout_secs: 30,
         metrics_port: None,
     }
 }


### PR DESCRIPTION
## Summary

Adds three configurable safeguards to `ProxyService` to prevent out-of-memory kills caused by unbounded concurrent upstream artifact fetches (#737):

- **Concurrent fetch semaphore** (`PROXY_MAX_CONCURRENT_FETCHES`, default 20): limits parallel upstream downloads. Requests that cannot acquire a permit within `PROXY_QUEUE_TIMEOUT_SECS` (default 30) receive HTTP 503.
- **Per-artifact size limit** (`PROXY_MAX_ARTIFACT_SIZE_BYTES`, default 2 GB): checks `Content-Length` before reading the body and actual body size after reading, returning HTTP 502 for oversized artifacts.
- **Connection pool limits** (`pool_max_idle_per_host=50`, `pool_idle_timeout=90s`) on the proxy HTTP client to bound idle connection fan-out to upstream registries.

Also adds a `ServiceUnavailable` error variant (HTTP 503) and an `ak_proxy_fetches_in_flight` gauge metric for monitoring concurrent proxy fetches.

Peak proxy memory is now bounded to approximately `concurrent_fetches * max_artifact_size` (40 GB worst case at defaults, much lower in practice). Operators on memory-constrained hosts should lower both values.

This is a targeted patch for `release/1.1.x`. The full streaming proxy rewrite (replacing `response.bytes()` with chunked `AsyncRead`) is deferred to v1.2.0.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

New unit tests (9 total):
- `test_proxy_semaphore_limits_concurrent_fetches`
- `test_proxy_semaphore_timeout_returns_503`
- `test_proxy_semaphore_releases_on_drop`
- `test_proxy_rejects_oversized_content_length`
- `test_proxy_allows_content_length_within_limit`
- `test_proxy_rejects_oversized_body_no_content_length`
- `test_proxy_allows_body_within_limit_no_content_length`
- `test_proxy_config_defaults`
- `test_proxy_config_custom_values`

Plus 2 error tests for the new `ServiceUnavailable` variant.

Closes #737