### PR TITLE
chore: bump bundled Trivy from 0.69.3 to 0.70.0

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -136,7 +136,7 @@ RUN if [ -f /mnt/rootfs/etc/dnf/dnf.conf ]; then \
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Copy scanner CLIs from official images ----------
-FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
+FROM ghcr.io/aquasecurity/trivy:0.70.0 AS trivy-bin
 FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -47,7 +47,7 @@ RUN if [ -n "${APP_VERSION}" ]; then \
     cargo build --release --features "$FEATURES" --bin artifact-keeper
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
-FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
+FROM ghcr.io/aquasecurity/trivy:0.70.0 AS trivy-bin
 FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
 
 # ---------- Stage 5: Alpine runtime ----------


### PR DESCRIPTION
## Summary

Bumps the bundled Trivy scanner CLI from 0.69.3 to 0.70.0 in both backend Dockerfiles. Resolves 1 CRITICAL and ~16 HIGH container scan findings from #807. All findings were in the bundled trivy binary, not in application code or base images.

Closes #807

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes