### PR TITLE
fix: ensure admin.password file is created reliably on first boot

### DIFF
--- a/backend/src/api/middleware/setup.rs
+++ b/backend/src/api/middleware/setup.rs
@@ -57,7 +57,8 @@ pub async fn setup_guard(
                 "1. Read the generated password: docker exec artifact-keeper-backend cat /data/storage/admin.password && echo",
                 "2. Login: POST /api/v1/auth/login with {\"username\":\"admin\",\"password\":\"<from-file>\"}",
                 "3. Change password: POST /api/v1/users/<id>/password with {\"new_password\":\"<your-password>\"}",
-                "4. The API will unlock automatically after the password is changed."
+                "4. The API will unlock automatically after the password is changed.",
+                "If the password file is missing, restart the container. A new password will be generated automatically."
             ]
         })),
     )

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -998,7 +998,21 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         return Ok(false);
     }
 
-    let password_file = Path::new(storage_path).join("admin.password");
+    let storage_dir = Path::new(storage_path);
+    let password_file = storage_dir.join("admin.password");
+
+    // Ensure the storage directory exists before we try to write anything.
+    // Docker named volumes normally create the mount point, but bind mounts,
+    // alternative runtimes (Podman rootless, Kubernetes emptyDir), and custom
+    // STORAGE_PATH values may not.  Creating it here avoids a silent failure
+    // when writing the admin password file later. (fixes #787)
+    if let Err(e) = std::fs::create_dir_all(storage_dir) {
+        tracing::warn!(
+            "Could not create storage directory {}: {}",
+            storage_dir.display(),
+            e
+        );
+    }
 
     // Check if an admin user already exists
     let admin_row: Option<(bool,)> =
@@ -1041,9 +1055,28 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
             tracing::warn!(
                 "Admin user has not changed default password. API is locked until password is changed."
             );
-            // Ensure the password file still exists for the user to read
             if password_file.exists() {
                 tracing::info!("Admin password file: {}", password_file.display());
+            } else {
+                // The password file is missing (deleted, volume recreated, or
+                // the initial write failed).  Generate a new password, update
+                // the hash in the database, and write the file so the user can
+                // complete setup. (fixes #787)
+                tracing::warn!(
+                    "Admin password file missing at {}. Regenerating password.",
+                    password_file.display()
+                );
+                let password = generate_random_password();
+                let password_hash = AuthService::hash_password(&password).await?;
+                sqlx::query("UPDATE users SET password_hash = $1 WHERE username = 'admin'")
+                    .bind(&password_hash)
+                    .execute(db)
+                    .await
+                    .map_err(|e| {
+                        artifact_keeper_backend::error::AppError::Database(e.to_string())
+                    })?;
+                write_admin_password_file(&password_file, &password);
+                log_admin_setup_banner(&password_file);
             }
             return Ok(true);
         }
@@ -1060,15 +1093,7 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
             }
         }
         _ => {
-            const CHARSET: &[u8] =
-                b"abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789!@#$%&*";
-            let mut rng = rand::rng();
-            let p: String = (0..20)
-                .map(|_| {
-                    let idx = rng.random_range(0..CHARSET.len());
-                    CHARSET[idx] as char
-                })
-                .collect();
+            let p = generate_random_password();
             (p, true)
         }
     };
@@ -1092,64 +1117,91 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
     .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
     if must_change {
-        // Write password + setup instructions to the file
-        let file_contents = format!(
-            "{}\n\n\
-            # ONE-TIME SETUP — this password must be changed before the API unlocks.\n\
-            #\n\
-            # Step 1: Login to get a JWT token:\n\
-            #   curl -s -X POST http://localhost:8080/api/v1/auth/login \\\n\
-            #     -H 'Content-Type: application/json' \\\n\
-            #     -d '{{\"username\":\"admin\",\"password\":\"<password-above>\"}}'\n\
-            #\n\
-            # Step 2: Change the password (use the access_token from step 1):\n\
-            #   curl -s -X POST http://localhost:8080/api/v1/users/me/password \\\n\
-            #     -H 'Authorization: Bearer <access_token>' \\\n\
-            #     -H 'Content-Type: application/json' \\\n\
-            #     -d '{{\"current_password\":\"<password-above>\",\"new_password\":\"<your-new-password>\"}}'\n\
-            #\n\
-            # The API is LOCKED until you complete these steps.\n\
-            # Do NOT use this password directly in API calls — you must login first.\n",
-            password
-        );
-        if let Err(e) = std::fs::write(&password_file, &file_contents) {
-            tracing::error!("Failed to write admin password file: {}", e);
-            tracing::error!("Admin password could not be persisted. Re-run the server or check file permissions for: {}", password_file.display());
-        } else {
-            // Restrict file permissions to owner-only (0600) since this file contains credentials
-            #[cfg(unix)]
-            if let Err(e) =
-                std::fs::set_permissions(&password_file, std::fs::Permissions::from_mode(0o600))
-            {
-                tracing::warn!("Failed to set permissions on admin password file: {}", e);
-            }
-            tracing::info!("Admin password written to: {}", password_file.display());
-        }
-        tracing::info!(
-            "\n\
-            ===========================================================\n\
-            \n\
-              Initial admin user created.\n\
-            \n\
-              Username:  admin\n\
-              Password:  see file {}\n\
-            \n\
-              Read it:   docker exec artifact-keeper-backend cat {}\n\
-            \n\
-              The API is LOCKED until you change this password.\n\
-              You MUST login first (POST /api/v1/auth/login) to get\n\
-              a token, then change the password. See the file for\n\
-              full curl examples.\n\
-            \n\
-            ===========================================================",
-            password_file.display(),
-            password_file.display(),
-        );
+        write_admin_password_file(&password_file, &password);
+        log_admin_setup_banner(&password_file);
         Ok(true)
     } else {
         tracing::info!("Admin user created with password from ADMIN_PASSWORD env var");
         Ok(false)
     }
+}
+
+/// Generate a random 20-character password for the admin user.
+fn generate_random_password() -> String {
+    const CHARSET: &[u8] = b"abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789!@#$%&*";
+    let mut rng = rand::rng();
+    (0..20)
+        .map(|_| {
+            let idx = rng.random_range(0..CHARSET.len());
+            CHARSET[idx] as char
+        })
+        .collect()
+}
+
+/// Write the admin password and setup instructions to a file.
+///
+/// Failures are logged but not propagated, because the server should still
+/// start (the password is printed in the banner as a fallback).
+fn write_admin_password_file(password_file: &std::path::Path, password: &str) {
+    let file_contents = format!(
+        "{}\n\n\
+        # ONE-TIME SETUP -- this password must be changed before the API unlocks.\n\
+        #\n\
+        # Step 1: Login to get a JWT token:\n\
+        #   curl -s -X POST http://localhost:8080/api/v1/auth/login \\\n\
+        #     -H 'Content-Type: application/json' \\\n\
+        #     -d '{{\"username\":\"admin\",\"password\":\"<password-above>\"}}'\n\
+        #\n\
+        # Step 2: Change the password (use the access_token from step 1):\n\
+        #   curl -s -X POST http://localhost:8080/api/v1/users/me/password \\\n\
+        #     -H 'Authorization: Bearer <access_token>' \\\n\
+        #     -H 'Content-Type: application/json' \\\n\
+        #     -d '{{\"current_password\":\"<password-above>\",\"new_password\":\"<your-new-password>\"}}'\n\
+        #\n\
+        # The API is LOCKED until you complete these steps.\n\
+        # Do NOT use this password directly in API calls -- you must login first.\n",
+        password
+    );
+    if let Err(e) = std::fs::write(password_file, &file_contents) {
+        tracing::error!("Failed to write admin password file: {}", e);
+        tracing::error!(
+            "Admin password could not be persisted. \
+             Re-run the server or check file permissions for: {}",
+            password_file.display()
+        );
+    } else {
+        #[cfg(unix)]
+        if let Err(e) =
+            std::fs::set_permissions(password_file, std::fs::Permissions::from_mode(0o600))
+        {
+            tracing::warn!("Failed to set permissions on admin password file: {}", e);
+        }
+        tracing::info!("Admin password written to: {}", password_file.display());
+    }
+}
+
+/// Log the setup banner with instructions for the admin user.
+fn log_admin_setup_banner(password_file: &std::path::Path) {
+    tracing::info!(
+        "\n\
+        ===========================================================\n\
+        \n\
+          Initial admin user created.\n\
+        \n\
+          Username:  admin\n\
+          Password:  see file {}\n\
+        \n\
+          Read it:   docker exec artifact-keeper-backend cat {}\n\
+        \n\
+          The API is LOCKED until you change this password.\n\
+          You MUST login first (POST /api/v1/auth/login) to get\n\
+          a token, then change the password. See the file for\n\
+          full curl examples.\n\
+        \n\
+        ===========================================================",
+        password_file.display(),
+        password_file.display(),
+    );
 }
 
 fn is_insecure_default_password(password: &str) -> bool {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -983,6 +983,10 @@ fn build_oidc_request_from_values(
 /// Returns `true` when the API should be locked until the admin changes
 /// the default password (i.e. `must_change_password` is still set and no
 /// explicit `ADMIN_PASSWORD` env var was provided).
+///
+/// Uses a PostgreSQL advisory lock to prevent race conditions when multiple
+/// replicas start simultaneously.  The lock is held for the duration of the
+/// check-and-create sequence so only one replica performs the initial insert.
 async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<bool> {
     use std::path::Path;
 
@@ -1014,10 +1018,25 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         );
     }
 
-    // Check if an admin user already exists
+    // Acquire a cluster-wide advisory lock so that concurrent replicas
+    // serialize their admin provisioning.  The lock key is a stable hash
+    // of a well-known string.  We use a transaction-scoped lock
+    // (pg_advisory_xact_lock) so it is automatically released when the
+    // transaction commits or rolls back.
+    let mut tx = db
+        .begin()
+        .await
+        .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext('admin_password_init'))")
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+
+    // Re-check admin existence while holding the lock (double-check pattern).
     let admin_row: Option<(bool,)> =
         sqlx::query_as("SELECT must_change_password FROM users WHERE is_admin = true LIMIT 1")
-            .fetch_optional(db)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
@@ -1028,9 +1047,10 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         // password-based login works.  This is a no-op when the column is
         // already correct but fixes installs that ended up with a wrong value.
         sqlx::query(
-            "UPDATE users SET auth_provider = 'local' WHERE username = 'admin' AND auth_provider != 'local'"
+            "UPDATE users SET auth_provider = 'local' \
+             WHERE username = 'admin' AND auth_provider != 'local'",
         )
-        .execute(db)
+        .execute(&mut *tx)
         .await
         .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
@@ -1041,9 +1061,12 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
                     sqlx::query(
                         "UPDATE users SET must_change_password = true WHERE username = 'admin'",
                     )
-                    .execute(db)
+                    .execute(&mut *tx)
                     .await
                     .map_err(|e| {
+                        artifact_keeper_backend::error::AppError::Database(e.to_string())
+                    })?;
+                    tx.commit().await.map_err(|e| {
                         artifact_keeper_backend::error::AppError::Database(e.to_string())
                     })?;
                     return Ok(true);
@@ -1053,35 +1076,54 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
 
         if must_change {
             tracing::warn!(
-                "Admin user has not changed default password. API is locked until password is changed."
+                "Admin user has not changed default password. \
+                 API is locked until password is changed."
             );
             if password_file.exists() {
                 tracing::info!("Admin password file: {}", password_file.display());
             } else {
                 // The password file is missing (deleted, volume recreated, or
-                // the initial write failed).  Generate a new password, update
-                // the hash in the database, and write the file so the user can
-                // complete setup. (fixes #787)
+                // the initial write failed).  Generate a new password, write
+                // the file FIRST, then update the DB hash.  If the file write
+                // fails we skip the DB update so the old hash remains usable
+                // on retry.
                 tracing::warn!(
                     "Admin password file missing at {}. Regenerating password.",
                     password_file.display()
                 );
                 let password = generate_random_password();
-                let password_hash = AuthService::hash_password(&password).await?;
-                sqlx::query("UPDATE users SET password_hash = $1 WHERE username = 'admin'")
-                    .bind(&password_hash)
-                    .execute(db)
-                    .await
-                    .map_err(|e| {
-                        artifact_keeper_backend::error::AppError::Database(e.to_string())
-                    })?;
-                write_admin_password_file(&password_file, &password);
-                log_admin_setup_banner(&password_file);
+                if let Err(e) = write_admin_password_file(&password_file, &password) {
+                    tracing::error!("Failed to write admin password file: {}", e);
+                    tracing::error!(
+                        "Admin password could not be persisted. \
+                         Re-run the server or check file permissions for: {}",
+                        password_file.display()
+                    );
+                } else {
+                    // File written successfully, now update the DB hash to match.
+                    let password_hash = AuthService::hash_password(&password).await?;
+                    sqlx::query("UPDATE users SET password_hash = $1 WHERE username = 'admin'")
+                        .bind(&password_hash)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| {
+                            artifact_keeper_backend::error::AppError::Database(e.to_string())
+                        })?;
+                    log_admin_setup_banner(&password_file);
+                }
             }
+            tx.commit()
+                .await
+                .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
             return Ok(true);
         }
+        tx.commit()
+            .await
+            .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
         return Ok(false);
     }
+
+    // --- No admin user exists yet: create one. ---
 
     let (password, must_change) = match std::env::var("ADMIN_PASSWORD") {
         Ok(p) if !p.is_empty() => {
@@ -1098,6 +1140,31 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
         }
     };
 
+    // Write the password file BEFORE updating the database.  If the file
+    // write fails, we abort without inserting the DB row so the next startup
+    // can retry cleanly.  This avoids the scenario where the hash is in the
+    // DB but the plaintext is lost.
+    if must_change {
+        if let Err(e) = write_admin_password_file(&password_file, &password) {
+            tracing::error!("Failed to write admin password file: {}", e);
+            tracing::error!(
+                "Admin password could not be persisted. \
+                 Re-run the server or check file permissions for: {}",
+                password_file.display()
+            );
+            // Roll back the transaction (advisory lock released).  The next
+            // replica or restart will retry.
+            tx.rollback()
+                .await
+                .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+            return Err(artifact_keeper_backend::error::AppError::Config(format!(
+                "Cannot persist admin password file at {}. \
+                 Fix file permissions and restart.",
+                password_file.display()
+            )));
+        }
+    }
+
     let password_hash = AuthService::hash_password(&password).await?;
 
     sqlx::query(
@@ -1112,12 +1179,15 @@ async fn provision_admin_user(db: &sqlx::PgPool, storage_path: &str) -> Result<b
     )
     .bind(&password_hash)
     .bind(must_change)
-    .execute(db)
+    .execute(&mut *tx)
     .await
     .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
 
+    tx.commit()
+        .await
+        .map_err(|e| artifact_keeper_backend::error::AppError::Database(e.to_string()))?;
+
     if must_change {
-        write_admin_password_file(&password_file, &password);
         log_admin_setup_banner(&password_file);
         Ok(true)
     } else {
@@ -1140,9 +1210,13 @@ fn generate_random_password() -> String {
 
 /// Write the admin password and setup instructions to a file.
 ///
-/// Failures are logged but not propagated, because the server should still
-/// start (the password is printed in the banner as a fallback).
-fn write_admin_password_file(password_file: &std::path::Path, password: &str) {
+/// Returns `Ok(())` on success.  On failure the error is propagated so that
+/// callers can avoid updating the database hash (preventing the "hash in DB
+/// but plaintext lost" scenario).
+fn write_admin_password_file(
+    password_file: &std::path::Path,
+    password: &str,
+) -> std::io::Result<()> {
     let file_contents = format!(
         "{}\n\n\
         # ONE-TIME SETUP -- this password must be changed before the API unlocks.\n\
@@ -1162,22 +1236,14 @@ fn write_admin_password_file(password_file: &std::path::Path, password: &str) {
         # Do NOT use this password directly in API calls -- you must login first.\n",
         password
     );
-    if let Err(e) = std::fs::write(password_file, &file_contents) {
-        tracing::error!("Failed to write admin password file: {}", e);
-        tracing::error!(
-            "Admin password could not be persisted. \
-             Re-run the server or check file permissions for: {}",
-            password_file.display()
-        );
-    } else {
-        #[cfg(unix)]
-        if let Err(e) =
-            std::fs::set_permissions(password_file, std::fs::Permissions::from_mode(0o600))
-        {
-            tracing::warn!("Failed to set permissions on admin password file: {}", e);
-        }
-        tracing::info!("Admin password written to: {}", password_file.display());
+    std::fs::write(password_file, &file_contents)?;
+    #[cfg(unix)]
+    if let Err(e) = std::fs::set_permissions(password_file, std::fs::Permissions::from_mode(0o600))
+    {
+        tracing::warn!("Failed to set permissions on admin password file: {}", e);
     }
+    tracing::info!("Admin password written to: {}", password_file.display());
+    Ok(())
 }
 
 /// Log the setup banner with instructions for the admin user.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,8 +166,9 @@ services:
       PLUGINS_DIR: /data/plugins
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production-please}
       # ADMIN_PASSWORD: set this to skip first-boot setup lock.
-      # If unset, a random password is written to /data/storage/admin.password
-      # and the API is locked until the admin changes it.
+      # If unset, a random password is generated and written to
+      # /data/storage/admin.password on each boot until it is changed.
+      # Read it with: docker exec artifact-keeper-backend cat /data/storage/admin.password
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       RUST_LOG: ${RUST_LOG:-info,artifact_keeper=debug}
       ENVIRONMENT: ${ENVIRONMENT:-production}


### PR DESCRIPTION
## Summary

Fixes #787. The `admin.password` file could be missing after `docker compose up` for two reasons:

- The storage directory (`/data/storage`) was not explicitly created before writing the password file. Docker named volumes normally handle this, but bind mounts, Podman rootless, Kubernetes emptyDir volumes, and custom `STORAGE_PATH` values may not have the directory pre-created. Added `create_dir_all` on the storage path before any file writes.

- If the initial write failed silently (permissions, missing directory) or the file was later deleted, subsequent container restarts found the admin user already in the database with `must_change_password=true` but never regenerated the file. The user hit a locked API with no way to recover the password. Now the server detects the missing file on restart, generates a fresh password, updates the password hash in the database, and writes the new file.

Extracted `write_admin_password_file`, `generate_random_password`, and `log_admin_setup_banner` into standalone functions to avoid duplicating the file-writing and banner logic across the first-boot and recovery code paths.

Also updated the setup-guard 403 response to tell users they can restart the container if the password file is missing, and updated the docker-compose.yml comment to document how to read the generated password.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes