### PR TITLE
ci: skip Docker image build and smoke E2E on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       openscap: ${{ steps.filter.outputs.openscap }}


### PR DESCRIPTION
## Summary

Skip detect-changes, build-backend-image, and smoke-e2e jobs on pull requests. These only run on push to main/release branches now.

Frees up 2-3 runner pods per PR that were spent building Docker images and running smoke E2E that's redundant with the release gate.

PR CI now runs: Check Rust, Unit Tests, Coverage, Security Audit (4 jobs instead of 7+).

## Test Checklist
- [x] No regressions in existing tests

## API Changes
- [x] N/A