### PR TITLE
chore(process): regression-test contract for bug-fix PRs (#883)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,21 @@
 ## Summary
 <!-- What does this PR do and why? -->
 
+## Regression test (required for `fix/*` PRs)
+<!--
+Hardening Core (https://github.com/orgs/artifact-keeper/projects/2) requires
+every bug-fix PR to land with a regression test that fails on `main` and
+passes on this PR. Choose one that fits the bug:
+  - unit test (closest to the buggy logic)
+  - integration test (requires DB/storage/etc.)
+  - end-to-end test in artifact-keeper-test (exercises the user flow)
+
+For non-fix PRs (feat/, chore/, docs/, ci/, refactor/) check N/A.
+Reviewers should not approve fix/* PRs without a checked box.
+-->
+- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
+- [ ] N/A — this is not a bug fix
+
 ## Test Checklist
 - [ ] Unit tests added/updated
 - [ ] Integration tests added/updated (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,31 @@ cargo test --workspace --lib
 - Add tests for new functionality
 - Update documentation if your change affects user-facing behavior
 
+## Regression-test contract for bug fixes
+
+Every PR that fixes a bug must land with a regression test that fails on
+`main` and passes on the PR. This is enforced by checkbox in the PR
+template and by reviewer policy: `fix/*` PRs are not approved without
+the box checked.
+
+The test can live wherever fits the bug:
+
+- **Unit test** in the same crate as the fixed code, when the bug is
+  in pure logic.
+- **Integration test** in the same repo, when the bug requires a real
+  database, storage backend, or HTTP client.
+- **End-to-end test** in
+  [`artifact-keeper-test`](https://github.com/artifact-keeper/artifact-keeper-test),
+  when the bug surfaces only when the deployed system is exercised
+  through its native client (`mvn`, `npm`, `docker pull`, etc.).
+
+For PRs that aren't bug fixes (`feat/`, `chore/`, `docs/`, `ci/`,
+`refactor/`), check the "N/A" box on the template.
+
+This is part of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2),
+the stability program tracking the work to make every release deploy
+clean from a fresh helm install.
+
 ## Reporting Security Issues
 
 Please do **not** open a public issue for security vulnerabilities. Instead, email the maintainers directly or use GitHub's private vulnerability reporting.


### PR DESCRIPTION
Closes #883.

## Summary

PR template gets a required-for-fix checkbox ("This PR is a \`fix/*\` AND adds/updates a test that would have caught the bug") plus an N/A escape for non-fix PRs.

\`CONTRIBUTING.md\` describes where the test should live (unit / integration / E2E in \`artifact-keeper-test\`) and links the policy back to the Hardening Core project.

## Why now

Cheapest, highest-leverage piece of Phase 1: every future fix PR is a little better, and the test debt that produced #870, #871, #888 stops compounding from this point on.

## Test plan

- [x] PR template renders correctly (this PR uses it)
- [x] CONTRIBUTING.md links resolve

## API Changes

- [x] N/A — this is not a bug fix

## Hardening Core

Phase 1 of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2).