### PR TITLE
feat: add jemalloc and mimalloc allocator support with heap profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "meilisearch-sdk",
  "metrics",
  "metrics-exporter-prometheus",
+ "mimalloc",
  "mime_guess",
  "native-tls",
  "object_store",
@@ -237,6 +238,9 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -3049,6 +3053,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,6 +3312,15 @@ dependencies = [
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4071,7 +4094,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5616,6 +5639,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,6 +10,9 @@ path = "src/main.rs"
 
 [features]
 vendored-openssl = ["openssl/vendored"]
+jemalloc = ["dep:tikv-jemallocator"]
+mimalloc = ["dep:mimalloc"]
+profiling = ["jemalloc", "dep:tikv-jemalloc-ctl", "dep:tikv-jemalloc-sys", "tikv-jemallocator/profiling"]
 
 [dependencies]
 openssl = { workspace = true, optional = true }
@@ -156,6 +159,13 @@ zxcvbn = "3"
 
 # SMTP email delivery
 lettre.workspace = true
+
+# Allocators
+mimalloc = { version = "0.1", optional = true }
+[target.'cfg(not(windows))'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemalloc-ctl = { version = "0.6", optional = true, features = ["stats"] }
+tikv-jemalloc-sys = { version = "0.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8"

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -443,6 +443,130 @@ pub async fn metrics(State(state): State<SharedState>) -> impl IntoResponse {
     )
 }
 
+// ---------------------------------------------------------------------------
+// Jemalloc heap profiling (only available with `--features profiling`)
+// ---------------------------------------------------------------------------
+
+/// Dump a jemalloc heap profile.
+///
+/// Requires the binary to be started with `_RJEM_MALLOC_CONF=prof:true` (or
+/// the equivalent `MALLOC_CONF`). Returns a pprof-compatible heap profile
+/// that can be analyzed with `jeprof` / `pprof`.
+///
+/// Query parameters:
+/// - `activate` — if `"true"`, activate profiling at runtime (prof.active).
+/// - `deactivate` — if `"true"`, deactivate profiling (prof.active = false).
+/// - `dump` (default) — dump current profile to a temp file and return it.
+#[cfg(feature = "profiling")]
+pub async fn heap_profile(
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    use tikv_jemalloc_ctl::raw;
+
+    // Activate profiling at runtime.
+    if params.get("activate").map(|v| v == "true").unwrap_or(false) {
+        let name = b"prof.active\0";
+        let activated: bool = true;
+        if let Err(e) = unsafe { raw::write(name, activated) } {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                format!("Failed to activate profiling: {e}"),
+            )
+                .into_response();
+        }
+        return (StatusCode::OK, "profiling activated\n").into_response();
+    }
+
+    // Deactivate profiling.
+    if params
+        .get("deactivate")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        let name = b"prof.active\0";
+        let deactivated: bool = false;
+        if let Err(e) = unsafe { raw::write(name, deactivated) } {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                format!("Failed to deactivate profiling: {e}"),
+            )
+                .into_response();
+        }
+        return (StatusCode::OK, "profiling deactivated\n").into_response();
+    }
+
+    // Dump heap profile.
+    let path = format!("/tmp/ak_heap_{}.prof", std::process::id());
+    let c_path = match std::ffi::CString::new(path.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("bad path: {e}")).into_response()
+        }
+    };
+
+    let name = b"prof.dump\0";
+    if let Err(e) = unsafe { raw::write(name, c_path.as_ptr() as *const std::ffi::c_char) } {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            format!("Failed to dump profile: {e}\n\nHint: start with _RJEM_MALLOC_CONF=prof:true"),
+        )
+            .into_response();
+    }
+
+    match tokio::fs::read(&path).await {
+        Ok(data) => {
+            let _ = tokio::fs::remove_file(&path).await;
+            (
+                StatusCode::OK,
+                [
+                    (axum::http::header::CONTENT_TYPE, "application/octet-stream"),
+                    (
+                        axum::http::header::CONTENT_DISPOSITION,
+                        "attachment; filename=\"heap.prof\"",
+                    ),
+                ],
+                data,
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to read profile: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+/// Memory statistics from jemalloc (available with `--features profiling`).
+///
+/// Returns a JSON object with allocated, active, resident, mapped, and
+/// retained bytes.
+#[cfg(feature = "profiling")]
+pub async fn memory_stats() -> impl IntoResponse {
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    // Advance the jemalloc epoch to get fresh stats.
+    let _ = epoch::advance();
+
+    let allocated = stats::allocated::read().unwrap_or(0);
+    let active = stats::active::read().unwrap_or(0);
+    let resident = stats::resident::read().unwrap_or(0);
+    let mapped = stats::mapped::read().unwrap_or(0);
+    let retained = stats::retained::read().unwrap_or(0);
+
+    axum::Json(serde_json::json!({
+        "allocator": "jemalloc",
+        "allocated_bytes": allocated,
+        "active_bytes": active,
+        "resident_bytes": resident,
+        "mapped_bytes": mapped,
+        "retained_bytes": retained,
+    }))
+}
+
 #[derive(OpenApi)]
 #[openapi(
     paths(health_check, readiness_check, liveness_check, metrics),

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -344,21 +344,28 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         // Admin routes with admin middleware (requires is_admin)
         .nest(
             "/admin",
-            handlers::admin::router()
-                .route("/metrics", get(handlers::health::metrics))
-                .nest("/analytics", handlers::analytics::router())
-                .nest("/lifecycle", handlers::lifecycle::router())
-                .nest("/storage-gc", handlers::storage_gc::router())
-                .nest("/search", handlers::search::admin_router())
-                .nest("/telemetry", handlers::telemetry::router())
-                .nest("/monitoring", handlers::monitoring::router())
-                .nest("/sso", handlers::sso_admin::router())
-                .nest("/smtp", handlers::smtp::router())
-                .layer(DefaultBodyLimit::max(1024 * 1024)) // 1 MB
-                .layer(middleware::from_fn_with_state(
-                    auth_service.clone(),
-                    admin_middleware,
-                )),
+            {
+                let admin =
+                    handlers::admin::router().route("/metrics", get(handlers::health::metrics));
+                #[cfg(feature = "profiling")]
+                let admin = admin
+                    .route("/memory-stats", get(handlers::health::memory_stats))
+                    .route("/heap-profile", get(handlers::health::heap_profile));
+                admin
+            }
+            .nest("/analytics", handlers::analytics::router())
+            .nest("/lifecycle", handlers::lifecycle::router())
+            .nest("/storage-gc", handlers::storage_gc::router())
+            .nest("/search", handlers::search::admin_router())
+            .nest("/telemetry", handlers::telemetry::router())
+            .nest("/monitoring", handlers::monitoring::router())
+            .nest("/sso", handlers::sso_admin::router())
+            .nest("/smtp", handlers::smtp::router())
+            .layer(DefaultBodyLimit::max(1024 * 1024)) // 1 MB
+            .layer(middleware::from_fn_with_state(
+                auth_service.clone(),
+                admin_middleware,
+            )),
         )
         // Plugin routes with auth middleware
         .nest(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,24 @@
 //! Artifact Keeper - Main Entry Point
 
+// ---------------------------------------------------------------------------
+// Global allocator selection (non-Windows only)
+// ---------------------------------------------------------------------------
+// - `--features jemalloc`   -> use jemalloc
+// - `--features mimalloc`   -> use mimalloc
+// - `--features profiling`  -> use jemalloc with heap profiling enabled
+//   (profiling implies jemalloc)
+//
+// If both jemalloc and mimalloc features are enabled, jemalloc wins.
+// On Windows these features are unavailable; the system allocator is used.
+
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(all(feature = "mimalloc", not(feature = "jemalloc")))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -109,6 +128,20 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
 
     // Load configuration
     let config = Config::from_env()?;
+
+    // Log active allocator
+    #[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+    tracing::info!("Global allocator: jemalloc");
+    #[cfg(all(feature = "mimalloc", not(feature = "jemalloc")))]
+    tracing::info!("Global allocator: mimalloc");
+    #[cfg(not(any(
+        all(feature = "jemalloc", not(target_os = "windows")),
+        all(feature = "mimalloc", not(feature = "jemalloc")),
+    )))]
+    tracing::info!("Global allocator: system");
+    #[cfg(feature = "profiling")]
+    tracing::info!("Jemalloc profiling enabled — set _RJEM_MALLOC_CONF=prof:true to activate");
+
     tracing::info!("Starting Artifact Keeper");
 
     // Connect to database

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -32,7 +32,12 @@ FROM rust-base AS deps
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 ENV SQLX_OFFLINE=true
-RUN cargo chef cook --release --recipe-path recipe.json
+ARG CARGO_FEATURES=""
+RUN if [ -n "$CARGO_FEATURES" ]; then \
+      cargo chef cook --release --features "$CARGO_FEATURES" --recipe-path recipe.json; \
+    else \
+      cargo chef cook --release --recipe-path recipe.json; \
+    fi
 
 # ---------- Stage 3: Build binary ----------
 FROM rust-base AS builder
