### PR TITLE
ci(docker-publish): build :1.1-dev image on release/1.1.x pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Publish
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/1.1.x']
     tags: ['v*']
     paths-ignore:
       - '**/*.md'
@@ -488,6 +488,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -503,6 +504,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -607,6 +609,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -622,6 +625,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -711,6 +715,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -728,6 +733,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
Closes #884.

## Summary

Maintenance-line CI tax. When `release/1.1.x` receives a push (e.g. backport merge), the Docker Publish workflow now produces a moving `:1.1-dev` tag for backend, web, and openSCAP images. Without this, validating a cherry-picked backport on the maintenance branch requires either ad-hoc local builds or trusting unit tests alone.

## Change

- Add `release/1.1.x` to the push-trigger branches.
- Add `type=raw,value=1.1-dev,enable=${{ github.ref == 'refs/heads/release/1.1.x' }}` to every metadata-action block (6 total: backend digest, alpine digest, backend multi-arch manifest, alpine multi-arch manifest, openSCAP manifest, dockerhub mirror).
- Existing rules untouched: `main` continues to produce `:dev`, version tags continue to produce SemVer tags + `:latest`.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` passes
- [ ] After merge, push a no-op commit to `release/1.1.x` (or open this as a backport PR there) and confirm `:1.1-dev` appears on `ghcr.io/.../artifact-keeper-{backend,web,openscap}`
- [ ] Release-gate workflow with `backend_tag=1.1-dev` runs cleanly against the new image

## Hardening Core

Phase 1 of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2). Unblocks every cherry-pick we're about to land on `release/1.1.x` for v1.1.9.