### PR TITLE
ci(release): require all release-set images on ghcr.io AND docker.io before promote (#882)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,61 +181,92 @@ jobs:
       needs.build-binaries.result == 'success'
     timeout-minutes: 35
     steps:
-      - name: Wait for and verify required images on ghcr.io
+      - name: Wait for and verify required images on ghcr.io and docker.io
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -u
           VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "Verifying required images on ghcr.io for version: ${VERSION}"
+          echo "Verifying required images for version: ${VERSION}"
+          echo "Both registries (ghcr.io and docker.io) must have every image."
 
-          # Poll ghcr.io for up to 30 minutes for each image to appear.
-          # docker-publish workflows on backend, openSCAP and the separate
-          # web repo all run on the same tag-push event but have variable
-          # completion times (multi-arch + signing + provenance can take
-          # 15-25 minutes), so we wait rather than fail-fast.
+          # Poll both registries for up to 30 minutes per image. Multi-arch
+          # builds, cosign signing and provenance attestation routinely take
+          # 15-25 minutes, so we wait rather than fail-fast.
           DEADLINE=$(($(date +%s) + 30*60))
 
-          # Required image set. If any one of these is missing on ghcr.io,
-          # the release stays a draft.
+          # Required image set. Each entry is "<registry>|<name>:<tag>".
+          # ghcr.io uses the artifact-keeper org / hyphenated names.
+          # docker.io uses the artifactkeeper namespace / shorter names.
+          # Missing on EITHER registry blocks the release.
           IMAGES=(
-            "artifact-keeper/artifact-keeper-backend:${VERSION}"
-            "artifact-keeper/artifact-keeper-backend:${VERSION}-alpine"
-            "artifact-keeper/artifact-keeper-openscap:${VERSION}"
-            "artifact-keeper/artifact-keeper-web:${VERSION}"
+            "ghcr.io|artifact-keeper/artifact-keeper-backend:${VERSION}"
+            "ghcr.io|artifact-keeper/artifact-keeper-backend:${VERSION}-alpine"
+            "ghcr.io|artifact-keeper/artifact-keeper-openscap:${VERSION}"
+            "ghcr.io|artifact-keeper/artifact-keeper-web:${VERSION}"
+            "docker.io|artifactkeeper/backend:${VERSION}"
+            "docker.io|artifactkeeper/backend:${VERSION}-alpine"
+            "docker.io|artifactkeeper/openscap:${VERSION}"
+            "docker.io|artifactkeeper/web:${VERSION}"
           )
 
-          probe_image() {
-            local img="$1"
-            local name="${img%:*}"
-            local tag="${img#*:}"
-            # ghcr.io requires a Bearer token even for read; exchange the
-            # GITHUB_TOKEN for a registry token and HEAD the manifest.
+          # Common Accept headers cover OCI index, Docker manifest list,
+          # and Docker manifest v2 (different registries return different
+          # default media types).
+          MANIFEST_ACCEPT='-H Accept:application/vnd.oci.image.index.v1+json -H Accept:application/vnd.docker.distribution.manifest.list.v2+json -H Accept:application/vnd.docker.distribution.manifest.v2+json'
+
+          probe_ghcr() {
+            local name="$1"; local tag="$2"
             local token
             token=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${name}:pull" \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               | jq -r '.token // empty')
             [ -n "${token}" ] || return 1
+            # shellcheck disable=SC2086
             curl -sfL -o /dev/null \
               -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/vnd.oci.image.index.v1+json" \
-              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
-              -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              ${MANIFEST_ACCEPT} \
               "https://ghcr.io/v2/${name}/manifests/${tag}"
           }
 
+          probe_dockerhub() {
+            local name="$1"; local tag="$2"
+            # Docker Hub anonymous token (works for public repos).
+            local token
+            token=$(curl -sf "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${name}:pull" \
+              | jq -r '.token // empty')
+            [ -n "${token}" ] || return 1
+            # shellcheck disable=SC2086
+            curl -sfL -o /dev/null \
+              -H "Authorization: Bearer ${token}" \
+              ${MANIFEST_ACCEPT} \
+              "https://registry-1.docker.io/v2/${name}/manifests/${tag}"
+          }
+
+          probe() {
+            local registry="$1"; local img="$2"
+            local name="${img%:*}"; local tag="${img#*:}"
+            case "${registry}" in
+              ghcr.io)   probe_ghcr "${name}" "${tag}" ;;
+              docker.io) probe_dockerhub "${name}" "${tag}" ;;
+              *) echo "::error::unknown registry ${registry}"; return 2 ;;
+            esac
+          }
+
           missing=()
-          for img in "${IMAGES[@]}"; do
+          for entry in "${IMAGES[@]}"; do
+            registry="${entry%%|*}"
+            img="${entry#*|}"
             echo ""
-            echo "Polling ghcr.io/${img}"
+            echo "Polling ${registry}/${img}"
             while true; do
-              if probe_image "${img}"; then
-                echo "  ✓ ghcr.io/${img}"
+              if probe "${registry}" "${img}"; then
+                echo "  ✓ ${registry}/${img}"
                 break
               fi
               if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
-                echo "::error::Required image missing on ghcr.io after 30m: ${img}"
-                missing+=("${img}")
+                echo "::error::Required image missing on ${registry} after 30m: ${img}"
+                missing+=("${registry}/${img}")
                 break
               fi
               echo "  not yet present, waiting 30s..."
@@ -245,12 +276,12 @@ jobs:
 
           if [ "${#missing[@]}" -gt 0 ]; then
             echo ""
-            echo "::error::One or more required images are missing on ghcr.io after the deadline. The GitHub Release will be marked DRAFT and will not promote to stable until every required image is published."
+            echo "::error::One or more required images are missing on ghcr.io and/or docker.io after the deadline. The GitHub Release will be marked DRAFT and will not promote to stable until every required image is published on both registries."
             printf '  - %s\n' "${missing[@]}"
             exit 1
           fi
           echo ""
-          echo "All required images present on ghcr.io for version ${VERSION}."
+          echo "All required images present on ghcr.io AND docker.io for version ${VERSION}."
 
   # ════════════════════════════════════════════════════════════════════════════
   # CREATE RELEASE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,13 +154,112 @@ jobs:
             dist/${{ matrix.name }}.exe*
 
   # ════════════════════════════════════════════════════════════════════════════
+  # VERIFY REQUIRED IMAGES PUBLISHED ON GHCR.IO
+  #
+  # Cross-repo image-publish gate. v1.1.8 shipped with no
+  # ghcr.io/.../artifact-keeper-web:1.1.8 published, breaking every fresh
+  # helm install. This job polls ghcr.io for every image the chart
+  # references at the release version tag, and fails if any is missing
+  # after the docker-publish workflows have had time to complete.
+  #
+  # When this gate fails, the GitHub Release stays a draft (see Check
+  # gate status step in the release job below).
+  #
+  # Tracks Hardening Core issue
+  # https://github.com/artifact-keeper/artifact-keeper/issues/882
+  # ════════════════════════════════════════════════════════════════════════════
+
+  verify-images-published:
+    name: 🐳 Verify Required Images Published
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    needs: [build-binaries]
+    if: |
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.build-binaries.result == 'success'
+    timeout-minutes: 35
+    steps:
+      - name: Wait for and verify required images on ghcr.io
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -u
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Verifying required images on ghcr.io for version: ${VERSION}"
+
+          # Poll ghcr.io for up to 30 minutes for each image to appear.
+          # docker-publish workflows on backend, openSCAP and the separate
+          # web repo all run on the same tag-push event but have variable
+          # completion times (multi-arch + signing + provenance can take
+          # 15-25 minutes), so we wait rather than fail-fast.
+          DEADLINE=$(($(date +%s) + 30*60))
+
+          # Required image set. If any one of these is missing on ghcr.io,
+          # the release stays a draft.
+          IMAGES=(
+            "artifact-keeper/artifact-keeper-backend:${VERSION}"
+            "artifact-keeper/artifact-keeper-backend:${VERSION}-alpine"
+            "artifact-keeper/artifact-keeper-openscap:${VERSION}"
+            "artifact-keeper/artifact-keeper-web:${VERSION}"
+          )
+
+          probe_image() {
+            local img="$1"
+            local name="${img%:*}"
+            local tag="${img#*:}"
+            # ghcr.io requires a Bearer token even for read; exchange the
+            # GITHUB_TOKEN for a registry token and HEAD the manifest.
+            local token
+            token=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${name}:pull" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              | jq -r '.token // empty')
+            [ -n "${token}" ] || return 1
+            curl -sfL -o /dev/null \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json" \
+              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+              -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              "https://ghcr.io/v2/${name}/manifests/${tag}"
+          }
+
+          missing=()
+          for img in "${IMAGES[@]}"; do
+            echo ""
+            echo "Polling ghcr.io/${img}"
+            while true; do
+              if probe_image "${img}"; then
+                echo "  ✓ ghcr.io/${img}"
+                break
+              fi
+              if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+                echo "::error::Required image missing on ghcr.io after 30m: ${img}"
+                missing+=("${img}")
+                break
+              fi
+              echo "  not yet present, waiting 30s..."
+              sleep 30
+            done
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo ""
+            echo "::error::One or more required images are missing on ghcr.io after the deadline. The GitHub Release will be marked DRAFT and will not promote to stable until every required image is published."
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo ""
+          echo "All required images present on ghcr.io for version ${VERSION}."
+
+  # ════════════════════════════════════════════════════════════════════════════
   # CREATE RELEASE
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-binaries, release-gate, mesh-e2e-gate]
+    needs: [build-binaries, release-gate, mesh-e2e-gate, verify-images-published]
     if: always() && needs.build-binaries.result == 'success'
     steps:
       - name: Checkout
@@ -188,15 +287,17 @@ jobs:
         run: |
           RELEASE_GATE="${{ needs.release-gate.result }}"
           MESH_GATE="${{ needs.mesh-e2e-gate.result }}"
+          IMAGES_GATE="${{ needs.verify-images-published.result }}"
           echo "release_gate=${RELEASE_GATE}" >> $GITHUB_OUTPUT
           echo "mesh_gate=${MESH_GATE}" >> $GITHUB_OUTPUT
+          echo "images_gate=${IMAGES_GATE}" >> $GITHUB_OUTPUT
 
-          if [[ "$RELEASE_GATE" == "success" ]]; then
+          if [[ "$RELEASE_GATE" == "success" && "$IMAGES_GATE" == "success" ]]; then
             echo "all_passed=true" >> $GITHUB_OUTPUT
-            echo "Gates passed: release=$RELEASE_GATE mesh=$MESH_GATE (mesh is optional)"
+            echo "Gates passed: release=$RELEASE_GATE images=$IMAGES_GATE mesh=$MESH_GATE (mesh is optional)"
           else
             echo "all_passed=false" >> $GITHUB_OUTPUT
-            echo "::warning::Release gate not green: release=$RELEASE_GATE mesh=$MESH_GATE. Release will be created as DRAFT."
+            echo "::warning::A required gate is not green: release=$RELEASE_GATE images=$IMAGES_GATE mesh=$MESH_GATE. Release will be created as DRAFT."
           fi
 
       - name: Collect release assets


### PR DESCRIPTION
Closes #882.

## Summary

v1.1.8 shipped with no `ghcr.io/.../artifact-keeper-web:1.1.8` published, breaking every fresh helm install. There was no gate that would have caught this; the release tag promoted regardless of cross-repo image state.

This PR adds a `verify-images-published` job to `release.yml` that polls ghcr.io for the full required image set at the release version tag and fails if any image is missing.

## Behavior

- Triggered only on `v*` tag pushes (no-op on workflow_dispatch).
- Polls ghcr.io with 30-second intervals for up to 30 minutes per image.
- Required image set: `artifact-keeper-backend:<v>`, `artifact-keeper-backend:<v>-alpine`, `artifact-keeper-openscap:<v>`, `artifact-keeper-web:<v>` (web is in a separate repo, this is the cross-repo gate).
- Bearer token exchange via `ghcr.io/token` against the workflow's `GITHUB_TOKEN`.
- Accepts both OCI image index and Docker manifest list media types.
- Single ::error:: message names every missing image.

If the gate fails, the existing `gate-status` step flips `all_passed=false`, which sets `draft: true` on the GitHub Release and skips the docker-release dispatch. Operator can resolve the missing image (re-run the relevant publish workflow, fix versioning lockstep) and re-trigger.

## Why poll instead of fail-fast

Multi-arch builds, cosign signing, and provenance attestation routinely run 15-25 minutes. A naive HEAD probe at release-job start would always 404. The 30-minute window absorbs normal completion latency without masking actual missing-image scenarios.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` passes
- [ ] Tag a no-op pre-release (e.g. `v1.1.9-test.0`) and confirm the job polls correctly and the release stays draft if web image is intentionally not published
- [ ] Confirm a normal release tag with all images present shows `all_passed=true`

## Hardening Core

Phase 1 of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2). One of the meta-fixes that prevents the next v1.1.8.