### PR TITLE
fix(scanner): mark scan FAILED when Trivy pod is unreachable (backport of #897 to 1.1.x)

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2075,26 +2075,21 @@ async fn fetch_upstream_tags_page(
     })?;
 
     let upstream_path = format!("v2/{}/{}", image, build_remote_tags_list_path(n, last));
-    let (content, _ct, link) = proxy_helpers::proxy_fetch_uncached(
-        proxy,
-        repo_id,
-        repo_key,
-        upstream_url,
-        &upstream_path,
-    )
-    .await
-    .map_err(|resp| match resp.status() {
-        StatusCode::NOT_FOUND => oci_error(
-            StatusCode::NOT_FOUND,
-            "NAME_UNKNOWN",
-            "repository not found upstream",
-        ),
-        _ => oci_error(
-            StatusCode::BAD_GATEWAY,
-            "UNKNOWN",
-            "failed to fetch tags from upstream",
-        ),
-    })?;
+    let (content, _ct, link) =
+        proxy_helpers::proxy_fetch_uncached(proxy, repo_id, repo_key, upstream_url, &upstream_path)
+            .await
+            .map_err(|resp| match resp.status() {
+                StatusCode::NOT_FOUND => oci_error(
+                    StatusCode::NOT_FOUND,
+                    "NAME_UNKNOWN",
+                    "repository not found upstream",
+                ),
+                _ => oci_error(
+                    StatusCode::BAD_GATEWAY,
+                    "UNKNOWN",
+                    "failed to fetch tags from upstream",
+                ),
+            })?;
 
     let parsed = serde_json::from_slice::<serde_json::Value>(&content).map_err(|e| {
         warn!("Invalid upstream tags/list response for {}: {}", image, e);
@@ -2121,7 +2116,11 @@ async fn fetch_upstream_tags_page(
             .iter()
             .filter_map(|t| t.as_str().map(String::from))
             .collect(),
-        next_last: if link.is_empty() { None } else { parse_upstream_pagination_last(&link) },
+        next_last: if link.is_empty() {
+            None
+        } else {
+            parse_upstream_pagination_last(&link)
+        },
     })
 }
 

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -90,17 +90,78 @@ impl ImageScanner {
         None
     }
 
+    /// Number of `/healthz` attempts before declaring the Trivy server down.
+    /// Three attempts with backoff covers a 30-60s pod restart without
+    /// permanently failing in-flight scans, which would otherwise flag the
+    /// underlying artifacts. See issue #888.
+    const HEALTH_CHECK_ATTEMPTS: u32 = 3;
+    /// Per-attempt timeout for `/healthz`. Independent of the 300s scan
+    /// timeout so a NetworkPolicy-blocked or hung Trivy does not tie up a
+    /// worker for five minutes per scan.
+    const HEALTH_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    /// Backoff between health-check attempts. Short on purpose: the goal is
+    /// to absorb a pod-restart blip, not to wait out a sustained outage.
+    const HEALTH_CHECK_BACKOFF: std::time::Duration = std::time::Duration::from_millis(500);
+
     /// Check if the Trivy server is available.
