### PR TITLE
chore(ci): refuse HTTPS-to-HTTP redirects in verify-images-published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,9 @@ jobs:
               | jq -r '.token // empty')
             [ -n "${token}" ] || return 1
             # shellcheck disable=SC2086
-            curl -sfL -o /dev/null \
+            # --proto =https refuses to follow HTTPS->HTTP redirects so the
+            # Bearer token can never leak over plaintext.
+            curl -sfL --proto =https -o /dev/null \
               -H "Authorization: Bearer ${token}" \
               ${MANIFEST_ACCEPT} \
               "https://ghcr.io/v2/${name}/manifests/${tag}"
@@ -237,7 +239,9 @@ jobs:
               | jq -r '.token // empty')
             [ -n "${token}" ] || return 1
             # shellcheck disable=SC2086
-            curl -sfL -o /dev/null \
+            # --proto =https refuses to follow HTTPS->HTTP redirects so the
+            # Bearer token can never leak over plaintext.
+            curl -sfL --proto =https -o /dev/null \
               -H "Authorization: Bearer ${token}" \
               ${MANIFEST_ACCEPT} \
               "https://registry-1.docker.io/v2/${name}/manifests/${tag}"


### PR DESCRIPTION
Sister fix to [artifact-keeper-iac#76](https://github.com/artifact-keeper/artifact-keeper-iac/pull/76) for the same SonarCloud security-hotspot class.

## Summary

The \`verify-images-published\` gate added in #893 probes ghcr.io and docker.io with \`curl -sfL\`. The \`-L\` flag follows redirects, but does not enforce that redirects stay on HTTPS. A hostile or compromised registry endpoint could redirect curl from HTTPS to HTTP, leaking the Bearer token to a passive observer on the wire.

Add \`--proto =https\` to both probe calls. curl now refuses to follow any redirect that does not preserve HTTPS; the redirect just fails and the probe returns "missing" rather than leaking the token.

## Why now

PR #76 (chart-side image-reference gate in iac) hit the same Sonar finding. Same one-line fix applies here. Better to land both before any release tag actually triggers the verify-images job in production.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(...)'\` parses cleanly
- [ ] After merge, the next release-tag push runs verify-images-published with the new flag and still resolves correctly

## API Changes

- [x] N/A — workflow only

## Regression test

- [x] N/A — this is not a bug fix, it is a defense-in-depth flag addition

## Hardening Core

Phase 1 of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2). Closes the same SonarCloud hotspot class on the release-side gate.