### PR TITLE
fix: satisfy clippy 1.95 unnecessary_sort_by lint

### DIFF
--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -514,7 +514,7 @@ mod tests {
         ];
 
         // Sort by prefix length descending so longest match wins
-        handler_sources.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        handler_sources.sort_by_key(|a| std::cmp::Reverse(a.0.len()));
 
         let mut missing = Vec::new();
 


### PR DESCRIPTION
## Summary

Clippy 1.95 introduced the `unnecessary_sort_by` lint which flags `sort_by(|a, b| b.0.len().cmp(&a.0.len()))` as improvable. Replaced with `sort_by_key(|a| std::cmp::Reverse(a.0.len()))` in `openapi.rs`.

This one-line change unblocks all open PRs that are failing the lint check after the Rust 1.95 stable release.

## Test Checklist
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes