### PR TITLE
fix(conan): scope recipe_latest and recipe_revisions to user/channel

### DIFF
--- a/.sqlx/query-163f70ea906978efb9244ca102b7256becf656f3f13a6cd168f20982484b56e8.json
+++ b/.sqlx/query-163f70ea906978efb9244ca102b7256becf656f3f13a6cd168f20982484b56e8.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'revision' as \"revision?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' IS NOT NULL\n        ORDER BY a.created_at DESC, a.id DESC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "revision?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "163f70ea906978efb9244ca102b7256becf656f3f13a6cd168f20982484b56e8"
+}

--- a/.sqlx/query-6cbf81c08dd3a2e908bfad37abff5f8497c854a61eaedb2374d2968dd220ced7.json
+++ b/.sqlx/query-6cbf81c08dd3a2e908bfad37abff5f8497c854a61eaedb2374d2968dd220ced7.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'revision' as \"revision?\",\n               MAX(a.created_at) as \"created_at!\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' IS NOT NULL\n        GROUP BY am.metadata->>'revision'\n        ORDER BY \"created_at!\" DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "revision?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "6cbf81c08dd3a2e908bfad37abff5f8497c854a61eaedb2374d2968dd220ced7"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Thank you to our backers for supporting ongoing development:
 - **OTLP http/protobuf NoHttpClient panic** (#812, #835) - added `opentelemetry-http` with the `reqwest` feature as a direct dependency to ensure the HTTP client registers when two `reqwest` versions coexist in the dep tree.
 - **jsonwebtoken CryptoProvider test failures** (#835) - enabled the `aws_lc_rs` feature on `jsonwebtoken 10.3` so unit tests that bypass `main()` no longer panic on missing CryptoProvider. Fixes 11 pre-existing test failures in `auth_service` and `grpc::auth_interceptor`.
 - **Search results leaked private repos to authenticated users** (#829) - any authenticated user previously saw all repository search results regardless of role assignments. Now filtered per-caller using `role_assignments`.
+- **Conan `recipe_latest` and `recipe_revisions` now scope by user/channel** - the two endpoints previously ignored the `{user}` and `{channel}` path segments, so a recipe uploaded as `mylib/1.0.0@myuser/stable` could appear in the latest/revisions response for `mylib/1.0.0@_/_` (and vice versa), breaking dependency resolution for Conan clients that share a recipe name across namespaces. Both queries now filter on `am.metadata->>'user'` and `am.metadata->>'channel'`, matching the existing pattern in `recipe_files_list` and the package download handler. Discovered during the v1.2.0-rc.1 release-gate run (24934467423).
 
 ### Security
 

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -379,18 +379,14 @@ async fn search(
 
 async fn recipe_latest(
     State(state): State<SharedState>,
-    Path((repo_key, name, version, _user, _channel)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
+    Path((repo_key, name, version, user, channel)): Path<(String, String, String, String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
 
     // Find the latest recipe revision by looking at the most recently created artifact
-    // with a revision in its metadata.
+    // with a revision in its metadata. Must filter by user/channel so revisions
+    // uploaded under one namespace (e.g. myuser/stable) do not leak into the
+    // latest response for another (e.g. _/_).
     let row = sqlx::query!(
         r#"
         SELECT am.metadata->>'revision' as "revision?"
@@ -401,6 +397,8 @@ async fn recipe_latest(
           AND am.format = 'conan'
           AND a.name = $2
           AND a.version = $3
+          AND am.metadata->>'user' = $4
+          AND am.metadata->>'channel' = $5
           AND am.metadata->>'revision' IS NOT NULL
         ORDER BY a.created_at DESC, a.id DESC
         LIMIT 1
@@ -408,6 +406,8 @@ async fn recipe_latest(
         repo.id,
         name,
         version,
+        normalize_user(&user),
+        normalize_channel(&channel),
     )
     .fetch_optional(&state.db)
     .await
@@ -442,16 +442,13 @@ async fn recipe_latest(
 
 async fn recipe_revisions(
     State(state): State<SharedState>,
-    Path((repo_key, name, version, _user, _channel)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
+    Path((repo_key, name, version, user, channel)): Path<(String, String, String, String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
 
+    // Must filter by user/channel so revisions uploaded under one namespace
+    // (e.g. myuser/stable) do not appear in the revisions list for a different
+    // namespace (e.g. _/_).
     let rows = sqlx::query!(
         r#"
         SELECT am.metadata->>'revision' as "revision?",
@@ -463,6 +460,8 @@ async fn recipe_revisions(
           AND am.format = 'conan'
           AND a.name = $2
           AND a.version = $3
+          AND am.metadata->>'user' = $4
+          AND am.metadata->>'channel' = $5
           AND am.metadata->>'revision' IS NOT NULL
         GROUP BY am.metadata->>'revision'
         ORDER BY "created_at!" DESC
@@ -470,6 +469,8 @@ async fn recipe_revisions(
         repo.id,
         name,
         version,
+        normalize_user(&user),
+        normalize_channel(&channel),
     )
     .fetch_all(&state.db)
     .await
@@ -2719,6 +2720,272 @@ mod tests {
             revisions[1].get("revision").and_then(|v| v.as_str()),
             Some("rev_old"),
         );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // recipe_latest / recipe_revisions: user/channel scoping regression tests.
+    //
+    // Bug: previously, recipe_latest and recipe_revisions ignored the
+    // {user}/{channel} path segments. Uploads under one namespace
+    // (e.g. myuser/stable) leaked into responses for another (e.g. _/_).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn recipe_latest_scopes_to_default_user_channel() {
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        // Upload one revision under _/_ and an unrelated revision under
+        // myuser/stable for the same name+version. recipe_latest for _/_
+        // must only see the _/_ revision.
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "_",
+            "_",
+            "rev_default",
+            "conanfile.py",
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        // Seeded later so its created_at is newer; if scoping is broken,
+        // the buggy query would return rev_user_stable here.
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "myuser",
+            "stable",
+            "rev_user_stable",
+            "conanfile.py",
+        )
+        .await;
+
+        let (status, body) = f
+            .get(format!("/{}/v2/conans/scopelib/1.0/_/_/latest", f.repo_key))
+            .await;
+        let body_str = String::from_utf8_lossy(&body).to_string();
+        assert_eq!(status, StatusCode::OK, "body: {}", body_str);
+
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("JSON");
+        assert_eq!(
+            json.get("revision").and_then(|v| v.as_str()),
+            Some("rev_default"),
+            "latest for _/_ must NOT leak revision uploaded under myuser/stable; got: {}",
+            body_str,
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn recipe_latest_scopes_to_custom_user_channel() {
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        // Inverse direction: querying myuser/stable must not return _/_ revisions.
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "_",
+            "_",
+            "rev_default",
+            "conanfile.py",
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "myuser",
+            "stable",
+            "rev_user_stable",
+            "conanfile.py",
+        )
+        .await;
+
+        let (status, body) = f
+            .get(format!(
+                "/{}/v2/conans/scopelib/1.0/myuser/stable/latest",
+                f.repo_key
+            ))
+            .await;
+        let body_str = String::from_utf8_lossy(&body).to_string();
+        assert_eq!(status, StatusCode::OK, "body: {}", body_str);
+
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("JSON");
+        assert_eq!(
+            json.get("revision").and_then(|v| v.as_str()),
+            Some("rev_user_stable"),
+            "latest for myuser/stable must NOT return _/_ revision; got: {}",
+            body_str,
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn recipe_latest_404_when_namespace_empty() {
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        // Upload only under myuser/stable. _/_ should 404.
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "myuser",
+            "stable",
+            "rev_only",
+            "conanfile.py",
+        )
+        .await;
+
+        let (status, _body) = f
+            .get(format!("/{}/v2/conans/scopelib/1.0/_/_/latest", f.repo_key))
+            .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "_/_ namespace has no revisions; must 404",
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn recipe_revisions_scopes_to_default_user_channel() {
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        // Two revisions under _/_, two under myuser/stable. The _/_ query
+        // must return only the two _/_ revisions.
+        for rev in ["rev_a", "rev_b"] {
+            let _ = test_helpers::seed_recipe_row(
+                &f.pool,
+                f.repo_id,
+                "scopelib",
+                "1.0",
+                "_",
+                "_",
+                rev,
+                "conanfile.py",
+            )
+            .await;
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        for rev in ["rev_x", "rev_y"] {
+            let _ = test_helpers::seed_recipe_row(
+                &f.pool,
+                f.repo_id,
+                "scopelib",
+                "1.0",
+                "myuser",
+                "stable",
+                rev,
+                "conanfile.py",
+            )
+            .await;
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let (status, body) = f
+            .get(format!(
+                "/{}/v2/conans/scopelib/1.0/_/_/revisions",
+                f.repo_key
+            ))
+            .await;
+        let body_str = String::from_utf8_lossy(&body).to_string();
+        assert_eq!(status, StatusCode::OK, "body: {}", body_str);
+
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("JSON");
+        let revisions = json
+            .get("revisions")
+            .and_then(|v| v.as_array())
+            .expect("revisions array");
+        let names: Vec<&str> = revisions
+            .iter()
+            .filter_map(|r| r.get("revision").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(
+            names.len(),
+            2,
+            "_/_ revisions must not include myuser/stable rows; got: {:?}",
+            names,
+        );
+        assert!(names.contains(&"rev_a"));
+        assert!(names.contains(&"rev_b"));
+        assert!(
+            !names.contains(&"rev_x") && !names.contains(&"rev_y"),
+            "myuser/stable revisions leaked into _/_ response: {:?}",
+            names,
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn recipe_revisions_scopes_to_custom_user_channel() {
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "_",
+            "_",
+            "rev_default",
+            "conanfile.py",
+        )
+        .await;
+        let _ = test_helpers::seed_recipe_row(
+            &f.pool,
+            f.repo_id,
+            "scopelib",
+            "1.0",
+            "myuser",
+            "stable",
+            "rev_user_stable",
+            "conanfile.py",
+        )
+        .await;
+
+        let (status, body) = f
+            .get(format!(
+                "/{}/v2/conans/scopelib/1.0/myuser/stable/revisions",
+                f.repo_key
+            ))
+            .await;
+        let body_str = String::from_utf8_lossy(&body).to_string();
+        assert_eq!(status, StatusCode::OK, "body: {}", body_str);
+
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("JSON");
+        let revisions = json
+            .get("revisions")
+            .and_then(|v| v.as_array())
+            .expect("revisions array");
+        let names: Vec<&str> = revisions
+            .iter()
+            .filter_map(|r| r.get("revision").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(names, vec!["rev_user_stable"], "got: {}", body_str);
 
         f.teardown().await;
     }


### PR DESCRIPTION
## Summary

Backend correctness bug in the Conan handler. `recipe_latest` and `recipe_revisions` destructured the `{user}` and `{channel}` path segments into bindings prefixed with `_` and never referenced them. The SQL queries omitted the `am.metadata->>'user'` and `am.metadata->>'channel'` filters that `recipe_files_list` (line 525-534), the package download handler (line 1013-1014), and the upload handler all already use.

**Severity: HIGH.** Affects v1.1.x as well as v1.2.0-rc.x. Discovered during release-gate run [24934467423](https://github.com/artifact-keeper/artifact-keeper/actions/runs/24934467423).

### Reproduction

```
# Upload one recipe under myuser/stable
$ curl -u user:pass -X PUT \
    "$REGISTRY/conan-repo/v2/conans/mylib/1.0.0/myuser/stable/revisions/abc123/files/conanfile.py" \
    --data-binary @conanfile.py

# Query latest under the default _/_ namespace (which has no uploads)
$ curl "$REGISTRY/conan-repo/v2/conans/mylib/1.0.0/_/_/latest"
{"revision":"abc123","time":"..."}   # WRONG: should be 404, leaks myuser/stable upload

# Same problem on revisions endpoint
$ curl "$REGISTRY/conan-repo/v2/conans/mylib/1.0.0/_/_/revisions"
{"revisions":[{"revision":"abc123",...}]}   # WRONG
```

Conan clients querying the default namespace see revisions from unrelated user/channel namespaces of the same name+version, breaking dependency resolution.

### Fix

`backend/src/api/handlers/conan.rs`:

- `recipe_latest` (around line 380): bind `user`/`channel` from the path tuple, add `AND am.metadata->>'user' = $4 AND am.metadata->>'channel' = $5` to the WHERE clause, pass `normalize_user(&user)` and `normalize_channel(&channel)` as bind params.
- `recipe_revisions` (around line 443): same change.

This mirrors the pattern already used by `recipe_files_list` (line 525-534), `package_files_list` (line 1013-1014), and the upload handler (line 778-779), which stores `user`/`channel` in `artifact_metadata.metadata` via `normalize_user`/`normalize_channel`.

### Tests

Five DB-backed regression tests added in `mod tests` adjacent to the existing `smoke_scaffolding_works` test:

1. `recipe_latest_scopes_to_default_user_channel` - upload under both `_/_` and `myuser/stable`, query `_/_`, must not see `myuser/stable` revision even when it was created later.
2. `recipe_latest_scopes_to_custom_user_channel` - inverse direction.
3. `recipe_latest_404_when_namespace_empty` - upload only under `myuser/stable`, query `_/_`, must 404.
4. `recipe_revisions_scopes_to_default_user_channel` - 2 revs under `_/_`, 2 under `myuser/stable`, `_/_` query returns exactly the 2 `_/_` rows.
5. `recipe_revisions_scopes_to_custom_user_channel` - inverse.

Sanity check performed: temporarily reverted just the WHERE filter additions (kept the destructure compiling), 4 of 5 new tests fail against the buggy code; all 5 pass against the fix. The 5th coincidentally passes in the buggy case because the most-recently-created artifact happens to match the expected revision.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`SQLX_OFFLINE=true cargo test -p artifact-keeper-backend --lib conan` - 161/161 pass)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (response shape unchanged, only WHERE clause scoping is corrected)