@@ -43,9 +48,14 @@ COPY Cargo.toml Cargo.lock ./
 COPY .sqlx ./.sqlx
 COPY backend ./backend
 ARG GIT_SHA=unknown
+ARG CARGO_FEATURES=""
 ENV SQLX_OFFLINE=true
 ENV GIT_SHA=${GIT_SHA}
-RUN cargo build --release --bin artifact-keeper
+RUN if [ -n "$CARGO_FEATURES" ]; then \
+      cargo build --release --features "$CARGO_FEATURES" --bin artifact-keeper; \
+    else \
+      cargo build --release --bin artifact-keeper; \
+    fi
 
 # ---------- Stage 4: Build minimal rootfs ----------
 FROM registry.access.redhat.com/ubi9/ubi:9.7 AS rootfs-builder

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -20,7 +20,10 @@ FROM rust-alpine-base AS deps
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 ENV SQLX_OFFLINE=true
-RUN cargo chef cook --release --features vendored-openssl --recipe-path recipe.json
+ARG CARGO_FEATURES=""
+RUN FEATURES="vendored-openssl"; \
+    if [ -n "$CARGO_FEATURES" ]; then FEATURES="$FEATURES,$CARGO_FEATURES"; fi && \
+    cargo chef cook --release --features "$FEATURES" --recipe-path recipe.json
 
 # ---------- Stage 3: Build binary ----------
 FROM rust-alpine-base AS builder
@@ -31,9 +34,12 @@ COPY Cargo.toml Cargo.lock ./
 COPY .sqlx ./.sqlx
 COPY backend ./backend
 ARG GIT_SHA=unknown
+ARG CARGO_FEATURES=""
 ENV SQLX_OFFLINE=true
 ENV GIT_SHA=${GIT_SHA}
-RUN cargo build --release --features vendored-openssl --bin artifact-keeper
+RUN FEATURES="vendored-openssl"; \
+    if [ -n "$CARGO_FEATURES" ]; then FEATURES="$FEATURES,$CARGO_FEATURES"; fi && \
+    cargo build --release --features "$FEATURES" --bin artifact-keeper
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
- Add compile-time allocator selection via cargo feature flags: `jemalloc`, `mimalloc`, and `profiling`. The system allocator remains the default when no feature is enabled.
- jemalloc is non-Windows only; mimalloc is cross-platform (Cargo.toml deps are gated to non-Windows for build simplicity, but main.rs does not artificially restrict mimalloc on Windows).
- The `profiling` feature implies jemalloc and exposes two admin-only endpoints behind auth:
  - `GET /api/v1/admin/memory-stats` — returns jemalloc memory statistics (allocated, active, resident, mapped, retained)
  - `GET /api/v1/admin/heap-profile` — dumps a pprof-compatible heap profile for analysis with `jeprof`/`pprof`, with `?activate=true` / `?deactivate=true` to toggle profiling at runtime
- Both Dockerfiles (`Dockerfile.backend`, `Dockerfile.backend.alpine`) now accept a `CARGO_FEATURES` build arg so operators can choose the allocator at image build time, e.g. `docker build --build-arg CARGO_FEATURES=jemalloc`.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes