### PR TITLE
feat(conan): add recipe and package files-listing endpoints

### DIFF
--- a/.sqlx/query-b6f2cb71d744e292a728b61c98e051a6447e0398b1a5848ec6907bd57a3353aa.json
+++ b/.sqlx/query-b6f2cb71d744e292a728b61c98e051a6447e0398b1a5848ec6907bd57a3353aa.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'file' as \"file?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND am.metadata->>'type' = 'package'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' = $6\n          AND am.metadata->>'packageId' = $7\n          AND am.metadata->>'packageRevision' = $8\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "file?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b6f2cb71d744e292a728b61c98e051a6447e0398b1a5848ec6907bd57a3353aa"
+}

--- a/.sqlx/query-c88d26fb4ac95c434e7e6c35fc9d778bf96a7fc78bc493abee8cfe9ee1680505.json
+++ b/.sqlx/query-c88d26fb4ac95c434e7e6c35fc9d778bf96a7fc78bc493abee8cfe9ee1680505.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'file' as \"file?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND am.metadata->>'type' = 'recipe'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' = $6\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "file?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c88d26fb4ac95c434e7e6c35fc9d778bf96a7fc78bc493abee8cfe9ee1680505"
+}

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -40,7 +40,11 @@ use crate::models::repository::RepositoryType;
 
 pub fn router() -> Router<SharedState> {
     Router::new()
-        // Ping
+        // Ping. Conan 2 clients probe `/v1/ping` for server capabilities
+        // (the `x-conan-server-capabilities` header) even when using the v2
+        // protocol — see `conan/internal/rest/rest_client.py::_get_api`. Both
+        // routes return the same response.
+        .route("/:repo_key/v1/ping", get(ping))
         .route("/:repo_key/v2/ping", get(ping))
         // Authentication
         .route(
@@ -1277,6 +1281,22 @@ async fn package_file_upload(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn ping_returns_revisions_capability() {
+        let response = ping().await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let capabilities = response
+            .headers()
+            .get("x-conan-server-capabilities")
+            .expect("x-conan-server-capabilities header must be present")
+            .to_str()
+            .expect("header value must be ASCII");
+        assert!(
+            capabilities.contains("revisions"),
+            "capability header must advertise 'revisions', got: {capabilities}"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (moved into test module)

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -9,10 +9,12 @@
 //!   GET  /conan/{repo_key}/v2/conans/search                                                                - Search packages
 //!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/latest                               - Latest recipe revision
 //!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions                            - List recipe revisions
+//!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/files                - List recipe files
 //!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/files/{path}         - Download recipe file
 //!   PUT  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/files/{path}         - Upload recipe file
 //!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/packages/{pkg_id}/latest           - Latest package revision
 //!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/packages/{pkg_id}/revisions        - List package revisions
+//!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/packages/{pkg_id}/revisions/{pkg_rev}/files                - List package files
 //!   GET  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/packages/{pkg_id}/revisions/{pkg_rev}/files/{path} - Download package file
 //!   PUT  /conan/{repo_key}/v2/conans/{name}/{version}/{user}/{channel}/revisions/{rev}/packages/{pkg_id}/revisions/{pkg_rev}/files/{path} - Upload package file
 
@@ -67,6 +69,13 @@ pub fn router() -> Router<SharedState> {
             "/:repo_key/v2/conans/:name/:version/:user/:channel/revisions",
             get(recipe_revisions),
         )
+        // Recipe files list (must precede the wildcard route below so axum
+        // matches exact `/files` requests here rather than treating them as
+        // a wildcard with an empty path segment).
+        .route(
+            "/:repo_key/v2/conans/:name/:version/:user/:channel/revisions/:revision/files",
+            get(recipe_files_list),
+        )
         // Recipe file download / upload
         .route(
             "/:repo_key/v2/conans/:name/:version/:user/:channel/revisions/:revision/files/*file_path",
@@ -81,6 +90,12 @@ pub fn router() -> Router<SharedState> {
         .route(
             "/:repo_key/v2/conans/:name/:version/:user/:channel/revisions/:revision/packages/:package_id/revisions",
             get(package_revisions),
+        )
+        // Package files list (precedes the wildcard route, same reason as
+        // the recipe files-list route above).
+        .route(
+            "/:repo_key/v2/conans/:name/:version/:user/:channel/revisions/:revision/packages/:package_id/revisions/:pkg_revision/files",
+            get(package_files_list),
         )
         // Package file download / upload
         .route(
@@ -475,6 +490,59 @@ async fn recipe_revisions(
         .header(CONTENT_TYPE, "application/json")
         .body(Body::from(serde_json::to_string(&json).unwrap()))
         .unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// GET  .../revisions/{rev}/files — List recipe files
+// ---------------------------------------------------------------------------
+
+async fn recipe_files_list(
+    State(state): State<SharedState>,
+    Path((repo_key, name, version, user, channel, revision)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Result<Response, Response> {
+    let repo = resolve_conan_repo(&state.db, &repo_key).await?;
+
+    let rows = sqlx::query!(
+        r#"
+        SELECT am.metadata->>'file' as "file?"
+        FROM artifacts a
+        JOIN artifact_metadata am ON am.artifact_id = a.id
+        WHERE a.repository_id = $1
+          AND a.is_deleted = false
+          AND am.format = 'conan'
+          AND am.metadata->>'type' = 'recipe'
+          AND a.name = $2
+          AND a.version = $3
+          AND am.metadata->>'user' = $4
+          AND am.metadata->>'channel' = $5
+          AND am.metadata->>'revision' = $6
+        "#,
+        repo.id,
+        name,
+        version,
+        normalize_user(&user),
+        normalize_channel(&channel),
+        revision,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+            .into_response()
+    })?;
+
+    let filenames: Vec<String> = rows.into_iter().filter_map(|r| r.file).collect();
+    Ok(files_listing_response(filenames))
 }
 
 // ---------------------------------------------------------------------------
@@ -934,6 +1002,88 @@ async fn package_revisions(
 }
 
 // ---------------------------------------------------------------------------
+// GET  .../packages/{pkg_id}/revisions/{pkg_rev}/files — List package files
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::type_complexity)]
+async fn package_files_list(
+    State(state): State<SharedState>,
+    Path((repo_key, name, version, user, channel, revision, package_id, pkg_revision)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Result<Response, Response> {
+    let repo = resolve_conan_repo(&state.db, &repo_key).await?;
+
+    let rows = sqlx::query!(
+        r#"
+        SELECT am.metadata->>'file' as "file?"
+        FROM artifacts a
+        JOIN artifact_metadata am ON am.artifact_id = a.id
+        WHERE a.repository_id = $1
+          AND a.is_deleted = false
+          AND am.format = 'conan'
+          AND am.metadata->>'type' = 'package'
+          AND a.name = $2
+          AND a.version = $3
+          AND am.metadata->>'user' = $4
+          AND am.metadata->>'channel' = $5
+          AND am.metadata->>'revision' = $6
+          AND am.metadata->>'packageId' = $7
+          AND am.metadata->>'packageRevision' = $8
+        "#,
+        repo.id,
+        name,
+        version,
+        normalize_user(&user),
+        normalize_channel(&channel),
+        revision,
+        package_id,
+        pkg_revision,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+            .into_response()
+    })?;
+
+    let filenames: Vec<String> = rows.into_iter().filter_map(|r| r.file).collect();
+    Ok(files_listing_response(filenames))
+}
+
+/// Build the Conan v2 files-listing JSON body. The protocol shape is
+/// `{"files": {"filename.ext": {}, ...}}` — see
+/// `conan/internal/rest/rest_client_v2.py::_get_file_list_json`. Returns an
+/// empty `files` object when no artifacts match, matching what Conan expects
+/// for a recipe/package revision that has zero files.
+fn build_files_listing_json(filenames: Vec<String>) -> serde_json::Value {
+    let mut files = serde_json::Map::new();
+    for name in filenames {
+        files.insert(name, serde_json::json!({}));
+    }
+    serde_json::json!({ "files": files })
+}
+
+fn files_listing_response(filenames: Vec<String>) -> Response {
+    let body = build_files_listing_json(filenames);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
 // GET  .../packages/{pkg_id}/revisions/{pkg_rev}/files/{path} — Download package file
 // ---------------------------------------------------------------------------
 
@@ -1296,6 +1446,33 @@ mod tests {
             capabilities.contains("revisions"),
             "capability header must advertise 'revisions', got: {capabilities}"
         );
+    }
+
+    #[test]
+    fn build_files_listing_json_empty() {
+        let json = build_files_listing_json(Vec::new());
+        assert_eq!(json, serde_json::json!({ "files": {} }));
+    }
+
+    #[test]
+    fn build_files_listing_json_with_filenames() {
+        let json = build_files_listing_json(vec![
+            "conanfile.py".to_string(),
+            "conanmanifest.txt".to_string(),
+            "conan_export.tgz".to_string(),
+        ]);
+        let files = json
+            .get("files")
+            .and_then(|v| v.as_object())
+            .expect("response must have a 'files' object");
+        assert_eq!(files.len(), 3);
+        for name in ["conanfile.py", "conanmanifest.txt", "conan_export.tgz"] {
+            assert_eq!(
+                files.get(name),
+                Some(&serde_json::json!({})),
+                "missing or wrong value for {name}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #780. **Stacks on #781** — rebase to target `main` once that merges. Without #781 the Conan 2 client can't get past the capability probe to reach these endpoints, so this PR alone doesn't unblock `conan install`.

Conan 2's install flow enumerates a revision's files by calling `GET .../revisions/{rev}/files` (and the package equivalent) before downloading them — see `conan/internal/rest/rest_client_v2.py::_get_file_list_json`. Neither endpoint was mounted; only the per-file download/upload wildcard route existed. Result: after #781 unblocked uploads, every `conan install`, `conan download`, or other call that enumerates files aborted with the same opaque `NotFoundException: b''`.

This PR adds the two listing handlers. They query `artifact_metadata` keyed on `name/version/user/channel/revision` (and `packageId/packageRevision` for packages) — the same shape already populated by `recipe_file_upload`/`package_file_upload` and already queried by `recipe_revisions`/`package_revisions`, so no schema changes. Response JSON matches the Conan protocol: `{"files": {"filename.ext": {}, ...}}`. The new routes are registered **before** the wildcard download routes so axum matches the bare `/files` URLs exactly.

Together with #781, this enables the full `conan create` → `conan upload` → `conan install` → link → run cycle against an Artifact Keeper Conan repo. End-to-end validated by publishing a small `hello_world/0.1.0@demo/stable` C++ library from one Conan client and consuming it from a second (after a `conan remove "*" -c` cache wipe) to produce a working binary that prints `Hello, artifact-keeper!`.

## Test Checklist
- [x] Unit tests added/updated — `build_files_listing_json_empty` + `build_files_listing_json_with_filenames` pin the response JSON shape so the Conan protocol contract can't silently drift
- [x] Integration tests added/updated (if applicable) — the existing `test_conan_package_lifecycle` in `backend/tests/integration_tests.rs` is already `#[ignore]`'d (requires a running HTTP server); not extended in this PR. A future integration test that POSTs a recipe and asserts the listing response against a live DB would be the natural home for coverage of the SQL.
- [ ] E2E tests added/updated (if applicable) — N/A, no `scripts/native-tests/test-conan.sh` exists; manual reproduction documented above
- [x] Manually tested locally — reproduced the install failure on main with #781 alone, applied this PR, rebuilt the backend image, repeated the full publish → cache wipe → install → `cmake --build` → `./app` flow; the executable prints `Hello, artifact-keeper!` and backend logs show the expected `GET .../revisions/{rev}/files` returning 200
- [x] No regressions in existing tests — `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` all green; the conan module now has 47 tests passing (was 45)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations — following the existing convention in `backend/src/api/handlers/conan.rs`, none of the Conan protocol handlers carry utoipa annotations (they implement a third-party protocol contract rather than a first-class Artifact Keeper REST API). Happy to add annotations for the whole module if that's the preferred direction.
- [ ] Request/response types have `#[derive(ToSchema)]` — N/A, responses are ad-hoc `serde_json::Value` matching the Conan wire format
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid` — confirmed still passing (no OpenAPI surface change)
- [ ] Migration is reversible (if applicable) — N/A, no migrations
- [x] N/A - no API changes — in the Artifact Keeper public-API sense. Conan protocol surface expanded to match what Conan 2 clients already expect to call.