### PR TITLE
chore: use self-hosted runners for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
   lint-rust:
     name: 🦀 Lint Rust
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -64,7 +64,7 @@ jobs:
 
   test-backend-unit:
     name: 🧪 Backend Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -86,7 +86,7 @@ jobs:
 
   coverage:
     name: 📊 Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     services:
       postgres:
         image: postgres:16-alpine
@@ -160,7 +160,7 @@ jobs:
 
   test-backend-integration:
     name: 🔗 Backend Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && github.event_name == 'push'
     services:
       postgres:
@@ -313,7 +313,7 @@ jobs:
 
   detect-changes:
     name: 🔍 Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
       pull-requests: read
@@ -339,7 +339,7 @@ jobs:
 
   build-backend-image:
     name: 🐳 Build Backend Image
-    runs-on: ubuntu-24.04
+    runs-on: ak-ci-runners
     needs: detect-changes
     if: needs.detect-changes.outputs.backend == 'true'
     steps:
@@ -390,7 +390,7 @@ jobs:
 
   build-openscap-image:
     name: 🐳 Build OpenSCAP Image
-    runs-on: ubuntu-24.04
+    runs-on: ak-ci-runners
     needs: detect-changes
     if: needs.detect-changes.outputs.openscap == 'true'
     steps:
@@ -452,7 +452,7 @@ jobs:
 
   ci-complete:
     name: ✅ CI Complete
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     needs: [lint-rust, test-backend-unit, coverage, test-backend-integration, smoke-e2e, build-backend-image, build-openscap-image, security-audit]
     if: always()
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-24.04
+            runner: ak-ci-runners
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     outputs:
@@ -105,7 +105,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-24.04
+            runner: ak-ci-runners
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     outputs:
@@ -171,7 +171,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-24.04
+            runner: ak-ci-runners
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     outputs:


### PR DESCRIPTION
## Summary

Switch CI jobs from GitHub-hosted runners (ubuntu-latest, ubuntu-24.04) to the self-hosted `ak-ci-runners` scale set on the K8s cluster for faster builds and lower costs.

Changes in `ci.yml`: lint-rust, test-backend-unit, coverage, test-backend-integration, detect-changes, build-backend-image, build-openscap-image, and ci-complete all now use `ak-ci-runners`.

Changes in `docker-publish.yml`: amd64 build matrix entries for build-backend, build-openscap, and build-backend-alpine now use `ak-ci-runners`. ARM64 builds remain on `ubuntu-24.04-arm` (Rocky cluster is x86 only).

Unchanged:
- `smoke-e2e` stays on `ak-e2e-runners` (needs DinD + test fixtures)
- `build-windows-dev` stays on `windows-latest`
- `security-audit` stays on `ubuntu-latest`
- `scan-containers` and merge jobs stay on GitHub-hosted runners

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes