### PR TITLE
fix(debian): add .xz support and catch-all dists proxy for remote repos

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -10,11 +10,13 @@
 //!   GET  /debian/{repo_key}/dists/{distribution}/gpg-key.asc                        - Repository public key
 //!   GET  /debian/{repo_key}/dists/{distribution}/{component}/binary-{arch}/Packages - Packages index
 //!   GET  /debian/{repo_key}/dists/{distribution}/{component}/binary-{arch}/Packages.gz - Compressed Packages index
+//!   GET  /debian/{repo_key}/dists/{distribution}/{component}/binary-{arch}/Packages.xz - XZ-compressed Packages index
+//!   GET  /debian/{repo_key}/dists/{distribution}/*path                              - Catch-all dists proxy (i18n, Sources, etc.)
 //!   GET  /debian/{repo_key}/pool/{component}/*path                                  - Download .deb
 //!   PUT  /debian/{repo_key}/pool/{component}/*path                                  - Upload .deb
 //!   POST /debian/{repo_key}/upload                                                  - Upload .deb (raw body)
 
-use std::io::Write;
+use std::io::{self, Write};
 
 use axum::body::Body;
 use axum::extract::{Path, State};
@@ -68,11 +70,15 @@ pub fn router() -> Router<SharedState> {
             "/:repo_key/dists/:distribution/:component/:binary_arch/Packages.gz",
             get(packages_index_gz),
         )
-        // TODO: Add Packages.xz support once xz2/lzma crate is available
-        // .route(
-        //     "/:repo_key/dists/:distribution/:component/:binary_arch/Packages.xz",
-        //     get(packages_index_xz),
-        // )
+        .route(
+            "/:repo_key/dists/:distribution/:component/:binary_arch/Packages.xz",
+            get(packages_index_xz),
+        )
+        // Catch-all for other dists metadata (i18n/Translation-*.xz, Sources, etc.)
+        .route(
+            "/:repo_key/dists/:distribution/*dists_path",
+            get(dists_proxy_catchall),
+        )
         // Pool: download and upload
         .route(
             "/:repo_key/pool/:component/*path",
@@ -634,7 +640,113 @@ async fn packages_index_gz(
 }
 
 // ---------------------------------------------------------------------------
-// GET /debian/{repo_key}/pool/{component}/*path — Download .deb
+// GET /debian/{repo_key}/dists/{dist}/{component}/binary-{arch}/Packages.xz
+// ---------------------------------------------------------------------------
+
+async fn packages_index_xz(
+    State(state): State<SharedState>,
+    Path((repo_key, distribution, component, binary_arch)): Path<(String, String, String, String)>,
+) -> Result<Response, Response> {
+    let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    let packages_xz_suffix = format!("{}/{}/Packages.xz", component, binary_arch);
+    proxy
+        .dists(&packages_xz_suffix, "application/x-xz", &repo)
+        .await?;
+
+    let arch = binary_arch.strip_prefix("binary-").unwrap_or(&binary_arch);
+
+    let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
+    let text = build_packages_text(&entries);
+
+    let compressed = xz_compress(text.as_bytes()).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("XZ compression error: {}", e),
+        )
+            .into_response()
+    })?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/x-xz")
+        .header(CONTENT_LENGTH, compressed.len().to_string())
+        .body(Body::from(compressed))
+        .unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// GET /debian/{repo_key}/dists/{distribution}/*dists_path -- Catch-all proxy
+// ---------------------------------------------------------------------------
+
+/// Catch-all handler for dists metadata that does not have a dedicated route.
+/// This covers files like `i18n/Translation-en.xz`, `i18n/Translation-en.gz`,
+/// `Sources`, `Sources.gz`, `Sources.xz`, and other index files that upstream
+/// Debian mirrors serve under `dists/`.
+///
+/// For remote repositories the file is fetched from upstream and returned
+/// directly. For hosted repositories the handler returns 404 because these
+/// metadata files are generated on-the-fly only through the dedicated routes.
+async fn dists_proxy_catchall(
+    State(state): State<SharedState>,
+    Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+
+    if repo.repo_type != RepositoryType::Remote {
+        return Err((StatusCode::NOT_FOUND, "Not found").into_response());
+    }
+
+    let (upstream_url, proxy) = match (&repo.upstream_url, &state.proxy_service) {
+        (Some(u), Some(p)) => (u, p),
+        _ => return Err((StatusCode::NOT_FOUND, "Not found").into_response()),
+    };
+
+    let upstream_path = format!("dists/{}/{}", distribution, dists_path);
+    let (content, upstream_ct) =
+        proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path).await?;
+
+    let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_LENGTH, content.len().to_string())
+        .body(Body::from(content))
+        .unwrap())
+}
+
+/// Infer a reasonable content-type from the file extension when the upstream
+/// response does not include one. Covers the common Debian index
+/// compressions and the uncompressed fallback.
+fn content_type_for_dists_path(path: &str) -> String {
+    if path.ends_with(".xz") {
+        "application/x-xz".to_string()
+    } else if path.ends_with(".gz") {
+        "application/gzip".to_string()
+    } else if path.ends_with(".bz2") {
+        "application/x-bzip2".to_string()
+    } else if path.ends_with(".lz4") {
+        "application/x-lz4".to_string()
+    } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+        "application/zstd".to_string()
+    } else {
+        "text/plain; charset=utf-8".to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// XZ compression helper
+// ---------------------------------------------------------------------------
+
+/// Compress data using XZ/LZMA2.
+fn xz_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
+    let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 6);
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
+// ---------------------------------------------------------------------------
+// GET /debian/{repo_key}/pool/{component}/*path -- Download .deb
 // ---------------------------------------------------------------------------
 
 async fn pool_download(
@@ -1310,6 +1422,26 @@ mod tests {
                 "main/binary-amd64/Packages.gz",
                 "dists/trixie/main/binary-amd64/Packages.gz",
             ),
+            (
+                "trixie",
+                "main/binary-amd64/Packages.xz",
+                "dists/trixie/main/binary-amd64/Packages.xz",
+            ),
+            (
+                "bookworm",
+                "main/i18n/Translation-en.xz",
+                "dists/bookworm/main/i18n/Translation-en.xz",
+            ),
+            (
+                "bookworm",
+                "main/i18n/Translation-en.gz",
+                "dists/bookworm/main/i18n/Translation-en.gz",
+            ),
+            (
+                "trixie",
+                "main/source/Sources.xz",
+                "dists/trixie/main/source/Sources.xz",
+            ),
         ];
         for (dist, suffix, expected) in &cases {
             let path = format!("dists/{}/{}", dist, suffix);
@@ -1331,6 +1463,97 @@ mod tests {
         assert_eq!(
             full_url,
             "http://deb.debian.org/debian/dists/trixie/InRelease"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XZ compression round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_xz_compress_round_trip() {
+        let original = b"Package: hello\nVersion: 1.0\nArchitecture: amd64\n";
+        let compressed = xz_compress(original).expect("xz compression should succeed");
+        // XZ magic bytes: 0xFD, '7', 'z', 'X', 'Z', 0x00
+        assert_eq!(&compressed[..6], &[0xFD, b'7', b'z', b'X', b'Z', 0x00]);
+        // Decompress and verify round-trip
+        use std::io::Read;
+        let mut decoder = xz2::read::XzDecoder::new(&compressed[..]);
+        let mut decompressed = Vec::new();
+        decoder
+            .read_to_end(&mut decompressed)
+            .expect("xz decompression should succeed");
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn test_xz_compress_empty_input() {
+        let compressed = xz_compress(b"").expect("xz compression of empty input should succeed");
+        assert!(!compressed.is_empty(), "xz output is never zero-length");
+        use std::io::Read;
+        let mut decoder = xz2::read::XzDecoder::new(&compressed[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+        assert!(decompressed.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // content_type_for_dists_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_content_type_for_dists_path_xz() {
+        assert_eq!(
+            content_type_for_dists_path("main/i18n/Translation-en.xz"),
+            "application/x-xz"
+        );
+        assert_eq!(
+            content_type_for_dists_path("main/binary-amd64/Packages.xz"),
+            "application/x-xz"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_dists_path_gz() {
+        assert_eq!(
+            content_type_for_dists_path("main/i18n/Translation-en.gz"),
+            "application/gzip"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_dists_path_bz2() {
+        assert_eq!(
+            content_type_for_dists_path("main/source/Sources.bz2"),
+            "application/x-bzip2"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_dists_path_plain() {
+        assert_eq!(
+            content_type_for_dists_path("main/i18n/Translation-en"),
+            "text/plain; charset=utf-8"
+        );
+        assert_eq!(
+            content_type_for_dists_path("main/source/Sources"),
+            "text/plain; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_dists_path_zstd() {
+        assert_eq!(
+            content_type_for_dists_path("main/binary-amd64/Packages.zst"),
+            "application/zstd"
+        );
+    }
+
+    #[test]
+    fn test_content_type_for_dists_path_lz4() {
+        assert_eq!(
+            content_type_for_dists_path("main/binary-amd64/Packages.lz4"),
+            "application/x-lz4"
         );
     }
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -569,6 +569,33 @@ async fn gpg_key_asc(
 }
 
 // ---------------------------------------------------------------------------
+// Shared helpers for Packages index handlers
+// ---------------------------------------------------------------------------
+
+/// Strip the `binary-` prefix from an Axum path segment like `binary-amd64`,
+/// returning just `amd64`. If the prefix is absent, returns the input unchanged.
+fn strip_binary_arch_prefix(binary_arch: &str) -> &str {
+    binary_arch.strip_prefix("binary-").unwrap_or(binary_arch)
+}
+
+/// Build the dists-relative suffix for a Packages index file.
+/// e.g. `("main", "binary-amd64", "gz")` -> `"main/binary-amd64/Packages.gz"`
+/// Pass an empty string for `ext` to get the uncompressed path.
+fn packages_index_suffix(component: &str, binary_arch: &str, ext: &str) -> String {
+    if ext.is_empty() {
+        format!("{}/{}/Packages", component, binary_arch)
+    } else {
+        format!("{}/{}/Packages.{}", component, binary_arch, ext)
+    }
+}
+
+/// Build a Packages index and compress it with XZ.
+fn build_packages_xz(entries: &[PackageEntry]) -> Result<Vec<u8>, io::Error> {
+    let text = build_packages_text(entries);
+    xz_compress(text.as_bytes())
+}
+
+// ---------------------------------------------------------------------------
 // GET /debian/{repo_key}/dists/{dist}/{component}/binary-{arch}/Packages
 // ---------------------------------------------------------------------------
 
@@ -577,13 +604,12 @@ async fn packages_index(
     Path((repo_key, distribution, component, binary_arch)): Path<(String, String, String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
-    let packages_suffix = format!("{}/{}/Packages", component, binary_arch);
+    let packages_suffix = packages_index_suffix(&component, &binary_arch, "");
     proxy
         .dists(&packages_suffix, "text/plain; charset=utf-8", &repo)
         .await?;
 
-    // binary_arch is like "binary-amd64", strip the "binary-" prefix
-    let arch = binary_arch.strip_prefix("binary-").unwrap_or(&binary_arch);
+    let arch = strip_binary_arch_prefix(&binary_arch);
 
     let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
     let text = build_packages_text(&entries);
@@ -605,12 +631,12 @@ async fn packages_index_gz(
     Path((repo_key, distribution, component, binary_arch)): Path<(String, String, String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
-    let packages_gz_suffix = format!("{}/{}/Packages.gz", component, binary_arch);
+    let packages_gz_suffix = packages_index_suffix(&component, &binary_arch, "gz");
     proxy
         .dists(&packages_gz_suffix, "application/gzip", &repo)
         .await?;
 
-    let arch = binary_arch.strip_prefix("binary-").unwrap_or(&binary_arch);
+    let arch = strip_binary_arch_prefix(&binary_arch);
 
     let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
     let text = build_packages_text(&entries);
@@ -648,17 +674,16 @@ async fn packages_index_xz(
     Path((repo_key, distribution, component, binary_arch)): Path<(String, String, String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
-    let packages_xz_suffix = format!("{}/{}/Packages.xz", component, binary_arch);
+    let packages_xz_suffix = packages_index_suffix(&component, &binary_arch, "xz");
     proxy
         .dists(&packages_xz_suffix, "application/x-xz", &repo)
         .await?;
 
-    let arch = binary_arch.strip_prefix("binary-").unwrap_or(&binary_arch);
+    let arch = strip_binary_arch_prefix(&binary_arch);
 
     let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
-    let text = build_packages_text(&entries);
 
-    let compressed = xz_compress(text.as_bytes()).map_err(|e| {
+    let compressed = build_packages_xz(&entries).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("XZ compression error: {}", e),
@@ -1555,5 +1580,202 @@ mod tests {
             content_type_for_dists_path("main/binary-amd64/Packages.lz4"),
             "application/x-lz4"
         );
+    }
+
+    #[test]
+    fn test_content_type_for_dists_path_zstd_long_extension() {
+        assert_eq!(
+            content_type_for_dists_path("main/binary-arm64/Packages.zstd"),
+            "application/zstd"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // strip_binary_arch_prefix
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_strip_binary_arch_prefix_amd64() {
+        assert_eq!(strip_binary_arch_prefix("binary-amd64"), "amd64");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_arm64() {
+        assert_eq!(strip_binary_arch_prefix("binary-arm64"), "arm64");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_i386() {
+        assert_eq!(strip_binary_arch_prefix("binary-i386"), "i386");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_all() {
+        assert_eq!(strip_binary_arch_prefix("binary-all"), "all");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_no_prefix() {
+        assert_eq!(strip_binary_arch_prefix("amd64"), "amd64");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_empty() {
+        assert_eq!(strip_binary_arch_prefix(""), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // packages_index_suffix
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_packages_index_suffix_uncompressed() {
+        assert_eq!(
+            packages_index_suffix("main", "binary-amd64", ""),
+            "main/binary-amd64/Packages"
+        );
+    }
+
+    #[test]
+    fn test_packages_index_suffix_gz() {
+        assert_eq!(
+            packages_index_suffix("main", "binary-amd64", "gz"),
+            "main/binary-amd64/Packages.gz"
+        );
+    }
+
+    #[test]
+    fn test_packages_index_suffix_xz() {
+        assert_eq!(
+            packages_index_suffix("main", "binary-amd64", "xz"),
+            "main/binary-amd64/Packages.xz"
+        );
+    }
+
+    #[test]
+    fn test_packages_index_suffix_non_free_arm64() {
+        assert_eq!(
+            packages_index_suffix("non-free", "binary-arm64", "xz"),
+            "non-free/binary-arm64/Packages.xz"
+        );
+    }
+
+    #[test]
+    fn test_packages_index_suffix_contrib() {
+        assert_eq!(
+            packages_index_suffix("contrib", "binary-i386", "gz"),
+            "contrib/binary-i386/Packages.gz"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // build_packages_xz (integration of build_packages_text + xz_compress)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_packages_xz_single_entry() {
+        let entries = vec![PackageEntry {
+            name: "curl".to_string(),
+            version: "7.88.1-10".to_string(),
+            arch: "amd64".to_string(),
+            filename: "pool/main/c/curl/curl_7.88.1-10_amd64.deb".to_string(),
+            size: 311296,
+            sha256: "abcdef1234567890".to_string(),
+            description: "command line tool for transferring data with URL syntax".to_string(),
+        }];
+        let compressed = build_packages_xz(&entries).expect("xz compression should succeed");
+        // Verify XZ magic bytes
+        assert_eq!(&compressed[..6], &[0xFD, b'7', b'z', b'X', b'Z', 0x00]);
+        // Decompress and verify it contains the expected package text
+        use std::io::Read;
+        let mut decoder = xz2::read::XzDecoder::new(&compressed[..]);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed).unwrap();
+        assert!(decompressed.contains("Package: curl\n"));
+        assert!(decompressed.contains("Version: 7.88.1-10\n"));
+        assert!(decompressed.contains("Architecture: amd64\n"));
+    }
+
+    #[test]
+    fn test_build_packages_xz_multiple_entries() {
+        let entries = vec![
+            PackageEntry {
+                name: "nginx".to_string(),
+                version: "1.24.0".to_string(),
+                arch: "amd64".to_string(),
+                filename: "pool/main/n/nginx/nginx_1.24.0_amd64.deb".to_string(),
+                size: 1024,
+                sha256: "aaa".to_string(),
+                description: "HTTP server".to_string(),
+            },
+            PackageEntry {
+                name: "curl".to_string(),
+                version: "8.0.0".to_string(),
+                arch: "amd64".to_string(),
+                filename: "pool/main/c/curl/curl_8.0.0_amd64.deb".to_string(),
+                size: 2048,
+                sha256: "bbb".to_string(),
+                description: "URL transfer tool".to_string(),
+            },
+        ];
+        let compressed = build_packages_xz(&entries).expect("xz compression should succeed");
+        use std::io::Read;
+        let mut decoder = xz2::read::XzDecoder::new(&compressed[..]);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed).unwrap();
+        assert!(decompressed.contains("Package: nginx\n"));
+        assert!(decompressed.contains("Package: curl\n"));
+        // Entries separated by blank line
+        assert!(decompressed.contains("\n\n"));
+    }
+
+    #[test]
+    fn test_build_packages_xz_empty_entries() {
+        let entries: Vec<PackageEntry> = vec![];
+        let compressed = build_packages_xz(&entries).expect("xz of empty input should succeed");
+        use std::io::Read;
+        let mut decoder = xz2::read::XzDecoder::new(&compressed[..]);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed).unwrap();
+        assert!(decompressed.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // xz_compress with realistic Packages-sized data
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_xz_compress_large_packages_text() {
+        // Generate a realistic multi-package index (the kind of data the
+        // handler compresses in production).
+        let mut text = String::new();
+        for i in 0..50 {
+            if i > 0 {
+                text.push('\n');
+            }
+            text.push_str(&format!("Package: libfoo{}\n", i));
+            text.push_str(&format!("Version: 1.0.{}\n", i));
+            text.push_str("Architecture: amd64\n");
+            text.push_str(&format!(
+                "Filename: pool/main/libf/libfoo{}/libfoo{}_1.0.{}_amd64.deb\n",
+                i, i, i
+            ));
+            text.push_str("Size: 10240\n");
+            text.push_str("SHA256: deadbeef\n");
+            text.push_str("Description: Test library\n");
+        }
+        let compressed = xz_compress(text.as_bytes()).expect("xz compression should succeed");
+        // XZ compresses well on repetitive data
+        assert!(
+            compressed.len() < text.len(),
+            "compressed ({}) should be smaller than original ({})",
+            compressed.len(),
+            text.len()
+        );
+        use std::io::Read;
+        let mut decoder = xz2::read::XzDecoder::new(&compressed[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(decompressed, text.as_bytes());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #810. The Debian remote proxy only served .gz-compressed indices and had no route for files outside the known set (Packages, Release, InRelease, etc.). Clients requesting .xz-compressed indices or i18n Translation files received 404 responses.

Three changes:

1. **Packages.xz route** -- uses the `xz2` crate (already a dependency, used in the Incus handler) to compress the Packages index with LZMA2, matching the existing .gz route pattern.
2. **Catch-all dists proxy** -- a wildcard route at `/:repo_key/dists/:distribution/*dists_path` that forwards any unmatched path to the upstream mirror for remote repositories. This covers `i18n/Translation-*.xz`, `Sources.xz`, `Sources.gz`, and any other metadata files that Debian mirrors serve under `dists/`.
3. **Content-type inference** -- a `content_type_for_dists_path` helper that maps file extensions (.xz, .gz, .bz2, .lz4, .zst) to MIME types when the upstream response omits Content-Type.

The catch-all route is registered after all specific routes so it does not shadow them. For hosted repositories it returns 404, since those files are generated on-the-fly only through the dedicated routes.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

8 new unit tests: xz round-trip compression, empty-input compression, content-type inference for xz/gz/bz2/plain/zstd/lz4, and upstream path construction for Packages.xz, Translation-en.xz, Translation-en.gz, and Sources.xz. All 81 Debian tests pass.

## API Changes
- [x] N/A - no API changes

No new utoipa annotations needed. The new routes use internal proxy plumbing only.