### PR TITLE
ci: run duplication gate independently from coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           fi
 
       - name: Code duplication gate
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         run: |
           # Install jscpd (copy-paste detector, same approach as SonarCloud's CPD engine)
           npm install -g jscpd@4 --silent 2>/dev/null
@@ -236,6 +236,7 @@ jobs:
           fi
 
       - name: Upload coverage artifact
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lcov-coverage


### PR DESCRIPTION
The code duplication gate was being skipped when the coverage gate failed because GitHub Actions stops subsequent steps on failure. Added `if: always()` so both gates report independently. Also ensures the lcov artifact is always uploaded.

## API Changes
- [x] N/A