### PR TITLE
fix(conan): validate repo exists in v2/ping handler

### DIFF
--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -238,12 +238,16 @@ fn content_type_for_conan_file(path: &str) -> &'static str {
 // GET /conan/{repo_key}/v2/ping
 // ---------------------------------------------------------------------------
 
-async fn ping() -> Response {
-    Response::builder()
+async fn ping(
+    State(state): State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    let _repo = resolve_conan_repo(&state.db, &repo_key).await?;
+    Ok(Response::builder()
         .status(StatusCode::OK)
         .header("X-Conan-Server-Capabilities", "revisions")
         .body(Body::empty())
-        .unwrap()
+        .unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -1393,18 +1397,52 @@ mod tests {
 
     #[tokio::test]
     async fn ping_returns_revisions_capability() {
-        let response = ping().await;
-        assert_eq!(response.status(), StatusCode::OK);
-        let capabilities = response
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        let app = f.router();
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri(format!("/{}/v2/ping", f.repo_key))
+            .body(Body::empty())
+            .expect("build request");
+        let resp = tower::ServiceExt::oneshot(app, req).await.expect("oneshot");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let capabilities = resp
             .headers()
             .get("x-conan-server-capabilities")
             .expect("x-conan-server-capabilities header must be present")
             .to_str()
-            .expect("header value must be ASCII");
+            .expect("header value must be ASCII")
+            .to_string();
         assert!(
             capabilities.contains("revisions"),
             "capability header must advertise 'revisions', got: {capabilities}"
         );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn ping_returns_404_when_repo_missing() {
+        let Some(f) = test_helpers::TestFixture::setup("local").await else {
+            return;
+        };
+
+        let bogus_key = format!("nonexistent-{}", uuid::Uuid::new_v4());
+        let app = f.router();
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri(format!("/{}/v2/ping", bogus_key))
+            .body(Body::empty())
+            .expect("build request");
+        let resp = tower::ServiceExt::oneshot(app, req).await.expect("oneshot");
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        f.teardown().await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Conan `v2/ping` handler was parameterless and always returned HTTP 200 plus the `X-Conan-Server-Capabilities` header, even when the `repo_key` in the URL path did not correspond to any repository. Real Conan clients use this as a health-check probe; returning 200 for a bogus repo is misleading and breaks the standard 404-on-missing-repo error semantics.

Surfaced by release-gate run [24938542187](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/24938542187) on the "Ping on non-existent repo returns 404" assertion in `test-conan-errors.sh`.

## Change

`backend/src/api/handlers/conan.rs`: take `State` and `Path<String>` extractors in `ping()`, call `resolve_conan_repo` first. On a missing repo, `resolve_conan_repo` already returns 404. Convert the function to `Result<Response, Response>` matching the convention used elsewhere in this file.

Updated the existing `ping_returns_revisions_capability` unit test to use `TestFixture` so it routes through the full handler with a real repo. Added `ping_returns_404_when_repo_missing` for the rejection path.

## Test Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --lib` passes (8441 passed, 0 failed)
- [x] New unit test covers the rejection path

## API Changes

None. The endpoint URL and response shape on a valid repo are unchanged. Behavior on a non-existent repo changes from `200 OK` to `404 Not Found`, matching the documented Conan client expectations.

Blocks v1.2.0-rc.1 tag.