### PR TITLE
ci: cross-compile Windows from Linux, drop windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,43 +480,25 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   build-windows-dev:
-    name: 🪟 Windows Dev Build
-    runs-on: windows-latest
-    # Only build Windows on main push (not PRs) to save 27+ min on PR checks.
+    name: 🪟 Windows Cross-Build
+    runs-on: ak-ci-runners
+    # Only build Windows on main push (not PRs).
     # The release workflow builds Windows binaries for actual releases.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-msvc
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: x86_64-pc-windows-msvc
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Windows binary
+      - name: Build Windows binary (cross-compile)
         env:
           SQLX_OFFLINE: true
           CARGO_TERM_COLOR: always
-        run: cargo build --release --target x86_64-pc-windows-msvc --features vendored-openssl
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+        run: cargo build --release --target x86_64-pc-windows-gnu --features vendored-openssl
 
       - name: Package binary
-        shell: bash
         run: |
           mkdir -p dist
-          cp target/x86_64-pc-windows-msvc/release/artifact-keeper.exe dist/artifact-keeper-windows-amd64.exe
+          cp target/x86_64-pc-windows-gnu/release/artifact-keeper.exe dist/artifact-keeper-windows-amd64.exe
           cd dist
           sha256sum artifact-keeper-windows-amd64.exe > artifact-keeper-windows-amd64.exe.sha256
           echo "Built: $(ls -lh artifact-keeper-windows-amd64.exe | awk '{print $5}')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             name: artifact-keeper-darwin-arm64
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
             name: artifact-keeper-windows-amd64
 
     steps:
@@ -96,15 +96,13 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Install Windows cross-compilation tools
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        run: sudo apt-get install -y mingw-w64
+
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf
-
-      - name: Install build dependencies (Windows)
-        if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -115,10 +113,11 @@ jobs:
         env:
           SQLX_OFFLINE: true
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
         run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
 
       - name: Package binary (Unix)
-        if: runner.os != 'Windows'
+        if: "!contains(matrix.target, 'windows')"
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/artifact-keeper dist/${{ matrix.name }}
@@ -132,8 +131,7 @@ jobs:
           fi
 
       - name: Package binary (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
+        if: contains(matrix.target, 'windows')
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/artifact-keeper.exe dist/${{ matrix.name }}.exe


### PR DESCRIPTION
## Summary

Replace Windows builds on `windows-latest` GitHub-hosted runners with cross-compilation from self-hosted Linux runners using MinGW.

- CI: Windows dev build now runs on `ak-ci-runners` with `--target x86_64-pc-windows-gnu`
- Release: Windows binary built on `ubuntu-latest` with `mingw-w64` instead of `windows-latest` with MSVC
- Packaging conditionals updated from `runner.os` checks to `matrix.target` checks
- Removes dtolnay/rust-toolchain, Swatinem/rust-cache, sccache-action, and setup-protoc from Windows job (all pre-installed in runner image)

Runner image updated in artifact-keeper-iac#65 with `mingw-w64` and `x86_64-pc-windows-gnu` target.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes