### PR TITLE
Fix Dependency-Track HTTP rejection and missing SBOM submission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -291,7 +291,7 @@ JWT_EXPIRATION_SECS=86400
 #
 # Note: HTTP is allowed automatically for private/local network addresses
 # (localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
-# *.svc.cluster.local, *.local) without setting this variable. Only set this
+# *.svc, *.svc.cluster.local, *.local) without setting this variable. Only set this
 # to true if your upstream services use HTTP on public/non-RFC-1918 addresses.
 #
 # Default: false (HTTPS enforced for non-private-network connections)

--- a/.env.example
+++ b/.env.example
@@ -288,7 +288,13 @@ JWT_EXPIRATION_SECS=86400
 # Allow HTTP (non-TLS) connections for remote repository proxying, Artifactory
 # migration, and Dependency-Track integration. Required when upstream services
 # use plain HTTP (common in air-gapped or development environments).
-# Default: false (HTTPS enforced for all external connections)
+#
+# Note: HTTP is allowed automatically for private/local network addresses
+# (localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+# *.svc.cluster.local, *.local) without setting this variable. Only set this
+# to true if your upstream services use HTTP on public/non-RFC-1918 addresses.
+#
+# Default: false (HTTPS enforced for non-private-network connections)
 # ALLOW_HTTP_INTEGRATIONS=false
 
 # Path to a PEM file containing one or more custom CA certificates.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -363,7 +363,7 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     let advisory_client = Arc::new(AdvisoryClient::new(std::env::var("GITHUB_TOKEN").ok()));
     let scan_result_service = Arc::new(ScanResultService::new(db_pool.clone()));
     let scan_config_service = Arc::new(ScanConfigService::new(db_pool.clone()));
-    let scanner_service = Arc::new(ScannerService::new(
+    let mut scanner_service = ScannerService::new(
         db_pool.clone(),
         advisory_client,
         scan_result_service,
@@ -375,7 +375,28 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         config.scan_workspace_path.clone(),
         config.openscap_url.clone(),
         config.openscap_profile.clone(),
-    ));
+    );
+
+    // Initialize Dependency-Track integration (before wrapping scanner in Arc,
+    // so we can wire the DT service into the scan pipeline for SBOM submission).
+    let dt_service_arc: Option<Arc<DependencyTrackService>> =
+        match DependencyTrackService::from_env() {
+            Some(Ok(dt_service)) => {
+                tracing::info!("Dependency-Track integration enabled");
+                Some(Arc::new(dt_service))
+            }
+            Some(Err(e)) => {
+                tracing::warn!("Failed to initialize Dependency-Track: {}", e);
+                None
+            }
+            None => None,
+        };
+
+    if let Some(ref dt) = dt_service_arc {
+        scanner_service.set_dependency_track(dt.clone());
+    }
+
+    let scanner_service = Arc::new(scanner_service);
 
     // Create application state with WASM plugin support
     let scheduler_storage = primary_storage.clone();
@@ -399,17 +420,8 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     if let Some(meili) = meili_service {
         app_state.set_meili_service(meili);
     }
-    // Initialize Dependency-Track integration
-    if let Some(dt_result) = DependencyTrackService::from_env() {
-        match dt_result {
-            Ok(dt_service) => {
-                tracing::info!("Dependency-Track integration enabled");
-                app_state.set_dependency_track(Arc::new(dt_service));
-            }
-            Err(e) => {
-                tracing::warn!("Failed to initialize Dependency-Track: {}", e);
-            }
-        }
+    if let Some(dt) = dt_service_arc {
+        app_state.set_dependency_track(dt);
     }
 
     app_state.set_metrics_handle(metrics_handle);

--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -384,7 +384,9 @@ pub fn is_private_network_url(raw_url: &str) -> bool {
             return v6.is_loopback()        // ::1
                 || v6.is_unspecified()     // ::
                 // fe80::/10 (link-local) -- no stable std method yet
-                || (v6.segments()[0] & 0xffc0) == 0xfe80;
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+                // fc00::/7 (unique local addresses)
+                || (v6.segments()[0] & 0xfe00) == 0xfc00;
         }
         url::Host::Domain(_) => {}
     }
@@ -432,10 +434,12 @@ impl DependencyTrackService {
                 "Dependency-Track base_url is not HTTPS and not a private network address. \
                  Set ALLOW_HTTP_INTEGRATIONS=1 to allow plain HTTP connections."
             );
-        } else if is_private && !config.base_url.starts_with("https://") && !explicit_allow_http {
+        }
+
+        if is_private && !config.base_url.starts_with("https://") && !explicit_allow_http {
             info!(
                 url = %config.base_url,
-                "Dependency-Track base_url is HTTP on a private network address, allowing automatically"
+                "Auto-allowing HTTP for private network URL: {}", config.base_url
             );
         }
 
@@ -1785,6 +1789,11 @@ mod tests {
     #[test]
     fn test_private_url_ipv6_link_local() {
         assert!(is_private_network_url("http://[fe80::1]:8080"));
+    }
+
+    #[test]
+    fn test_private_url_ipv6_unique_local() {
+        assert!(is_private_network_url("http://[fd12::1]:8080"));
     }
 
     // ===================================================================

--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -1796,6 +1796,155 @@ mod tests {
         assert!(is_private_network_url("http://[fd12::1]:8080"));
     }
 
+    // --- Additional edge cases for is_private_network_url ---
+
+    #[test]
+    fn test_private_url_ipv4_with_path_and_query() {
+        assert!(is_private_network_url(
+            "http://10.0.0.1:8080/api/v1?key=abc"
+        ));
+        assert!(is_private_network_url(
+            "http://192.168.1.1/health?format=json"
+        ));
+    }
+
+    #[test]
+    fn test_private_url_ipv4_with_auth_info() {
+        assert!(is_private_network_url("http://admin:pass@192.168.1.1:8080"));
+        assert!(is_private_network_url("http://user:pwd@10.0.0.5/api"));
+        assert!(is_private_network_url("http://user@127.0.0.1:9090"));
+    }
+
+    #[test]
+    fn test_private_url_ipv4_ports_on_private_ips() {
+        assert!(is_private_network_url("http://10.0.0.1:443"));
+        assert!(is_private_network_url("http://10.0.0.1:8443"));
+        assert!(is_private_network_url("http://172.16.0.1:9090"));
+        assert!(is_private_network_url("http://192.168.0.1:1"));
+        assert!(is_private_network_url("http://192.168.0.1:65535"));
+    }
+
+    #[test]
+    fn test_private_url_rfc1918_class_b_boundary() {
+        // 172.15.x.x is NOT private (below the 172.16-172.31 range)
+        assert!(!is_private_network_url("http://172.15.255.255:8080"));
+        // 172.16.0.0 is the start of the private range
+        assert!(is_private_network_url("http://172.16.0.0:8080"));
+        // 172.31.255.255 is the end of the private range
+        assert!(is_private_network_url("http://172.31.255.255:8080"));
+        // 172.32.0.0 is outside the private range
+        assert!(!is_private_network_url("http://172.32.0.0:8080"));
+    }
+
+    #[test]
+    fn test_private_url_ipv6_unspecified() {
+        assert!(is_private_network_url("http://[::]:8080"));
+    }
+
+    #[test]
+    fn test_private_url_ipv6_full_link_local() {
+        assert!(is_private_network_url("http://[fe80::abcd:1234]:8080"));
+        assert!(is_private_network_url("http://[fe80::abcd:ef01:2345]:9090"));
+    }
+
+    #[test]
+    fn test_private_url_ipv6_unique_local_range() {
+        // fc00::/7 covers fc00:: through fdff::
+        assert!(is_private_network_url("http://[fc00::1]:8080"));
+        assert!(is_private_network_url("http://[fdff::1]:8080"));
+    }
+
+    #[test]
+    fn test_public_url_ipv6_global() {
+        // 2001:db8:: is documentation range, but treated as public by the function
+        assert!(!is_private_network_url("http://[2001:db8::1]:8080"));
+        // 2600:: is a public IPv6 range
+        assert!(!is_private_network_url("http://[2600::1]:8080"));
+    }
+
+    #[test]
+    fn test_private_url_localhost_variants() {
+        assert!(is_private_network_url("http://localhost:3000/path"));
+        assert!(is_private_network_url("https://localhost:443"));
+        assert!(is_private_network_url("http://localhost"));
+        // LOCALHOST uppercase should not match (case-sensitive hostname comparison
+        // lowercases before checking, so it should match)
+        assert!(is_private_network_url("http://LOCALHOST:8080"));
+    }
+
+    #[test]
+    fn test_private_url_kubernetes_svc_variants() {
+        assert!(is_private_network_url(
+            "http://my-app.production.svc.cluster.local:8080"
+        ));
+        assert!(is_private_network_url(
+            "http://api.kube-system.svc.cluster.local"
+        ));
+        assert!(is_private_network_url("http://service.ns.svc"));
+        // Just ".svc" suffix should match
+        assert!(is_private_network_url("http://redis.default.svc:6379"));
+    }
+
+    #[test]
+    fn test_private_url_local_domain_variants() {
+        assert!(is_private_network_url("http://my-mac.local:8080"));
+        assert!(is_private_network_url("http://printer.local"));
+        assert!(is_private_network_url("http://nas.local:5000/api"));
+    }
+
+    #[test]
+    fn test_public_url_svc_in_middle() {
+        // "svc" appearing in the middle of a domain should NOT be private
+        assert!(!is_private_network_url("http://svc.example.com:8080"));
+        assert!(!is_private_network_url(
+            "http://my-svc-api.cloud.company.com"
+        ));
+    }
+
+    #[test]
+    fn test_private_url_loopback_full_range() {
+        // 127.0.0.0/8 covers 127.0.0.0 through 127.255.255.255
+        assert!(is_private_network_url("http://127.0.0.0:8080"));
+        assert!(is_private_network_url("http://127.0.0.1:8080"));
+        assert!(is_private_network_url("http://127.100.200.50:8080"));
+        assert!(is_private_network_url("http://127.255.255.254:8080"));
+    }
+
+    #[test]
+    fn test_private_url_invalid_schemes() {
+        // Schemes other than http/https should still be parseable by url::Url
+        // ftp with a private IP
+        assert!(is_private_network_url("ftp://192.168.1.1/file"));
+    }
+
+    #[test]
+    fn test_private_url_fragment_and_query() {
+        assert!(is_private_network_url(
+            "http://10.0.0.1:8080/path?q=1#section"
+        ));
+    }
+
+    #[test]
+    fn test_public_url_dot_local_like_but_not_local() {
+        // "example.locals" is not ".local"
+        assert!(!is_private_network_url("http://example.locals:8080"));
+        // "mylocal.com" is not ".local"
+        assert!(!is_private_network_url("http://mylocal.com:8080"));
+    }
+
+    #[test]
+    fn test_private_url_https_scheme() {
+        assert!(is_private_network_url("https://10.0.0.1:443"));
+        assert!(is_private_network_url("https://192.168.1.1"));
+        assert!(is_private_network_url("https://localhost:8443"));
+    }
+
+    #[test]
+    fn test_private_url_link_local_range() {
+        assert!(is_private_network_url("http://169.254.0.1:8080"));
+        assert!(is_private_network_url("http://169.254.255.254:8080"));
+    }
+
     // ===================================================================
     // Pagination (wiremock integration tests)
     // ===================================================================

--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -20,6 +20,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
+use url::Url;
 use utoipa::ToSchema;
 
 use crate::error::{AppError, Result};
@@ -349,17 +350,92 @@ pub struct DtAnalysisResponse {
     pub is_suppressed: bool,
 }
 
+/// Check whether a URL points to a private or local network address where
+/// HTTP (non-TLS) is acceptable. This covers:
+///
+/// - `localhost` / `127.0.0.0/8` / `::1`
+/// - RFC 1918 private ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+/// - Link-local: `169.254.0.0/16`, `fe80::/10`
+/// - Kubernetes service DNS: `*.svc`, `*.svc.cluster.local`
+/// - mDNS / local domains: `*.local`
+///
+/// Returns `false` for URLs that cannot be parsed or have no host component.
+pub fn is_private_network_url(raw_url: &str) -> bool {
+    let parsed = match Url::parse(raw_url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+
+    let host = match parsed.host() {
+        Some(h) => h,
+        None => return false,
+    };
+
+    // Check IP-based hosts using the parsed Host enum, which handles
+    // IPv6 bracket notation (e.g. [::1]) correctly.
+    match host {
+        url::Host::Ipv4(v4) => {
+            return v4.is_loopback()        // 127.0.0.0/8
+                || v4.is_private()         // 10/8, 172.16/12, 192.168/16
+                || v4.is_link_local()      // 169.254/16
+                || v4.is_unspecified(); // 0.0.0.0
+        }
+        url::Host::Ipv6(v6) => {
+            return v6.is_loopback()        // ::1
+                || v6.is_unspecified()     // ::
+                // fe80::/10 (link-local) -- no stable std method yet
+                || (v6.segments()[0] & 0xffc0) == 0xfe80;
+        }
+        url::Host::Domain(_) => {}
+    }
+
+    // Check hostname-based patterns
+    let host_lower = parsed.host_str().unwrap_or("").to_lowercase();
+
+    if host_lower == "localhost" {
+        return true;
+    }
+
+    // Kubernetes in-cluster service names (e.g. dependency-track.ns.svc.cluster.local)
+    if host_lower.ends_with(".svc") || host_lower.ends_with(".svc.cluster.local") {
+        return true;
+    }
+
+    // mDNS / local domains
+    if host_lower.ends_with(".local") {
+        return true;
+    }
+
+    false
+}
+
 impl DependencyTrackService {
     /// Create a new Dependency-Track service
     pub fn new(config: DependencyTrackConfig) -> Result<Self> {
-        // Enforce HTTPS unless explicitly opted out for local dev
-        let allow_http = std::env::var("ALLOW_HTTP_INTEGRATIONS")
+        // Determine whether HTTP (non-TLS) is acceptable for this URL.
+        //
+        // Priority:
+        //   1. Explicit opt-in via ALLOW_HTTP_INTEGRATIONS=1
+        //   2. Auto-allow for private/local network addresses (localhost,
+        //      RFC 1918, *.svc.cluster.local, *.local)
+        //   3. Default: require HTTPS
+        let explicit_allow_http = std::env::var("ALLOW_HTTP_INTEGRATIONS")
             .map(|v| v == "1" || v == "true")
             .unwrap_or(false);
+
+        let is_private = is_private_network_url(&config.base_url);
+        let allow_http = explicit_allow_http || is_private;
+
         if !allow_http && !config.base_url.starts_with("https://") {
             warn!(
                 url = %config.base_url,
-                "Dependency-Track base_url is not HTTPS. Set ALLOW_HTTP_INTEGRATIONS=1 for local dev."
+                "Dependency-Track base_url is not HTTPS and not a private network address. \
+                 Set ALLOW_HTTP_INTEGRATIONS=1 to allow plain HTTP connections."
+            );
+        } else if is_private && !config.base_url.starts_with("https://") && !explicit_allow_http {
+            info!(
+                url = %config.base_url,
+                "Dependency-Track base_url is HTTP on a private network address, allowing automatically"
             );
         }
 
@@ -1617,6 +1693,98 @@ mod tests {
         assert_eq!(json["analysisState"], "NOT_AFFECTED");
         assert!(json.get("analysisDetails").is_none());
         assert_eq!(json["isSuppressed"], true);
+    }
+
+    // ===================================================================
+    // is_private_network_url
+    // ===================================================================
+
+    #[test]
+    fn test_private_url_localhost() {
+        assert!(is_private_network_url("http://localhost:8080"));
+        assert!(is_private_network_url("http://localhost"));
+        assert!(is_private_network_url("https://localhost:443/api"));
+    }
+
+    #[test]
+    fn test_private_url_loopback_ipv4() {
+        assert!(is_private_network_url("http://127.0.0.1:8092"));
+        assert!(is_private_network_url("http://127.0.0.1"));
+        assert!(is_private_network_url("http://127.255.255.255:80"));
+    }
+
+    #[test]
+    fn test_private_url_loopback_ipv6() {
+        assert!(is_private_network_url("http://[::1]:8080"));
+        assert!(is_private_network_url("http://[::1]"));
+    }
+
+    #[test]
+    fn test_private_url_rfc1918_class_a() {
+        assert!(is_private_network_url("http://10.0.0.1:8080"));
+        assert!(is_private_network_url("http://10.255.255.255"));
+    }
+
+    #[test]
+    fn test_private_url_rfc1918_class_b() {
+        assert!(is_private_network_url("http://172.16.0.1:8080"));
+        assert!(is_private_network_url("http://172.31.255.255"));
+        // 172.32.x.x is NOT private
+        assert!(!is_private_network_url("http://172.32.0.1:8080"));
+    }
+
+    #[test]
+    fn test_private_url_rfc1918_class_c() {
+        assert!(is_private_network_url("http://192.168.0.1:8080"));
+        assert!(is_private_network_url("http://192.168.255.255"));
+    }
+
+    #[test]
+    fn test_private_url_link_local() {
+        assert!(is_private_network_url("http://169.254.1.1:8080"));
+    }
+
+    #[test]
+    fn test_private_url_kubernetes_svc() {
+        assert!(is_private_network_url(
+            "http://dependency-track.default.svc.cluster.local:8080"
+        ));
+        assert!(is_private_network_url("http://dt-api.ns.svc:8080"));
+        assert!(is_private_network_url(
+            "http://my-service.monitoring.svc.cluster.local"
+        ));
+    }
+
+    #[test]
+    fn test_private_url_local_domain() {
+        assert!(is_private_network_url("http://dt.local:8080"));
+        assert!(is_private_network_url("http://myhost.local"));
+    }
+
+    #[test]
+    fn test_private_url_unspecified() {
+        assert!(is_private_network_url("http://0.0.0.0:8080"));
+    }
+
+    #[test]
+    fn test_public_url_rejected() {
+        assert!(!is_private_network_url("http://dt.example.com:8080"));
+        assert!(!is_private_network_url("http://8.8.8.8:8080"));
+        assert!(!is_private_network_url(
+            "https://dependency-track.prod.company.com"
+        ));
+    }
+
+    #[test]
+    fn test_private_url_invalid_input() {
+        assert!(!is_private_network_url("not-a-url"));
+        assert!(!is_private_network_url(""));
+        assert!(!is_private_network_url("://missing-scheme"));
+    }
+
+    #[test]
+    fn test_private_url_ipv6_link_local() {
+        assert!(is_private_network_url("http://[fe80::1]:8080"));
     }
 
     // ===================================================================

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -47,7 +47,7 @@ pub(crate) fn sanitize_artifact_filename(name: &str) -> String {
 ///
 /// Common formats (pypi, npm, maven, etc.) get their standard purl type.
 /// Unknown formats fall back to `"generic"`.
-fn format_to_purl_type(format: &str) -> &str {
+fn format_to_purl_type(format: &str) -> &'static str {
     match format.to_lowercase().as_str() {
         "pypi" => "pypi",
         "npm" => "npm",
@@ -70,6 +70,54 @@ fn format_to_purl_type(format: &str) -> &str {
         "apk" | "alpine" => "apk",
         _ => "generic",
     }
+}
+
+/// Derive the Dependency-Track project name and purl type from an optional
+/// repo name and format. When the repo row is missing, falls back to the
+/// raw repository UUID string.
+///
+/// Returns `(project_name, purl_type)`.
+pub(crate) fn derive_dt_project_info(
+    repo_row: Option<(String, Option<String>)>,
+    fallback_id: &str,
+) -> (String, &'static str) {
+    let (project_name, repo_format) = match repo_row {
+        Some((name, format)) => (name, format),
+        None => (fallback_id.to_string(), None),
+    };
+    let purl_type = match repo_format {
+        Some(ref fmt) => format_to_purl_type(fmt),
+        None => "generic",
+    };
+    (project_name, purl_type)
+}
+
+/// Build a list of [`DependencyInfo`] from scan-finding rows.
+///
+/// Each row is `(component_name, optional_version, optional_source)`.
+/// When a version is present the function generates a purl string using
+/// the supplied `purl_type`.
+pub(crate) fn build_dependency_info_from_findings(
+    findings_rows: Vec<(String, Option<String>, Option<String>)>,
+    purl_type: &str,
+) -> Vec<crate::services::sbom_service::DependencyInfo> {
+    use crate::services::sbom_service::DependencyInfo;
+
+    findings_rows
+        .into_iter()
+        .map(|(name, version, _source)| {
+            let purl = version
+                .as_deref()
+                .map(|v| format!("pkg:{}/{}@{}", purl_type, name, v));
+            DependencyInfo {
+                name,
+                version,
+                purl,
+                license: None,
+                sha256: None,
+            }
+        })
+        .collect()
 }
 
 /// Shared scan workspace utilities for scanners that need to write artifact
@@ -1391,7 +1439,7 @@ impl ScannerService {
         artifact: &Artifact,
     ) {
         use crate::models::sbom::SbomFormat;
-        use crate::services::sbom_service::{DependencyInfo, SbomService};
+        use crate::services::sbom_service::SbomService;
 
         // Fetch repository name and format for the DT project
         let repo_row: Option<(String, Option<String>)> =
@@ -1402,15 +1450,8 @@ impl ScannerService {
                 .ok()
                 .flatten();
 
-        let (project_name, repo_format) = match repo_row {
-            Some((name, format)) => (name, format),
-            None => (artifact.repository_id.to_string(), None),
-        };
-
-        let purl_type = repo_format
-            .as_deref()
-            .map(format_to_purl_type)
-            .unwrap_or("generic");
+        let (project_name, purl_type) =
+            derive_dt_project_info(repo_row, &artifact.repository_id.to_string());
 
         // Fetch scan findings to build dependency info for the SBOM.
         // The scan_findings table stores affected components in the
@@ -1430,21 +1471,7 @@ impl ScannerService {
         .await
         .unwrap_or_default();
 
-        let deps: Vec<DependencyInfo> = findings_rows
-            .into_iter()
-            .map(|(name, version, _source)| {
-                let purl = version
-                    .as_deref()
-                    .map(|v| format!("pkg:{}/{}@{}", purl_type, name, v));
-                DependencyInfo {
-                    name,
-                    version,
-                    purl,
-                    license: None,
-                    sha256: None,
-                }
-            })
-            .collect();
+        let deps = build_dependency_info_from_findings(findings_rows, purl_type);
 
         if deps.is_empty() {
             info!(
@@ -5801,5 +5828,354 @@ mod tests {
         extract_tar_gz_safe(&archive, tmp.path()).unwrap();
         // Should succeed with no files created
         assert_eq!(std::fs::read_dir(tmp.path()).unwrap().count(), 0);
+    }
+
+    // ===================================================================
+    // format_to_purl_type -- exhaustive mapping tests
+    // ===================================================================
+
+    #[test]
+    fn test_format_to_purl_type_pypi() {
+        assert_eq!(format_to_purl_type("pypi"), "pypi");
+        assert_eq!(format_to_purl_type("PyPI"), "pypi");
+        assert_eq!(format_to_purl_type("PYPI"), "pypi");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_npm() {
+        assert_eq!(format_to_purl_type("npm"), "npm");
+        assert_eq!(format_to_purl_type("NPM"), "npm");
+        assert_eq!(format_to_purl_type("Npm"), "npm");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_cargo() {
+        assert_eq!(format_to_purl_type("cargo"), "cargo");
+        assert_eq!(format_to_purl_type("crates"), "cargo");
+        assert_eq!(format_to_purl_type("Cargo"), "cargo");
+        assert_eq!(format_to_purl_type("CRATES"), "cargo");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_maven() {
+        assert_eq!(format_to_purl_type("maven"), "maven");
+        assert_eq!(format_to_purl_type("Maven"), "maven");
+        assert_eq!(format_to_purl_type("MAVEN"), "maven");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_go() {
+        assert_eq!(format_to_purl_type("go"), "golang");
+        assert_eq!(format_to_purl_type("golang"), "golang");
+        assert_eq!(format_to_purl_type("Go"), "golang");
+        assert_eq!(format_to_purl_type("GOLANG"), "golang");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_nuget() {
+        assert_eq!(format_to_purl_type("nuget"), "nuget");
+        assert_eq!(format_to_purl_type("NuGet"), "nuget");
+        assert_eq!(format_to_purl_type("NUGET"), "nuget");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_rubygems() {
+        assert_eq!(format_to_purl_type("rubygems"), "gem");
+        assert_eq!(format_to_purl_type("gem"), "gem");
+        assert_eq!(format_to_purl_type("RubyGems"), "gem");
+        assert_eq!(format_to_purl_type("GEM"), "gem");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_docker() {
+        assert_eq!(format_to_purl_type("docker"), "docker");
+        assert_eq!(format_to_purl_type("oci"), "docker");
+        assert_eq!(format_to_purl_type("container"), "docker");
+        assert_eq!(format_to_purl_type("Docker"), "docker");
+        assert_eq!(format_to_purl_type("OCI"), "docker");
+        assert_eq!(format_to_purl_type("Container"), "docker");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_composer() {
+        assert_eq!(format_to_purl_type("composer"), "composer");
+        assert_eq!(format_to_purl_type("php"), "composer");
+        assert_eq!(format_to_purl_type("PHP"), "composer");
+        assert_eq!(format_to_purl_type("Composer"), "composer");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_cocoapods() {
+        assert_eq!(format_to_purl_type("cocoapods"), "cocoapods");
+        assert_eq!(format_to_purl_type("pods"), "cocoapods");
+        assert_eq!(format_to_purl_type("CocoaPods"), "cocoapods");
+        assert_eq!(format_to_purl_type("PODS"), "cocoapods");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_swift() {
+        assert_eq!(format_to_purl_type("swift"), "swift");
+        assert_eq!(format_to_purl_type("Swift"), "swift");
+        assert_eq!(format_to_purl_type("SWIFT"), "swift");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_hex() {
+        assert_eq!(format_to_purl_type("hex"), "hex");
+        assert_eq!(format_to_purl_type("elixir"), "hex");
+        assert_eq!(format_to_purl_type("Hex"), "hex");
+        assert_eq!(format_to_purl_type("Elixir"), "hex");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_pub() {
+        assert_eq!(format_to_purl_type("pub"), "pub");
+        assert_eq!(format_to_purl_type("dart"), "pub");
+        assert_eq!(format_to_purl_type("Pub"), "pub");
+        assert_eq!(format_to_purl_type("Dart"), "pub");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_conan() {
+        assert_eq!(format_to_purl_type("conan"), "conan");
+        assert_eq!(format_to_purl_type("cpp"), "conan");
+        assert_eq!(format_to_purl_type("Conan"), "conan");
+        assert_eq!(format_to_purl_type("CPP"), "conan");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_conda() {
+        assert_eq!(format_to_purl_type("conda"), "conda");
+        assert_eq!(format_to_purl_type("Conda"), "conda");
+        assert_eq!(format_to_purl_type("CONDA"), "conda");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_hackage() {
+        assert_eq!(format_to_purl_type("hackage"), "hackage");
+        assert_eq!(format_to_purl_type("haskell"), "hackage");
+        assert_eq!(format_to_purl_type("Hackage"), "hackage");
+        assert_eq!(format_to_purl_type("Haskell"), "hackage");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_rpm() {
+        assert_eq!(format_to_purl_type("rpm"), "rpm");
+        assert_eq!(format_to_purl_type("RPM"), "rpm");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_deb() {
+        assert_eq!(format_to_purl_type("deb"), "deb");
+        assert_eq!(format_to_purl_type("debian"), "deb");
+        assert_eq!(format_to_purl_type("apt"), "deb");
+        assert_eq!(format_to_purl_type("DEB"), "deb");
+        assert_eq!(format_to_purl_type("Debian"), "deb");
+        assert_eq!(format_to_purl_type("APT"), "deb");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_apk() {
+        assert_eq!(format_to_purl_type("apk"), "apk");
+        assert_eq!(format_to_purl_type("alpine"), "apk");
+        assert_eq!(format_to_purl_type("APK"), "apk");
+        assert_eq!(format_to_purl_type("Alpine"), "apk");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_unknown_fallback() {
+        assert_eq!(format_to_purl_type("unknown"), "generic");
+        assert_eq!(format_to_purl_type("foo"), "generic");
+        assert_eq!(format_to_purl_type("terraform"), "generic");
+        assert_eq!(format_to_purl_type("helm"), "generic");
+        assert_eq!(format_to_purl_type("raw"), "generic");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_empty_string() {
+        assert_eq!(format_to_purl_type(""), "generic");
+    }
+
+    #[test]
+    fn test_format_to_purl_type_whitespace() {
+        // Leading/trailing whitespace is not trimmed by the function,
+        // so " npm " should fall through to generic.
+        assert_eq!(format_to_purl_type(" npm "), "generic");
+        assert_eq!(format_to_purl_type("npm "), "generic");
+        assert_eq!(format_to_purl_type(" npm"), "generic");
+    }
+
+    // ===================================================================
+    // derive_dt_project_info
+    // ===================================================================
+
+    #[test]
+    fn test_derive_dt_project_info_with_repo_name_and_format() {
+        let row = Some(("my-npm-repo".to_string(), Some("npm".to_string())));
+        let (name, purl) = derive_dt_project_info(row, "fallback-id");
+        assert_eq!(name, "my-npm-repo");
+        assert_eq!(purl, "npm");
+    }
+
+    #[test]
+    fn test_derive_dt_project_info_with_repo_name_no_format() {
+        let row = Some(("my-repo".to_string(), None));
+        let (name, purl) = derive_dt_project_info(row, "fallback-id");
+        assert_eq!(name, "my-repo");
+        assert_eq!(purl, "generic");
+    }
+
+    #[test]
+    fn test_derive_dt_project_info_no_repo_row() {
+        let (name, purl) = derive_dt_project_info(None, "abc-123-uuid");
+        assert_eq!(name, "abc-123-uuid");
+        assert_eq!(purl, "generic");
+    }
+
+    #[test]
+    fn test_derive_dt_project_info_format_case_insensitive() {
+        let row = Some(("repo".to_string(), Some("PyPI".to_string())));
+        let (_, purl) = derive_dt_project_info(row, "x");
+        assert_eq!(purl, "pypi");
+    }
+
+    #[test]
+    fn test_derive_dt_project_info_docker_format() {
+        let row = Some(("docker-repo".to_string(), Some("docker".to_string())));
+        let (name, purl) = derive_dt_project_info(row, "x");
+        assert_eq!(name, "docker-repo");
+        assert_eq!(purl, "docker");
+    }
+
+    #[test]
+    fn test_derive_dt_project_info_unknown_format_is_generic() {
+        let row = Some(("repo".to_string(), Some("custom-format".to_string())));
+        let (_, purl) = derive_dt_project_info(row, "x");
+        assert_eq!(purl, "generic");
+    }
+
+    // ===================================================================
+    // build_dependency_info_from_findings
+    // ===================================================================
+
+    #[test]
+    fn test_build_deps_empty_findings() {
+        let deps = build_dependency_info_from_findings(vec![], "npm");
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_build_deps_single_finding_with_version() {
+        let rows = vec![(
+            "lodash".to_string(),
+            Some("4.17.21".to_string()),
+            Some("trivy".to_string()),
+        )];
+        let deps = build_dependency_info_from_findings(rows, "npm");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "lodash");
+        assert_eq!(deps[0].version.as_deref(), Some("4.17.21"));
+        assert_eq!(deps[0].purl.as_deref(), Some("pkg:npm/lodash@4.17.21"));
+        assert!(deps[0].license.is_none());
+        assert!(deps[0].sha256.is_none());
+    }
+
+    #[test]
+    fn test_build_deps_finding_without_version() {
+        let rows = vec![("express".to_string(), None, None)];
+        let deps = build_dependency_info_from_findings(rows, "npm");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "express");
+        assert_eq!(deps[0].version, None);
+        // No version means no purl
+        assert_eq!(deps[0].purl, None);
+    }
+
+    #[test]
+    fn test_build_deps_multiple_findings() {
+        let rows = vec![
+            ("serde".to_string(), Some("1.0.200".to_string()), None),
+            ("tokio".to_string(), Some("1.35.0".to_string()), None),
+            ("uuid".to_string(), None, Some("grype".to_string())),
+        ];
+        let deps = build_dependency_info_from_findings(rows, "cargo");
+        assert_eq!(deps.len(), 3);
+        assert_eq!(deps[0].purl.as_deref(), Some("pkg:cargo/serde@1.0.200"));
+        assert_eq!(deps[1].purl.as_deref(), Some("pkg:cargo/tokio@1.35.0"));
+        assert_eq!(deps[2].purl, None);
+    }
+
+    #[test]
+    fn test_build_deps_purl_uses_given_type() {
+        let rows = vec![("flask".to_string(), Some("2.3.0".to_string()), None)];
+
+        let npm_deps = build_dependency_info_from_findings(rows.clone(), "npm");
+        assert_eq!(npm_deps[0].purl.as_deref(), Some("pkg:npm/flask@2.3.0"));
+
+        let pypi_deps = build_dependency_info_from_findings(
+            vec![("flask".to_string(), Some("2.3.0".to_string()), None)],
+            "pypi",
+        );
+        assert_eq!(pypi_deps[0].purl.as_deref(), Some("pkg:pypi/flask@2.3.0"));
+
+        let generic_deps = build_dependency_info_from_findings(
+            vec![("flask".to_string(), Some("2.3.0".to_string()), None)],
+            "generic",
+        );
+        assert_eq!(
+            generic_deps[0].purl.as_deref(),
+            Some("pkg:generic/flask@2.3.0")
+        );
+    }
+
+    #[test]
+    fn test_build_deps_source_field_ignored() {
+        // The source field should not affect the output
+        let rows = vec![
+            (
+                "pkg-a".to_string(),
+                Some("1.0".to_string()),
+                Some("trivy".to_string()),
+            ),
+            (
+                "pkg-b".to_string(),
+                Some("2.0".to_string()),
+                Some("grype".to_string()),
+            ),
+            ("pkg-c".to_string(), Some("3.0".to_string()), None),
+        ];
+        let deps = build_dependency_info_from_findings(rows, "maven");
+        assert_eq!(deps.len(), 3);
+        // All should produce valid purls regardless of source
+        for dep in &deps {
+            assert!(dep.purl.is_some());
+        }
+    }
+
+    #[test]
+    fn test_build_deps_special_characters_in_name() {
+        let rows = vec![(
+            "@scope/package".to_string(),
+            Some("1.0.0".to_string()),
+            None,
+        )];
+        let deps = build_dependency_info_from_findings(rows, "npm");
+        assert_eq!(
+            deps[0].purl.as_deref(),
+            Some("pkg:npm/@scope/package@1.0.0")
+        );
+    }
+
+    #[test]
+    fn test_build_deps_preserves_order() {
+        let rows = vec![
+            ("zzz".to_string(), Some("3.0".to_string()), None),
+            ("aaa".to_string(), Some("1.0".to_string()), None),
+            ("mmm".to_string(), Some("2.0".to_string()), None),
+        ];
+        let deps = build_dependency_info_from_findings(rows, "npm");
+        assert_eq!(deps[0].name, "zzz");
+        assert_eq!(deps[1].name, "aaa");
+        assert_eq!(deps[2].name, "mmm");
     }
 }

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -1084,6 +1084,8 @@ pub struct ScannerService {
     #[allow(dead_code)]
     storage_base_path: String,
     scan_workspace_path: String,
+    dependency_track:
+        Option<Arc<crate::services::dependency_track_service::DependencyTrackService>>,
 }
 
 impl ScannerService {
@@ -1146,7 +1148,16 @@ impl ScannerService {
             storage_registry,
             storage_base_path,
             scan_workspace_path,
+            dependency_track: None,
         }
+    }
+
+    /// Set the Dependency-Track service for SBOM submission after scans.
+    pub fn set_dependency_track(
+        &mut self,
+        dt: Arc<crate::services::dependency_track_service::DependencyTrackService>,
+    ) {
+        self.dependency_track = Some(dt);
     }
 
     /// Scan a single artifact: run all applicable scanners, persist results,
@@ -1331,7 +1342,155 @@ impl ScannerService {
             .recalculate_score(artifact.repository_id)
             .await?;
 
+        // Submit SBOM to Dependency-Track if integration is configured.
+        // This generates a CycloneDX SBOM from scan findings and uploads it
+        // to the corresponding DT project, closing the gap where scans
+        // completed but SBOMs were never forwarded to DT.
+        if let Some(ref dt) = self.dependency_track {
+            self.submit_sbom_to_dependency_track(dt, &artifact).await;
+        }
+
         Ok(())
+    }
+
+    /// Generate a CycloneDX SBOM from scan findings for the given artifact and
+    /// submit it to Dependency-Track. Errors are logged but do not fail the
+    /// scan pipeline, since DT submission is best-effort.
+    async fn submit_sbom_to_dependency_track(
+        &self,
+        dt: &crate::services::dependency_track_service::DependencyTrackService,
+        artifact: &Artifact,
+    ) {
+        use crate::models::sbom::SbomFormat;
+        use crate::services::sbom_service::{DependencyInfo, SbomService};
+
+        // Fetch repository name for the DT project
+        let repo_name: Option<String> =
+            sqlx::query_scalar("SELECT name FROM repositories WHERE id = $1")
+                .bind(artifact.repository_id)
+                .fetch_optional(&self.db)
+                .await
+                .ok()
+                .flatten();
+
+        let project_name = repo_name.unwrap_or_else(|| artifact.repository_id.to_string());
+
+        // Fetch scan findings to build dependency info for the SBOM.
+        // The scan_findings table stores affected components in the
+        // `affected_component` and `affected_version` columns.
+        let findings_rows: Vec<(String, Option<String>, Option<String>)> = sqlx::query_as(
+            r#"
+            SELECT DISTINCT f.affected_component, f.affected_version, f.source
+            FROM scan_findings f
+            JOIN scan_results sr ON f.scan_result_id = sr.id
+            WHERE sr.artifact_id = $1
+              AND f.affected_component IS NOT NULL
+              AND f.affected_component != ''
+            "#,
+        )
+        .bind(artifact.id)
+        .fetch_all(&self.db)
+        .await
+        .unwrap_or_default();
+
+        let deps: Vec<DependencyInfo> = findings_rows
+            .into_iter()
+            .map(|(name, version, _source)| {
+                let purl = version
+                    .as_deref()
+                    .map(|v| format!("pkg:generic/{}@{}", name, v));
+                DependencyInfo {
+                    name,
+                    version,
+                    purl,
+                    license: None,
+                    sha256: None,
+                }
+            })
+            .collect();
+
+        if deps.is_empty() {
+            info!(
+                artifact_id = %artifact.id,
+                "No scan findings with package info, skipping Dependency-Track SBOM submission"
+            );
+            return;
+        }
+
+        // Generate the CycloneDX SBOM
+        let sbom_service = SbomService::new(self.db.clone());
+        let sbom_doc = match sbom_service
+            .generate_sbom(
+                artifact.id,
+                artifact.repository_id,
+                SbomFormat::CycloneDX,
+                deps,
+            )
+            .await
+        {
+            Ok(doc) => doc,
+            Err(e) => {
+                warn!(
+                    artifact_id = %artifact.id,
+                    error = %e,
+                    "Failed to generate CycloneDX SBOM for Dependency-Track submission"
+                );
+                return;
+            }
+        };
+
+        // Extract the SBOM content as a string for DT upload
+        let sbom_content = match serde_json::to_string(&sbom_doc.content) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    artifact_id = %artifact.id,
+                    error = %e,
+                    "Failed to serialize SBOM content for Dependency-Track"
+                );
+                return;
+            }
+        };
+
+        // Get or create the DT project
+        let dt_project = match dt
+            .get_or_create_project(
+                &project_name,
+                artifact.version.as_deref(),
+                Some(&format!("Artifact: {}", artifact.name)),
+            )
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(
+                    artifact_id = %artifact.id,
+                    error = %e,
+                    "Failed to get or create Dependency-Track project"
+                );
+                return;
+            }
+        };
+
+        // Upload the SBOM
+        match dt.upload_sbom(&dt_project.uuid, &sbom_content).await {
+            Ok(upload_resp) => {
+                info!(
+                    artifact_id = %artifact.id,
+                    dt_project = %dt_project.name,
+                    dt_token = %upload_resp.token,
+                    components = sbom_doc.component_count,
+                    "Submitted SBOM to Dependency-Track"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    artifact_id = %artifact.id,
+                    error = %e,
+                    "Failed to upload SBOM to Dependency-Track"
+                );
+            }
+        }
     }
 
     /// Scan a single artifact (respects repo scan-enabled config).

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -43,6 +43,35 @@ pub(crate) fn sanitize_artifact_filename(name: &str) -> String {
         .to_string()
 }
 
+/// Map a repository format string to the corresponding purl type.
+///
+/// Common formats (pypi, npm, maven, etc.) get their standard purl type.
+/// Unknown formats fall back to `"generic"`.
+fn format_to_purl_type(format: &str) -> &str {
+    match format.to_lowercase().as_str() {
+        "pypi" => "pypi",
+        "npm" => "npm",
+        "cargo" | "crates" => "cargo",
+        "maven" => "maven",
+        "go" | "golang" => "golang",
+        "nuget" => "nuget",
+        "rubygems" | "gem" => "gem",
+        "docker" | "oci" | "container" => "docker",
+        "composer" | "php" => "composer",
+        "cocoapods" | "pods" => "cocoapods",
+        "swift" => "swift",
+        "hex" | "elixir" => "hex",
+        "pub" | "dart" => "pub",
+        "conan" | "cpp" => "conan",
+        "conda" => "conda",
+        "hackage" | "haskell" => "hackage",
+        "rpm" => "rpm",
+        "deb" | "debian" | "apt" => "deb",
+        "apk" | "alpine" => "apk",
+        _ => "generic",
+    }
+}
+
 /// Shared scan workspace utilities for scanners that need to write artifact
 /// content to disk, optionally extract archives, and clean up after scanning.
 pub(crate) struct ScanWorkspace;
@@ -1364,16 +1393,24 @@ impl ScannerService {
         use crate::models::sbom::SbomFormat;
         use crate::services::sbom_service::{DependencyInfo, SbomService};
 
-        // Fetch repository name for the DT project
-        let repo_name: Option<String> =
-            sqlx::query_scalar("SELECT name FROM repositories WHERE id = $1")
+        // Fetch repository name and format for the DT project
+        let repo_row: Option<(String, Option<String>)> =
+            sqlx::query_as("SELECT name, format FROM repositories WHERE id = $1")
                 .bind(artifact.repository_id)
                 .fetch_optional(&self.db)
                 .await
                 .ok()
                 .flatten();
 
-        let project_name = repo_name.unwrap_or_else(|| artifact.repository_id.to_string());
+        let (project_name, repo_format) = match repo_row {
+            Some((name, format)) => (name, format),
+            None => (artifact.repository_id.to_string(), None),
+        };
+
+        let purl_type = repo_format
+            .as_deref()
+            .map(format_to_purl_type)
+            .unwrap_or("generic");
 
         // Fetch scan findings to build dependency info for the SBOM.
         // The scan_findings table stores affected components in the
@@ -1398,7 +1435,7 @@ impl ScannerService {
             .map(|(name, version, _source)| {
                 let purl = version
                     .as_deref()
-                    .map(|v| format!("pkg:generic/{}@{}", name, v));
+                    .map(|v| format!("pkg:{}/{}@{}", purl_type, name, v));
                 DependencyInfo {
                     name,
                     version,


### PR DESCRIPTION
## Summary

Fixes two bugs in the Dependency-Track integration (#764):

1. **HTTP URL rejection for private networks**: When `DEPENDENCY_TRACK_URL` uses HTTP (common for localhost, Kubernetes in-cluster, and local dev), the reqwest client was configured with `https_only(true)`, causing opaque "builder error for url" failures. The fix adds `is_private_network_url()` which detects localhost, RFC 1918 ranges (10/8, 172.16/12, 192.168/16), link-local addresses, `*.svc.cluster.local`, and `*.local` hostnames, and auto-allows HTTP for those targets. `ALLOW_HTTP_INTEGRATIONS` remains available as an explicit override for non-private HTTP endpoints, and is now better documented in `.env.example`.

2. **SBOMs never submitted to Dependency-Track**: After artifact scans completed, no code path generated or uploaded SBOMs to DT. The `ScannerService` now holds an optional `Arc<DependencyTrackService>`, wired in `main.rs`. After each artifact scan, it generates a CycloneDX SBOM from the scan findings (`affected_component`/`affected_version` in `scan_findings`), creates or finds the DT project by repository name, and uploads the BOM. Failures are logged as warnings, not errors that block the scan pipeline.

Closes #764

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes