### PR TITLE
fix: use configured admin group for role mapping instead of hardcoded patterns

### DIFF
--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -288,6 +288,13 @@ async fn oidc_callback_inner(
 
     let groups = extract_oidc_groups(&claims, groups_claim);
 
+    // Read admin group setting from DB attribute_mapping, falling back to env
+    let required_admin_group = attr
+        .get("admin_group")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("OIDC_ADMIN_GROUP").ok());
+
     // 7. Authenticate via federated flow (find/create user + generate tokens)
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
 
@@ -300,6 +307,7 @@ async fn oidc_callback_inner(
                 email,
                 display_name,
                 groups,
+                required_admin_group,
             },
         )
         .await?;
@@ -382,6 +390,7 @@ pub async fn ldap_login(
                 email: ldap_user.email,
                 display_name: ldap_user.display_name,
                 groups: ldap_user.groups,
+                required_admin_group: row.admin_group_dn.clone(),
             },
         )
         .await?;
@@ -520,6 +529,7 @@ pub async fn saml_acs(
                 email: saml_user.email,
                 display_name: saml_user.display_name,
                 groups: saml_user.groups,
+                required_admin_group: row.admin_group.clone(),
             },
         )
         .await?;

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -34,6 +34,8 @@ pub struct FederatedCredentials {
     pub display_name: Option<String>,
     /// Groups/roles from provider claims
     pub groups: Vec<String>,
+    /// Required group name for admin role (exact match); when set, replaces default pattern matching
+    pub required_admin_group: Option<String>,
 }
 
 /// Result of group-to-role mapping
@@ -900,21 +902,31 @@ impl AuthService {
     ///
     /// # Returns
     /// * `RoleMapping` - The mapped roles and admin status
-    pub fn map_groups_to_roles(&self, groups: &[String]) -> RoleMapping {
+    pub fn map_groups_to_roles(&self, groups: &[String], required_admin_group: Option<&str>) -> RoleMapping {
         let mut mapping = RoleMapping::default();
 
         // Normalize groups to lowercase for case-insensitive matching
         let normalized_groups: Vec<String> = groups.iter().map(|g| g.to_lowercase()).collect();
 
-        // Check for admin groups
-        // These patterns can be made configurable via Config
-        let admin_patterns = ["admin", "administrators", "superusers", "artifact-admins"];
-        for group in &normalized_groups {
-            for pattern in &admin_patterns {
-                if group.contains(pattern) {
-                    mapping.is_admin = Some(true);
-                    mapping.roles.push("admin".to_string());
-                    break;
+        // Check for admin groups: if admin_group is explicitly configured, use
+        // exact match only; otherwise fall back to built-in pattern matching.
+        if let Some(ag) = required_admin_group {
+            let ag_lower = ag.to_lowercase();
+            if normalized_groups.iter().any(|g| *g == ag_lower) {
+                mapping.is_admin = Some(true);
+                mapping.roles.push("admin".to_string());
+            } else {
+                mapping.is_admin = Some(false);
+            }
+        } else {
+            let admin_patterns = ["admin", "administrators", "superusers", "artifact-admins"];
+            for group in &normalized_groups {
+                for pattern in &admin_patterns {
+                    if group.contains(pattern) {
+                        mapping.is_admin = Some(true);
+                        mapping.roles.push("admin".to_string());
+                        break;
+                    }
                 }
             }
         }
@@ -1010,7 +1022,7 @@ impl AuthService {
         credentials: &FederatedCredentials,
     ) -> Result<User> {
         // Map groups to roles
-        let role_mapping = self.map_groups_to_roles(&credentials.groups);
+        let role_mapping = self.map_groups_to_roles(&credentials.groups, credentials.required_admin_group.as_deref());
 
         // Check if user exists by external_id
         let existing_user = sqlx::query_as!(
@@ -1633,6 +1645,7 @@ mod tests {
             email: "fed@example.com".to_string(),
             display_name: Some("Fed User".to_string()),
             groups: vec!["devs".to_string(), "admin".to_string()],
+            required_admin_group: None,
         };
         let debug = format!("{:?}", creds);
         assert!(debug.contains("feduser"));
@@ -1661,16 +1674,30 @@ mod tests {
     // Reimplement map_groups_to_roles locally since AuthService requires PgPool
     // and we cannot create one without a real database connection.
     fn test_map_groups_to_roles(groups: &[String]) -> RoleMapping {
+        test_map_groups_to_roles_with_admin(groups, None)
+    }
+
+    fn test_map_groups_to_roles_with_admin(groups: &[String], required_admin_group: Option<&str>) -> RoleMapping {
         let mut mapping = RoleMapping::default();
         let normalized_groups: Vec<String> = groups.iter().map(|g| g.to_lowercase()).collect();
 
-        let admin_patterns = ["admin", "administrators", "superusers", "artifact-admins"];
-        for group in &normalized_groups {
-            for pattern in &admin_patterns {
-                if group.contains(pattern) {
-                    mapping.is_admin = Some(true);
-                    mapping.roles.push("admin".to_string());
-                    break;
+        if let Some(ag) = required_admin_group {
+            let ag_lower = ag.to_lowercase();
+            if normalized_groups.iter().any(|g| *g == ag_lower) {
+                mapping.is_admin = Some(true);
+                mapping.roles.push("admin".to_string());
+            } else {
+                mapping.is_admin = Some(false);
+            }
+        } else {
+            let admin_patterns = ["admin", "administrators", "superusers", "artifact-admins"];
+            for group in &normalized_groups {
+                for pattern in &admin_patterns {
+                    if group.contains(pattern) {
+                        mapping.is_admin = Some(true);
+                        mapping.roles.push("admin".to_string());
+                        break;
+                    }
                 }
             }
         }
@@ -1804,6 +1831,38 @@ mod tests {
             .filter(|r| r.as_str() == "developer")
             .count();
         assert_eq!(dev_count, 1, "developer role should not be duplicated");
+    }
+
+    // -----------------------------------------------------------------------
+    // required_admin_group (exact match overrides default patterns)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_required_admin_group_exact_match() {
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["my-admins".to_string(), "devs".to_string()],
+            Some("my-admins"),
+        );
+        assert_eq!(mapping.is_admin, Some(true));
+    }
+
+    #[test]
+    fn test_required_admin_group_no_match() {
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["other-admins".to_string(), "devs".to_string()],
+            Some("my-admins"),
+        );
+        assert_eq!(mapping.is_admin, Some(false));
+    }
+
+    #[test]
+    fn test_required_admin_group_prevents_substring_match() {
+        // "company-admin-team" contains "admin" but should NOT match required "admin"
+        let mapping = test_map_groups_to_roles_with_admin(
+            &["company-admin-team".to_string()],
+            Some("admin"),
+        );
+        assert_eq!(mapping.is_admin, Some(false));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `map_groups_to_roles` function in `auth_service.rs` used hardcoded substring patterns ("admin", "administrators", "superusers", "artifact-admins") to determine admin status. Any user with any group containing the substring "admin" was granted admin privileges, regardless of the `admin_group` setting configured via the UI or `OIDC_ADMIN_GROUP` env var.

When `admin_group` is configured (from `attribute_mapping.admin_group` in DB or `OIDC_ADMIN_GROUP` env), the function now uses exact match. The existing default patterns are preserved as fallback only when no admin group is configured.

The fix covers all three SSO paths: OIDC, LDAP, and SAML.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes