### PR TITLE
fix(goproxy): allowlist sumdb hosts in proxy_sumdb

### DIFF
--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -228,12 +228,44 @@ async fn handle_get(
 // GET sumdb/... — Proxy to upstream checksum database
 // ---------------------------------------------------------------------------
 
+/// Hostnames the sumdb proxy is permitted to forward to.
+///
+/// SECURITY: `proxy_sumdb` builds `https://{host}/{path}` from URL path
+/// components controlled by the caller. Without an allowlist this is an
+/// SSRF vector — an attacker can request `sumdb/169.254.169.254/...`
+/// to make the server fetch cloud metadata. Only well-known Go
+/// checksum-database hosts may be proxied.
+const SUMDB_ALLOWLIST: &[&str] = &["sum.golang.org", "sum.golang.google.cn"];
+
+/// Returns true iff `host` is a permitted upstream sumdb hostname.
+/// Comparison is case-insensitive per RFC 1035.
+fn is_sumdb_host_allowed(host: &str) -> bool {
+    SUMDB_ALLOWLIST
+        .iter()
+        .any(|allowed| host.eq_ignore_ascii_case(allowed))
+}
+
 /// Proxy a sumdb request to the upstream checksum database.
 ///
 /// The Go toolchain performs go.sum verification by querying
 /// `$GOPROXY/sumdb/sum.golang.org/{path}`. We forward these requests
 /// to `https://{host}/{path}` (defaulting to sum.golang.org).
 async fn proxy_sumdb(host: &str, path: &str) -> Result<Response, Response> {
+    if !is_sumdb_host_allowed(host) {
+        tracing::warn!(
+            host = %host,
+            "Rejected sumdb proxy request to disallowed host (SSRF prevention)"
+        );
+        return Err((
+            StatusCode::FORBIDDEN,
+            format!(
+                "sumdb host '{}' is not in the allowlist of permitted upstreams",
+                host
+            ),
+        )
+            .into_response());
+    }
+
     let url = format!("https://{}/{}", host, path);
 
     tracing::debug!("Proxying sumdb request to {}", url);
@@ -1740,5 +1772,74 @@ mod tests {
             decode_module_path("github.com/!a!b/pkg"),
             "github.com/AB/pkg"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Sumdb host allowlist (SSRF prevention)
+    //
+    // proxy_sumdb forwards requests to https://{host}/{path} where {host}
+    // comes from the URL path component sumdb/{host}/.... Without an
+    // allowlist this is a textbook SSRF: an attacker can request
+    // /goproxy/{repo}/sumdb/169.254.169.254/latest/meta-data/iam/...
+    // and the server will fetch cloud metadata on their behalf.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_proxy_sumdb_rejects_aws_metadata_ssrf() {
+        // SECURITY: must reject SSRF attempts to AWS metadata service.
+        let result = proxy_sumdb("169.254.169.254", "latest/meta-data/").await;
+        let response = result.expect_err("proxy_sumdb must reject SSRF; instead it allowed it");
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "expected FORBIDDEN for SSRF attempt, got {}",
+            response.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_sumdb_rejects_internal_service_ssrf() {
+        // SECURITY: must reject SSRF attempts to internal cluster services.
+        let result = proxy_sumdb("internal-postgres.svc.cluster.local", "anything").await;
+        let response = result.expect_err("proxy_sumdb must reject internal-service SSRF");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_accepts_known_hosts() {
+        assert!(is_sumdb_host_allowed("sum.golang.org"));
+        assert!(is_sumdb_host_allowed("sum.golang.google.cn"));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_is_case_insensitive() {
+        // Hostnames are case-insensitive per RFC 1035.
+        assert!(is_sumdb_host_allowed("SUM.GOLANG.ORG"));
+        assert!(is_sumdb_host_allowed("Sum.Golang.Org"));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_rejects_cloud_metadata_endpoints() {
+        // SECURITY: cloud metadata endpoints are common SSRF targets.
+        assert!(!is_sumdb_host_allowed("169.254.169.254"));
+        assert!(!is_sumdb_host_allowed("metadata.google.internal"));
+        assert!(!is_sumdb_host_allowed("metadata.azure.com"));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_rejects_internal_services() {
+        assert!(!is_sumdb_host_allowed("localhost"));
+        assert!(!is_sumdb_host_allowed("127.0.0.1"));
+        assert!(!is_sumdb_host_allowed(
+            "internal-postgres.svc.cluster.local"
+        ));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_rejects_typosquatting() {
+        // SECURITY: prevent attacks via near-miss domain names.
+        assert!(!is_sumdb_host_allowed("sum.golang.org.evil.com"));
+        assert!(!is_sumdb_host_allowed("evil.com.sum.golang.org"));
+        assert!(!is_sumdb_host_allowed("sum-golang-org.evil.com"));
     }
 }


### PR DESCRIPTION
## Summary

`proxy_sumdb` (in `backend/src/api/handlers/goproxy.rs`) forwards HTTPS
requests to a host parsed from the URL path component
`sumdb/{host}/{remaining_path}`, with no validation. This change adds a
small static allowlist of permitted upstream sumdb hosts and rejects all
others with HTTP 403.

Security details: see GHSA-mc8p-6758-jfp2 (private advisory).

## Test Checklist
- [x] Unit tests added/updated (`is_sumdb_host_allowed` — 5 tests)
- [x] Integration tests added/updated (`proxy_sumdb` early-return on disallowed host — 2 tests)
- [ ] E2E tests added/updated (if applicable) — N/A, validation is in-process before any network call
- [x] Manually tested locally (`cargo test --lib api::handlers::goproxy`)
- [x] No regressions in existing tests (60 tests pass, 0 fail)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations — N/A (no new routes)
- [ ] Request/response types have `#[derive(ToSchema)]` — N/A
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid` — N/A
- [ ] Migration is reversible (if applicable) — N/A
- [x] N/A - no API changes

## Notes

Behavior change: requests to `sumdb/{host}/...` where `{host}` is anything
other than `sum.golang.org` or `sum.golang.google.cn` now return 403 Forbidden
instead of being forwarded. The Go toolchain only ever queries these two
hosts in normal operation, so this is invisible to legitimate `go get` users.