### PR TITLE
fix: alias /conan/{repo}/v1/ping for Conan 2 capability probe

### DIFF
--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -40,7 +40,11 @@ use crate::models::repository::RepositoryType;
 
 pub fn router() -> Router<SharedState> {
     Router::new()
-        // Ping
+        // Ping. Conan 2 clients probe `/v1/ping` for server capabilities
+        // (the `x-conan-server-capabilities` header) even when using the v2
+        // protocol — see `conan/internal/rest/rest_client.py::_get_api`. Both
+        // routes return the same response.
+        .route("/:repo_key/v1/ping", get(ping))
         .route("/:repo_key/v2/ping", get(ping))
         // Authentication
         .route(
@@ -1277,6 +1281,22 @@ async fn package_file_upload(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn ping_returns_revisions_capability() {
+        let response = ping().await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let capabilities = response
+            .headers()
+            .get("x-conan-server-capabilities")
+            .expect("x-conan-server-capabilities header must be present")
+            .to_str()
+            .expect("header value must be ASCII");
+        assert!(
+            capabilities.contains("revisions"),
+            "capability header must advertise 'revisions', got: {capabilities}"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (moved into test module)


### PR DESCRIPTION
## Summary

Fixes #779.

Conan 2 clients probe `GET /v1/ping` on every remote to read the `x-conan-server-capabilities` header and decide whether the server supports the revisions protocol — even when using the v2 API for every other request. See `conan/internal/rest/rest_client.py::_get_api`. The backend's Conan router only mounted `/v2/ping`, so the probe 404'd and every Conan 2 upload aborted with the opaque `NotFoundException: b''`.

This PR aliases `/v1/ping` to the same handler as `/v2/ping`. The response — 200 with `x-conan-server-capabilities: revisions` and an empty body — is identical across both protocol versions, so one handler serves both routes.

Scope is intentionally narrow: only the capability-probe endpoint is added. No other `/v1/*` routes are introduced. Conan 2 uses `v1/ping` solely for capability discovery and then speaks v2 for the rest of the protocol.

Note: after this fix, `conan upload` succeeds, but `conan install` still fails because the recipe/package files-listing endpoints (`.../revisions/{rev}/files`) are also missing — filed separately as #780.

## Test Checklist
- [x] Unit tests added/updated — added `ping_returns_revisions_capability` asserting the handler always advertises `revisions` in the capability header
- [ ] Integration tests added/updated (if applicable) — N/A, the route wiring is trivial and the existing capability-header test prevents the main regression
- [ ] E2E tests added/updated (if applicable) — N/A, no `scripts/native-tests/test-conan.sh` exists in the repo
- [x] Manually tested locally — reproduced the failure on `:latest`, applied the patch, rebuilt the backend image, reran `conan remote login` + `conan create` + `conan upload` against a local stack; upload now completes with both recipe and package revisions uploaded
- [x] No regressions in existing tests — `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib` (7815 passed, 0 failed) all green

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes — the added route is an alias of an existing handler; no new request/response types and no public API surface change beyond unblocking Conan 2 clients that were already expected to work