### PR TITLE
Bump grype 0.110.0 to 0.111.0 to fix Go stdlib CVEs

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -122,7 +122,7 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
-FROM ghcr.io/anchore/grype:v0.110.0 AS grype-bin
+FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.7

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -37,7 +37,7 @@ RUN cargo build --release --features vendored-openssl --bin artifact-keeper
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
-FROM ghcr.io/anchore/grype:v0.110.0 AS grype-bin
+FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
 
 # ---------- Stage 5: Alpine runtime ----------
 FROM alpine:3.23


### PR DESCRIPTION
## Summary

Bumps grype from 0.110.0 to 0.111.0 in `docker/Dockerfile.backend` and `docker/Dockerfile.backend.alpine`. Grype 0.111.0 is built with Go 1.25.8, which includes fixes for CVE-2026-25679, CVE-2026-27139, and CVE-2026-27142 in the Go standard library.

Trivy remains at 0.69.3 because no newer upstream release is available yet. Trivy 0.69.3 is still built with Go 1.25.6. Three of the six code scanning alerts (the grype ones: #145, #146, #147) should auto-resolve after this change. The trivy alerts (#148, #149, #150) will stay open until upstream ships a patched release.

Partially addresses #403.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes