### PR TITLE
fix(middleware): inject Option<AuthExtension> on missing repo

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -689,8 +689,14 @@ pub async fn repo_visibility_middleware(
         }
     };
 
-    // If no repo found for this key, let the handler return its own 404.
+    // If no repo found for this key, still inject Option<AuthExtension> so
+    // handlers that declare `Extension<Option<AuthExtension>>` don't fail
+    // Axum extraction with HTTP 500 (MissingExtension). The handler itself
+    // is responsible for returning the 404 once it tries to resolve the repo.
     let Some(repo) = repo else {
+        let extracted = extract_token(&request);
+        let auth_ext = try_resolve_auth(&vis_state.auth_service, extracted).await;
+        request.extensions_mut().insert(auth_ext);
         return next.run(request).await;
     };
 


### PR DESCRIPTION
## Summary

`repo_visibility_middleware` short-circuited when the repo lookup returned `None`, calling `next.run(request).await` without inserting `Option<AuthExtension>` into request extensions. Format handlers (conan, generic, others) declare `Extension<Option<AuthExtension>>` as an extractor, so Axum returned HTTP 500 (`MissingExtension`) on any request to a non-existent repo instead of letting the handler return its own 404.

Surfaced by release-gate run [24938542187](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/24938542187) on the "Upload to non-existent repo returns 404" assertion in `test-conan-errors.sh`. The bug affects every format handler that takes `Extension<Option<AuthExtension>>`, so the fix improves error fidelity across all 45 formats.

## Change

`backend/src/api/middleware/auth.rs`: in the `Some(repo) = repo else { ... }` branch, run the same `extract_token` + `try_resolve_auth` flow already used immediately below for the `Some(repo)` branch, insert the result into request extensions, then call `next.run`. The handler then resolves the repo and returns its own 404.

7 lines added, 1 removed.

## Test Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --lib` passes (8440 passed, 0 failed)

## API Changes

None directly. Behavior change: requests to non-existent repos now reach the handler and return its 404 instead of failing extraction with 500. No public surface changes.

Blocks v1.2.0-rc.1 tag.