-    async fn check_trivy_health(&self) -> bool {
-        match self
-            .http
-            .get(format!("{}/healthz", self.trivy_url))
-            .send()
-            .await
-        {
-            Ok(resp) => resp.status().is_success(),
-            Err(_) => false,
+    ///
+    /// Returns `Ok(())` when `/healthz` responds 2xx. On failure, retries
+    /// `HEALTH_CHECK_ATTEMPTS` times with `HEALTH_CHECK_BACKOFF` between
+    /// attempts before surfacing an `AppError::BadGateway` so the scan
+    /// orchestrator can mark the scan FAILED with a descriptive message
+    /// rather than silently completing with zero findings (issue #888).
+    ///
+    /// Each attempt has its own `HEALTH_CHECK_TIMEOUT` so a hung Trivy does
+    /// not block a worker for the full 300s scan timeout.
+    async fn check_trivy_health(&self) -> Result<()> {
+        let url = format!("{}/healthz", self.trivy_url);
+        let mut last_err: Option<AppError> = None;
+
+        for attempt in 1..=Self::HEALTH_CHECK_ATTEMPTS {
+            let result = self
+                .http
+                .get(&url)
+                .timeout(Self::HEALTH_CHECK_TIMEOUT)
+                .send()
+                .await;
+
+            match result {
+                Ok(resp) if resp.status().is_success() => return Ok(()),
+                Ok(resp) => {
+                    let msg = format!(
+                        "Trivy server at {} is unhealthy: HTTP {}",
+                        self.trivy_url,
+                        resp.status()
+                    );
+                    crate::services::metrics_service::record_scanner_health_check_failure(
+                        "trivy",
+                        "unhealthy",
+                    );
+                    warn!("Trivy /healthz attempt {} failed: {}", attempt, msg);
+                    last_err = Some(AppError::BadGateway(msg));
+                }
+                Err(e) => {
+                    let msg = format!("Trivy server at {} is unreachable: {}", self.trivy_url, e);
+                    crate::services::metrics_service::record_scanner_health_check_failure(
+                        "trivy",
+                        "unreachable",
+                    );
+                    warn!("Trivy /healthz attempt {} failed: {}", attempt, msg);
+                    last_err = Some(AppError::BadGateway(msg));
+                }
+            }
+
+            if attempt < Self::HEALTH_CHECK_ATTEMPTS {
+                tokio::time::sleep(Self::HEALTH_CHECK_BACKOFF).await;
+            }
         }
+
+        Err(last_err.unwrap_or_else(|| {
+            AppError::BadGateway(format!(
+                "Trivy server at {} health check failed",
+                self.trivy_url
+            ))
+        }))
     }
 
     /// Scan an image reference using the Trivy CLI with server mode.
@@ -241,13 +302,15 @@ impl Scanner for ImageScanner {
             }
         };
 
-        // Check if Trivy server is healthy
-        if !self.check_trivy_health().await {
-            warn!(
-                "Trivy server at {} is not available, skipping image scan for {}",
-                self.trivy_url, image_ref
-            );
-            return Ok(vec![]);
+        // Check if Trivy server is healthy. If it is not reachable we must
+        // surface an error so the scan record is marked FAILED. Returning
+        // Ok(vec![]) here would silently mark the scan COMPLETED with zero
+        // findings even though no scanning ever happened (issue #888).
+        if let Err(e) = self.check_trivy_health().await {
+            return Err(AppError::BadGateway(format!(
+                "Trivy image scan failed for {}: {}",
+                image_ref, e
+            )));
         }
 
         info!("Starting Trivy scan for image: {}", image_ref);
@@ -269,25 +332,35 @@ impl Scanner for ImageScanner {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_is_container_image() {
-        let mut artifact = Artifact {
+    /// Build an Artifact fixture for scanner tests. Most fields are not
+    /// load-bearing for the scanner — the scanner only branches on `path`
+    /// and `content_type` — so we collapse the boilerplate here.
+    fn make_test_artifact(path: &str, content_type: &str) -> Artifact {
+        Artifact {
             id: uuid::Uuid::new_v4(),
             repository_id: uuid::Uuid::new_v4(),
-            path: "v2/myapp/manifests/latest".to_string(),
-            name: "myapp".to_string(),
-            version: Some("latest".to_string()),
+            path: path.to_string(),
+            name: "test".to_string(),
+            version: None,
             size_bytes: 1000,
             checksum_sha256: "abc123".to_string(),
             checksum_md5: None,
             checksum_sha1: None,
-            content_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+            content_type: content_type.to_string(),
             storage_key: "test".to_string(),
             is_deleted: false,
             uploaded_by: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
-        };
+        }
+    }
+
+    #[test]
+    fn test_is_container_image() {
+        let mut artifact = make_test_artifact(
+            "v2/myapp/manifests/latest",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
         assert!(ImageScanner::is_container_image(&artifact));
 
         artifact.content_type = "application/json".to_string();
@@ -297,23 +370,10 @@ mod tests {
 
     #[test]
     fn test_extract_image_ref() {
-        let artifact = Artifact {
-            id: uuid::Uuid::new_v4(),
-            repository_id: uuid::Uuid::new_v4(),
-            path: "v2/myapp/manifests/v1.0.0".to_string(),
-            name: "myapp".to_string(),
-            version: Some("v1.0.0".to_string()),
-            size_bytes: 1000,
-            checksum_sha256: "abc123".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
-            storage_key: "test".to_string(),
-            is_deleted: false,
-            uploaded_by: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let artifact = make_test_artifact(
+            "v2/myapp/manifests/v1.0.0",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
         assert_eq!(
             ImageScanner::extract_image_ref(&artifact),
             Some("myapp:v1.0.0".to_string())
@@ -322,23 +382,10 @@ mod tests {
 
     #[test]
     fn test_extract_image_ref_with_namespace() {
-        let artifact = Artifact {
-            id: uuid::Uuid::new_v4(),
-            repository_id: uuid::Uuid::new_v4(),
-            path: "v2/org/myapp/manifests/sha256:abc123".to_string(),
-            name: "myapp".to_string(),
-            version: None,
-            size_bytes: 1000,
-            checksum_sha256: "abc123".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: "application/vnd.docker.distribution.manifest.v2+json".to_string(),
-            storage_key: "test".to_string(),
-            is_deleted: false,
-            uploaded_by: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let artifact = make_test_artifact(
+            "v2/org/myapp/manifests/sha256:abc123",
+            "application/vnd.docker.distribution.manifest.v2+json",
+        );
         assert_eq!(
             ImageScanner::extract_image_ref(&artifact),
             Some("org/myapp:sha256:abc123".to_string())
@@ -347,23 +394,7 @@ mod tests {
 
     #[test]
     fn test_extract_image_ref_invalid_path() {
-        let artifact = Artifact {
-            id: uuid::Uuid::new_v4(),
-            repository_id: uuid::Uuid::new_v4(),
-            path: "some/random/path".to_string(),
-            name: "test".to_string(),
-            version: None,
-            size_bytes: 0,
-            checksum_sha256: "abc".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
-            content_type: "application/json".to_string(),
-            storage_key: "test".to_string(),
-            is_deleted: false,
-            uploaded_by: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let artifact = make_test_artifact("some/random/path", "application/json");
         assert_eq!(ImageScanner::extract_image_ref(&artifact), None);
     }
 
@@ -431,6 +462,103 @@ mod tests {
 
         let findings = ImageScanner::convert_findings(&report);
         assert_eq!(findings.len(), 0);
+    }
+
+    /// Regression test for issue #888: when the Trivy server is
+    /// unreachable, `scan` must return Err so the orchestrator marks the
+    /// scan FAILED. Returning Ok(vec![]) would silently complete the scan
+    /// with zero findings even though Trivy never ran.
+    #[tokio::test]
+    async fn test_scan_fails_when_trivy_unreachable() {
+        // Use an unrouteable port so /healthz cannot succeed. Port 1 is
+        // reserved and any client binding to it will get a connection error.
+        let scanner = ImageScanner::new("http://127.0.0.1:1".to_string());
+        let artifact = make_test_artifact(
+            "v2/myapp/manifests/latest",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
+
+        let result = scanner.scan(&artifact, None, &Bytes::new()).await;
+
+        assert!(
+            result.is_err(),
+            "scan() must return Err when Trivy is unreachable, not Ok(vec![]); \
+             a silent Ok(vec![]) is what caused the scan to be marked COMPLETED \
+             instead of FAILED in issue #888"
+        );
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Trivy") && err_msg.contains("myapp:latest"),
+            "error must identify the failed scanner and image, got: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_trivy_health_returns_err_on_unreachable() {
+        let scanner = ImageScanner::new("http://127.0.0.1:1".to_string());
+        let result = scanner.check_trivy_health().await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("unreachable") || msg.contains("unhealthy"),
+            "error message should describe the health-check failure, got: {}",
+            msg
+        );
+    }
+
+    /// `check_trivy_health` retries before declaring failure so a brief
+    /// Trivy pod restart does not hard-fail every concurrent scan. Verified
+    /// indirectly by elapsed time: with ATTEMPTS=3 and BACKOFF=500ms there
+    /// are two backoff sleeps, so a fully-failed run takes >= ~900ms.
+    #[tokio::test]
+    async fn test_check_trivy_health_retries_before_failing() {
+        let scanner = ImageScanner::new("http://127.0.0.1:1".to_string());
+        let start = std::time::Instant::now();
+        let result = scanner.check_trivy_health().await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        let expected_min =
+            ImageScanner::HEALTH_CHECK_BACKOFF * (ImageScanner::HEALTH_CHECK_ATTEMPTS - 1);
+        assert!(
+            elapsed >= expected_min - std::time::Duration::from_millis(100),
+            "expected at least {:?} of backoff across {} attempts, got {:?}",
+            expected_min,
+            ImageScanner::HEALTH_CHECK_ATTEMPTS,
+            elapsed
+        );
+    }
+
+    /// `check_trivy_health` returns BadGateway, not Internal. The
+    /// orchestrator does not currently translate AppError to HTTP, but
+    /// classifying upstream-scanner failures as 502 keeps internal-error
+    /// alerting clean. Pinned because we just changed the variant.
+    #[tokio::test]
+    async fn test_check_trivy_health_error_is_bad_gateway() {
+        let scanner = ImageScanner::new("http://127.0.0.1:1".to_string());
+        let err = scanner.check_trivy_health().await.unwrap_err();
+        assert!(
+            matches!(err, AppError::BadGateway(_)),
+            "expected BadGateway, got {:?}",
+            err
+        );
+    }
+
+    /// When the artifact is not a container image, the scanner returns
+    /// Ok(vec![]) without ever contacting Trivy. This must remain true
+    /// even after the #888 fix — non-applicable artifacts are not failures.
+    #[tokio::test]
+    async fn test_scan_non_image_returns_ok_empty_without_trivy() {
+        let scanner = ImageScanner::new("http://127.0.0.1:1".to_string());
+        let artifact = make_test_artifact("pypi/pkg/1.0.0/pkg-1.0.0.tar.gz", "application/gzip");
+        let result = scanner.scan(&artifact, None, &Bytes::new()).await;
+        assert!(
+            result.is_ok(),
+            "non-container artifacts should not cause the image scanner to error"
+        );
+        assert!(result.unwrap().is_empty());
     }
 
     #[test]

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -43,6 +43,19 @@ pub fn record_security_scan(scanner: &str, success: bool, duration_secs: f64) {
         .record(duration_secs);
 }
 
+/// Record a scanner backend health-check failure. Distinct from
+/// `record_security_scan` so dashboards can separate "Trivy was down" from
+/// "scan ran and failed mid-execution". `reason` is "unreachable" (network
+/// error / timeout) or "unhealthy" (non-2xx response).
+pub fn record_scanner_health_check_failure(scanner: &str, reason: &str) {
+    counter!(
+        "ak_scanner_health_check_failures_total",
+        "scanner" => scanner.to_string(),
+        "reason" => reason.to_string()
+    )
+    .increment(1);
+}
+
 /// Record a webhook delivery event.
 pub fn record_webhook_delivery(event: &str, success: bool) {
     let status = if success { "success" } else { "failure" };
@@ -110,6 +123,12 @@ mod tests {
     fn test_record_security_scan_does_not_panic() {
         record_security_scan("trivy", true, 5.0);
         record_security_scan("openscap", false, 1.2);
+    }
+
+    #[test]
+    fn test_record_scanner_health_check_failure_does_not_panic() {
+        record_scanner_health_check_failure("trivy", "unreachable");
+        record_scanner_health_check_failure("trivy", "unhealthy");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cherry-picks #897 to release/1.1.x. Fixes the silent-success bug where the Trivy pod being unreachable caused scans to be marked COMPLETED with zero findings instead of FAILED. Customers running 1.1.x are exposed to the same issue.

The cherry-picked commit (squash from main: 980127b) includes:
- Surgical fix to ImageScanner::scan + check_trivy_health (Result<()> + propagation)
- 3-attempt retry loop with 500ms backoff so a brief Trivy pod restart does not hard-fail in-flight scans
- Per-request 5s timeout on /healthz, independent of the 300s scan timeout
- New metric \`ak_scanner_health_check_failures_total{scanner, reason}\`
- AppError::BadGateway for upstream failures (was Internal)
- Regression tests pinning the retry contract, BadGateway variant, and the original #888 silent-success class

## Cherry-pick conflict

backend/src/services/image_scanner.rs had test fixtures using the inlined Artifact struct literal on release/1.1.x. The cherry-pick refactored those into a make_test_artifact helper. Conflict resolved by accepting the helper version; the helper definition was auto-merged correctly without the quarantine_status / quarantine_until fields that exist on main but not on release/1.1.x.

## Bundled fmt fix

Includes a 2-chunk cargo fmt pass on backend/src/api/handlers/oci_v2.rs (pre-existing drift, same scope as the deferred PR #864). This is the minimum required for cargo fmt --check to pass on this branch and removes the dependency on #864.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable) - N/A
- [x] Manually tested locally (cargo test --workspace --lib image_scanner / metrics_service: 22 passed)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes