### PR TITLE
ci: allow integration tests on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
   test-backend-integration:
     name: 🔗 Backend Integration Tests
     runs-on: ak-ci-runners
-    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     services:
       postgres:
         image: postgres:16-alpine


### PR DESCRIPTION
## Summary

Allow the integration test job to run on `workflow_dispatch` events, not just `push`. This makes it possible to manually trigger full CI (including integration tests) without needing a push to main.

Pinned DinD to `docker:27-dind` in the ARC runner Helm values to fix the Docker 29.4.0 CDI regression (`failed to discover GPU vendor from CDI: no known GPU vendor found`) that was causing all `services:` blocks to fail.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes