### PR TITLE
fix: derive_format_key underscore handling and HuggingFace path validation

### DIFF
--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -28,6 +28,25 @@ use crate::api::SharedState;
 use crate::models::repository::RepositoryType;
 
 // ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+/// Maximum model ID length. The `name` column in the artifacts table is
+/// VARCHAR(512). HuggingFace model IDs follow the pattern `org/model-name`,
+/// so 255 characters provides ample room while preventing DB constraint
+/// violations with a clear error message.
+const MAX_MODEL_ID_LEN: usize = 255;
+
+/// Maximum revision length. The `version` column is VARCHAR(255).
+const MAX_REVISION_LEN: usize = 255;
+
+/// Maximum artifact path length. The `path` and `storage_key` columns are
+/// VARCHAR(2048). The storage key adds a `huggingface/` prefix (12 chars),
+/// so the artifact path must stay within 2036 to keep the storage key under
+/// the column limit.
+const MAX_PATH_LEN: usize = 2036;
+
+// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
@@ -369,6 +388,32 @@ async fn upload_file(
         return Err((StatusCode::BAD_REQUEST, "Empty file body").into_response());
     }
 
+    // Validate model_id length: the `name` database column is VARCHAR(512)
+    if model_id.len() > MAX_MODEL_ID_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Model ID exceeds maximum length of {} characters (got {})",
+                MAX_MODEL_ID_LEN,
+                model_id.len()
+            ),
+        )
+            .into_response());
+    }
+
+    // Validate revision length: the `version` database column is VARCHAR(255)
+    if revision.len() > MAX_REVISION_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Revision exceeds maximum length of {} characters (got {})",
+                MAX_REVISION_LEN,
+                revision.len()
+            ),
+        )
+            .into_response());
+    }
+
     // Extract filename from Content-Disposition header or default
     let filename = headers
         .get("x-filename")
@@ -387,6 +432,20 @@ async fn upload_file(
         .unwrap_or_else(|| "uploaded_file".to_string());
 
     let artifact_path = format!("{}/{}/{}", model_id, revision, filename);
+
+    // Validate total path length: the `path` database column is VARCHAR(2048)
+    if artifact_path.len() > MAX_PATH_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Artifact path exceeds maximum length of {} characters (got {}). \
+                 Use a shorter model ID, revision, or filename.",
+                MAX_PATH_LEN,
+                artifact_path.len()
+            ),
+        )
+            .into_response());
+    }
 
     // Compute SHA256
     let mut hasher = Sha256::new();
@@ -746,5 +805,71 @@ mod tests {
             upstream_url: Some("https://huggingface.co".to_string()),
         };
         assert_eq!(repo.upstream_url.as_deref(), Some("https://huggingface.co"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Length validation constants
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_model_id_within_limit() {
+        let model_id = "a".repeat(MAX_MODEL_ID_LEN);
+        assert!(model_id.len() <= MAX_MODEL_ID_LEN);
+    }
+
+    #[test]
+    fn test_model_id_exceeds_limit() {
+        let model_id = "a".repeat(MAX_MODEL_ID_LEN + 1);
+        assert!(model_id.len() > MAX_MODEL_ID_LEN);
+    }
+
+    #[test]
+    fn test_long_model_id_path_fits_in_db() {
+        // A 255-char model_id with "main" revision and a typical filename
+        // should produce a path under MAX_PATH_LEN.
+        let model_id = "a".repeat(MAX_MODEL_ID_LEN);
+        let revision = "main";
+        let filename = "model.safetensors";
+        let path = format!("{}/{}/{}", model_id, revision, filename);
+        assert!(
+            path.len() <= MAX_PATH_LEN,
+            "path length {} exceeds MAX_PATH_LEN {}",
+            path.len(),
+            MAX_PATH_LEN
+        );
+    }
+
+    #[test]
+    fn test_long_model_id_storage_key_fits_in_db() {
+        // Storage key adds "huggingface/" prefix (12 chars).
+        let model_id = "a".repeat(MAX_MODEL_ID_LEN);
+        let revision = "main";
+        let filename = "model.safetensors";
+        let key = format!("huggingface/{}/{}/{}", model_id, revision, filename);
+        assert!(
+            key.len() <= 2048,
+            "storage_key length {} exceeds VARCHAR(2048)",
+            key.len()
+        );
+    }
+
+    #[test]
+    fn test_revision_within_limit() {
+        let revision = "v".repeat(MAX_REVISION_LEN);
+        assert!(revision.len() <= MAX_REVISION_LEN);
+    }
+
+    #[test]
+    fn test_long_model_name_artifact_path() {
+        // A model name over 100 characters should still produce valid paths.
+        let model_id = "x".repeat(120);
+        assert_eq!(model_id.len(), 120);
+        let path = format!("{}/{}/{}", model_id, "main", "weights.safetensors");
+        assert!(path.len() <= MAX_PATH_LEN);
+        let key = format!(
+            "huggingface/{}/{}/{}",
+            model_id, "main", "weights.safetensors"
+        );
+        assert!(key.len() <= 2048);
     }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -81,8 +81,68 @@ pub(crate) fn validate_remote_upstream(
 }
 
 /// Derive a format key string from a RepositoryFormat enum.
+///
+/// Returns the canonical snake_case format key matching the database enum
+/// value and the `FormatHandler::format_key()` contract. Using `Debug`
+/// formatting followed by `to_lowercase()` is insufficient because it
+/// drops underscores from multi-word variants (e.g., `CondaNative` becomes
+/// `"condanative"` instead of `"conda_native"`).
 pub(crate) fn derive_format_key(format: &RepositoryFormat) -> String {
-    format!("{:?}", format).to_lowercase()
+    match format {
+        RepositoryFormat::Maven => "maven",
+        RepositoryFormat::Gradle => "gradle",
+        RepositoryFormat::Npm => "npm",
+        RepositoryFormat::Pypi => "pypi",
+        RepositoryFormat::Nuget => "nuget",
+        RepositoryFormat::Go => "go",
+        RepositoryFormat::Rubygems => "rubygems",
+        RepositoryFormat::Docker => "docker",
+        RepositoryFormat::Helm => "helm",
+        RepositoryFormat::Rpm => "rpm",
+        RepositoryFormat::Debian => "debian",
+        RepositoryFormat::Conan => "conan",
+        RepositoryFormat::Cargo => "cargo",
+        RepositoryFormat::Generic => "generic",
+        RepositoryFormat::Podman => "podman",
+        RepositoryFormat::Buildx => "buildx",
+        RepositoryFormat::Oras => "oras",
+        RepositoryFormat::WasmOci => "wasm_oci",
+        RepositoryFormat::HelmOci => "helm_oci",
+        RepositoryFormat::Poetry => "poetry",
+        RepositoryFormat::Conda => "conda",
+        RepositoryFormat::Yarn => "yarn",
+        RepositoryFormat::Bower => "bower",
+        RepositoryFormat::Pnpm => "pnpm",
+        RepositoryFormat::Chocolatey => "chocolatey",
+        RepositoryFormat::Powershell => "powershell",
+        RepositoryFormat::Terraform => "terraform",
+        RepositoryFormat::Opentofu => "opentofu",
+        RepositoryFormat::Alpine => "alpine",
+        RepositoryFormat::CondaNative => "conda_native",
+        RepositoryFormat::Composer => "composer",
+        RepositoryFormat::Hex => "hex",
+        RepositoryFormat::Cocoapods => "cocoapods",
+        RepositoryFormat::Swift => "swift",
+        RepositoryFormat::Pub => "pub",
+        RepositoryFormat::Sbt => "sbt",
+        RepositoryFormat::Chef => "chef",
+        RepositoryFormat::Puppet => "puppet",
+        RepositoryFormat::Ansible => "ansible",
+        RepositoryFormat::Gitlfs => "gitlfs",
+        RepositoryFormat::Vscode => "vscode",
+        RepositoryFormat::Jetbrains => "jetbrains",
+        RepositoryFormat::Huggingface => "huggingface",
+        RepositoryFormat::Mlmodel => "mlmodel",
+        RepositoryFormat::Cran => "cran",
+        RepositoryFormat::Vagrant => "vagrant",
+        RepositoryFormat::Opkg => "opkg",
+        RepositoryFormat::P2 => "p2",
+        RepositoryFormat::Bazel => "bazel",
+        RepositoryFormat::Protobuf => "protobuf",
+        RepositoryFormat::Incus => "incus",
+        RepositoryFormat::Lxc => "lxc",
+    }
+    .to_string()
 }
 
 /// Build a SQL LIKE search pattern from a user query string.
@@ -1045,19 +1105,19 @@ mod tests {
 
     #[test]
     fn test_derive_format_key_wasm_oci() {
-        assert_eq!(derive_format_key(&RepositoryFormat::WasmOci), "wasmoci");
+        assert_eq!(derive_format_key(&RepositoryFormat::WasmOci), "wasm_oci");
     }
 
     #[test]
     fn test_derive_format_key_helm_oci() {
-        assert_eq!(derive_format_key(&RepositoryFormat::HelmOci), "helmoci");
+        assert_eq!(derive_format_key(&RepositoryFormat::HelmOci), "helm_oci");
     }
 
     #[test]
     fn test_derive_format_key_conda_native() {
         assert_eq!(
             derive_format_key(&RepositoryFormat::CondaNative),
-            "condanative"
+            "conda_native"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixed `derive_format_key` which used `Debug` formatting to derive format key strings from `RepositoryFormat` enum variants. Multi-word variants lost their underscores: `CondaNative` became `"condanative"` instead of `"conda_native"`, breaking the format handler enable/disable lookup for `conda_native`, `wasm_oci`, and `helm_oci` repositories. Replaced with an explicit match producing canonical snake_case keys that match the database enum values and the `FormatHandler::format_key()` contract.
- Added input length validation to the HuggingFace upload handler. Model IDs, revisions, and total artifact paths that exceed database column limits (`name VARCHAR(512)`, `version VARCHAR(255)`, `path VARCHAR(2048)`) are now rejected with a descriptive 400 response rather than causing a 500 database constraint error.

Closes #801, closes #802.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes