### PR TITLE
fix: address review findings on streaming storage

### DIFF
--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -123,7 +123,9 @@ impl StorageBackend for FilesystemStorage {
 
         // Write to a temp file in the same directory so rename is atomic
         // (same filesystem guarantees atomic rename on POSIX).
-        let temp_path = dest.with_extension(format!("tmp.{}", Uuid::new_v4()));
+        let mut temp_name = dest.as_os_str().to_os_string();
+        temp_name.push(format!(".tmp.{}", Uuid::new_v4()));
+        let temp_path = PathBuf::from(temp_name);
         let mut file = fs::File::create(&temp_path)
             .await
             .map_err(|e| AppError::Storage(format!("Failed to create temp file: {}", e)))?;
@@ -157,11 +159,11 @@ impl StorageBackend for FilesystemStorage {
         drop(file);
 
         // Atomic rename
-        fs::rename(&temp_path, &dest).await.map_err(|e| {
+        if let Err(e) = fs::rename(&temp_path, &dest).await {
             // Best-effort cleanup; the temp file may already be gone
-            let _ = std::fs::remove_file(&temp_path);
-            AppError::Storage(format!("Rename error: {}", e))
-        })?;
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(AppError::Storage(format!("Rename error: {}", e)));
+        }
 
         Ok(PutStreamResult {
             checksum_sha256: format!("{:x}", hasher.finalize()),
@@ -497,8 +499,8 @@ mod tests {
                 Box::pin(collect_tmp_files(entry.path(), out)).await;
             }
         } else if path
-            .extension()
-            .map(|e| e.to_string_lossy().starts_with("tmp."))
+            .file_name()
+            .map(|n| n.to_string_lossy().contains(".tmp."))
             .unwrap_or(false)
         {
             out.push(path);

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -109,6 +109,8 @@ pub trait StorageBackend: Send + Sync {
         use futures::StreamExt;
         use sha2::{Digest, Sha256};
 
+        tracing::debug!(key, "put_stream falling back to in-memory buffering");
+
         let mut hasher = Sha256::new();
         let mut buf = Vec::new();
         let mut total: u64 = 0;


### PR DESCRIPTION
## Summary

Fixes four issues raised in the review of #739 (streaming storage layer):

1. **`with_extension` mangles dotted keys**: `dest.with_extension(...)` replaces the existing extension, so `artifact.jar` would become `artifact.tmp.<uuid>` (losing `.jar`). Switched to `OsString::push` to append `.tmp.<uuid>` instead.

2. **`collect_tmp_files` test helper broken**: `PathBuf::extension()` only returns text after the last dot, so for `foo.tmp.550e8400` it returns `550e8400`, not `tmp.550e8400`. Changed to check whether the full filename contains `.tmp.` instead.

3. **Missing tracing in default `put_stream`**: Added a `tracing::debug` log when the default trait implementation falls back to in-memory buffering, so callers can tell which backends lack native streaming.

4. **Blocking `std::fs::remove_file` on tokio thread**: The rename error handler in `FilesystemStorage::put_stream` used `std::fs::remove_file` inside a synchronous `map_err` closure. Restructured to use `if let Err` with `tokio::fs::remove_file` to avoid blocking the async runtime.

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes