### PR TITLE
ci: skip code coverage when no Rust source files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Skip the expensive coverage build on PRs that touch no Rust source.
+      # Dependency bumps (Cargo.toml/Cargo.lock only), workflow edits, and
+      # docs-only changes cannot move coverage numbers, and the Backend Unit
+      # Tests job already validates the build. `rust_changed=true` for push
+      # events preserves the existing behavior on main.
+      - name: Detect Rust source changes
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          if git diff --name-only FETCH_HEAD -- '*.rs' | grep -q .; then
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust_changed=false" >> "$GITHUB_OUTPUT"
+            echo "### Coverage: skipped (no Rust source changes in this PR)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Run database migrations
+        if: steps.detect.outputs.rust_changed == 'true'
         run: sqlx migrate run --source backend/migrations
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
 
       - name: Generate coverage report
+        if: steps.detect.outputs.rust_changed == 'true'
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
           SQLX_OFFLINE: true
@@ -92,6 +114,7 @@ jobs:
         run: cargo llvm-cov --workspace --lib --lcov --output-path lcov.info
 
       - name: Coverage summary and gate
+        if: steps.detect.outputs.rust_changed == 'true'
         run: |
           # Total project coverage summary
           echo "### Coverage Summary" >> $GITHUB_STEP_SUMMARY
@@ -103,7 +126,7 @@ jobs:
           cargo llvm-cov --workspace --lib --no-run --fail-under-lines 50
 
       - name: New code coverage gate
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.detect.outputs.rust_changed == 'true'
         run: |
           # Fetch base branch so we can diff against it (checkout is shallow by default)
           git fetch --no-tags --depth=1 origin ${{ github.base_ref }}
@@ -279,7 +302,7 @@ jobs:
           fi
 
       - name: Upload coverage artifact
-        if: always()
+        if: always() && steps.detect.outputs.rust_changed == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lcov-coverage


### PR DESCRIPTION
## Summary

Coverage percentages cannot move unless \`.rs\` files change, yet the current workflow runs the full \`cargo llvm-cov\` instrumented build (~3-5 min) on every PR, including Cargo.toml / Cargo.lock-only bumps from dependabot. The new-code gate already has an early exit for this case (lines 115-118 on main), but by then the expensive build has already run. The Backend Unit Tests job is a separate job and still validates that dependency bumps compile.

Fix: add a preflight \`Detect Rust source changes\` step that computes a single \`rust_changed\` flag, and gate the migrations, coverage generation, summary gate, and artifact upload on it. Push events retain current behavior (\`rust_changed=true\` always), so main-branch coverage tracking is unchanged.

Motivation: on the 6 dependabot PRs merged on 2026-04-23 (openssl, grype, rust docker, setup-node, trivy-action, build-push-action), each one paid the full coverage cost on a sequence of rebases. This change makes future dep bumps merge on the order of Rust check + Unit Tests, not Rust check + Unit Tests + Coverage.

## Test Checklist
- [x] Unit tests added/updated (N/A — workflow-only change)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (YAML diff reviewed, aggregation logic in the CI Complete job handles step-level skips correctly — the coverage job still reports \`success\` since skipped steps don't fail the job)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes