### PR TITLE
fix: address security review findings on proxy safeguards

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -252,7 +252,7 @@ impl Config {
             gc_schedule: env::var("GC_SCHEDULE").unwrap_or_else(|_| "0 0 * * * *".into()),
             lifecycle_check_interval_secs: env_parse("LIFECYCLE_CHECK_INTERVAL_SECS", 60),
             max_upload_size_bytes: env_parse("MAX_UPLOAD_SIZE", 10_737_418_240_u64),
-            proxy_max_concurrent_fetches: env_parse("PROXY_MAX_CONCURRENT_FETCHES", 20),
+            proxy_max_concurrent_fetches: env_parse("PROXY_MAX_CONCURRENT_FETCHES", 20).max(1),
             proxy_max_artifact_size_bytes: env_parse(
                 "PROXY_MAX_ARTIFACT_SIZE_BYTES",
                 2_147_483_648_u64,
@@ -1095,6 +1095,41 @@ mod tests {
             env::set_var("PROXY_QUEUE_TIMEOUT_SECS", v);
         } else {
             env::remove_var("PROXY_QUEUE_TIMEOUT_SECS");
+        }
+    }
+
+    #[test]
+    fn test_proxy_max_concurrent_fetches_clamped_to_minimum_one() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let saved_db = env::var("DATABASE_URL").ok();
+        let saved_jwt = env::var("JWT_SECRET").ok();
+        let saved_fetches = env::var("PROXY_MAX_CONCURRENT_FETCHES").ok();
+
+        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("JWT_SECRET", "secret");
+        env::set_var("PROXY_MAX_CONCURRENT_FETCHES", "0");
+
+        let config = Config::from_env().unwrap();
+        assert_eq!(
+            config.proxy_max_concurrent_fetches, 1,
+            "PROXY_MAX_CONCURRENT_FETCHES=0 must be clamped to 1 to avoid permanent outage"
+        );
+
+        // Restore
+        if let Some(v) = saved_db {
+            env::set_var("DATABASE_URL", v);
+        } else {
+            env::remove_var("DATABASE_URL");
+        }
+        if let Some(v) = saved_jwt {
+            env::set_var("JWT_SECRET", v);
+        } else {
+            env::remove_var("JWT_SECRET");
+        }
+        if let Some(v) = saved_fetches {
+            env::set_var("PROXY_MAX_CONCURRENT_FETCHES", v);
+        } else {
+            env::remove_var("PROXY_MAX_CONCURRENT_FETCHES");
         }
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -148,6 +148,14 @@ impl IntoResponse for AppError {
             "message": message,
         }));
 
+        if status == StatusCode::SERVICE_UNAVAILABLE {
+            let mut response = (status, body).into_response();
+            response
+                .headers_mut()
+                .insert("Retry-After", axum::http::HeaderValue::from_static("5"));
+            return response;
+        }
+
         (status, body).into_response()
     }
 }
@@ -313,5 +321,20 @@ mod tests {
         let err = AppError::BadGateway("upstream failed".to_string());
         assert_eq!(err.user_message(), "upstream failed");
         assert_eq!(err.to_string(), "Bad gateway: upstream failed");
+    }
+
+    #[test]
+    fn test_service_unavailable_includes_retry_after_header() {
+        let err = AppError::ServiceUnavailable("queue full".to_string());
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response
+                .headers()
+                .get("Retry-After")
+                .map(|v| v.to_str().unwrap()),
+            Some("5"),
+            "503 responses must include a Retry-After header"
+        );
     }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
 use reqwest::header::{CONTENT_TYPE, ETAG, IF_NONE_MATCH, WWW_AUTHENTICATE};
 use reqwest::{Client, StatusCode};
@@ -559,25 +559,32 @@ impl ProxyService {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
-        let content = response
-            .bytes()
+        // Stream the response body in chunks, enforcing the size limit
+        // incrementally. This prevents unbounded memory allocation when the
+        // upstream uses chunked transfer encoding or HTTP/2 (no Content-Length).
+        let mut buf = BytesMut::new();
+        let mut response = response;
+        while let Some(chunk) = response
+            .chunk()
             .await
-            .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?;
-
-        // Post-download size check (handles missing or inaccurate Content-Length)
-        if content.len() as u64 > max_size {
-            tracing::warn!(
-                url = %url,
-                actual_size = content.len(),
-                max_size,
-                "Upstream artifact body exceeds size limit after download"
-            );
-            return Err(AppError::BadGateway(format!(
-                "Upstream artifact size ({} bytes) exceeds the configured limit ({} bytes)",
-                content.len(),
-                max_size
-            )));
+            .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?
+        {
+            buf.extend_from_slice(&chunk);
+            if buf.len() as u64 > max_size {
+                tracing::warn!(
+                    url = %url,
+                    accumulated = buf.len(),
+                    max_size,
+                    "Upstream artifact exceeds size limit during streaming download"
+                );
+                return Err(AppError::BadGateway(format!(
+                    "Upstream artifact size ({} bytes) exceeds the configured limit ({} bytes)",
+                    buf.len(),
+                    max_size
+                )));
+            }
         }
+        let content = buf.freeze();
 
         tracing::info!(
             "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?})",


### PR DESCRIPTION
## Summary

Addresses three review findings from PR #740 (proxy OOM safeguards):

1. **Chunked transfer bypass (must-fix):** `response.bytes()` buffered the entire upstream body before checking the size limit, defeating the safeguard when upstream uses chunked transfer encoding or HTTP/2 (no Content-Length). Replaced with a streaming `response.chunk()` loop that tracks accumulated bytes and aborts as soon as the limit is exceeded.

2. **PROXY_MAX_CONCURRENT_FETCHES=0 permanent outage (must-fix):** `Semaphore::new(0)` yields zero permits, making all proxy requests fail with 503. Added `.max(1)` clamp in `Config::from_env()` so the value is never below 1. Added a dedicated test.

3. **Missing Retry-After header on 503 (should-fix):** The `ServiceUnavailable` error variant now includes a `Retry-After: 5` header in its HTTP response, giving clients a hint for backoff timing.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes