### PR TITLE
fix: auto-set binary version from git tag (#808)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,6 +79,7 @@ jobs:
           provenance: mode=max
           build-args: |
             GIT_SHA=${{ github.sha }}
+            APP_VERSION=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
       - name: Export digest
         run: |
@@ -213,6 +214,7 @@ jobs:
           provenance: mode=max
           build-args: |
             GIT_SHA=${{ github.sha }}
+            APP_VERSION=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
       - name: Export digest
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,13 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "Setting workspace version to ${VERSION}"
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          head -5 Cargo.toml
+
       - name: Build
         env:
           SQLX_OFFLINE: true

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -49,9 +49,14 @@ COPY .sqlx ./.sqlx
 COPY backend ./backend
 ARG GIT_SHA=unknown
 ARG CARGO_FEATURES=""
+ARG APP_VERSION=""
 ENV SQLX_OFFLINE=true
 ENV GIT_SHA=${GIT_SHA}
-RUN if [ -n "$CARGO_FEATURES" ]; then \
+RUN if [ -n "${APP_VERSION}" ]; then \
+      CLEAN_VERSION=$(echo "${APP_VERSION}" | sed 's/^v//'); \
+      sed -i "s/^version = \".*\"/version = \"${CLEAN_VERSION}\"/" Cargo.toml; \
+    fi && \
+    if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --features "$CARGO_FEATURES" --bin artifact-keeper; \
     else \
       cargo build --release --bin artifact-keeper; \

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -35,9 +35,14 @@ COPY .sqlx ./.sqlx
 COPY backend ./backend
 ARG GIT_SHA=unknown
 ARG CARGO_FEATURES=""
+ARG APP_VERSION=""
 ENV SQLX_OFFLINE=true
 ENV GIT_SHA=${GIT_SHA}
-RUN FEATURES="vendored-openssl"; \
+RUN if [ -n "${APP_VERSION}" ]; then \
+      CLEAN_VERSION=$(echo "${APP_VERSION}" | sed 's/^v//'); \
+      sed -i "s/^version = \".*\"/version = \"${CLEAN_VERSION}\"/" Cargo.toml; \
+    fi && \
+    FEATURES="vendored-openssl"; \
     if [ -n "$CARGO_FEATURES" ]; then FEATURES="$FEATURES,$CARGO_FEATURES"; fi && \
     cargo build --release --features "$FEATURES" --bin artifact-keeper
 


### PR DESCRIPTION
Fixes #808. Injects APP_VERSION build arg from the git tag into Dockerfiles and the release workflow. Strips the v prefix. No-op for branch builds. Preserves CARGO_FEATURES support.

## Test Checklist
- [x] No regressions
## API Changes
- [x] N/A