### PR TITLE
fix(security): backport SSRF redirect-policy and IPv6 bypass fixes (#881) to 1.1.x

### DIFF
--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -2789,4 +2789,24 @@ mod tests {
             "legitimate external URL should be accepted"
         );
     }
+
+    /// Smoke test that the cargo `dl` field flows through
+    /// `validate_outbound_url`. The detailed coverage of each bypass
+    /// class lives in `api::validation::tests`; this test pins the
+    /// integration: a malicious upstream `config.json` returning a
+    /// crafted `dl` cannot reach AWS IMDS via the cargo download path.
+    /// One realistic case is sufficient — duplicating the full bypass
+    /// matrix here would shadow the validator's own tests.
+    #[test]
+    fn test_build_download_url_rejects_ipv6_ssrf_bypass() {
+        use crate::api::validation::validate_outbound_url;
+        let dl = "http://[::ffff:169.254.169.254]";
+        let url = build_download_url(dl, "evil", "1.0.0");
+        let err = validate_outbound_url(&url, "Cargo upstream download URL")
+            .expect_err("IPv4-mapped AWS IMDS via dl must be rejected");
+        assert!(
+            err.to_string().contains("private/internal network"),
+            "expected SSRF rejection reason in error message, got: {err}"
+        );
+    }
 }

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -238,7 +238,7 @@ async fn proxy_sumdb(host: &str, path: &str) -> Result<Response, Response> {
 
     tracing::debug!("Proxying sumdb request to {}", url);
 
-    let client = reqwest::Client::new();
+    let client = crate::services::http_client::default_client();
     let upstream_resp = client.get(&url).send().await.map_err(|e| {
         tracing::warn!("sumdb proxy request failed for {}: {}", url, e);
         (

--- a/backend/src/api/validation.rs
+++ b/backend/src/api/validation.rs
@@ -2,8 +2,90 @@
 //!
 //! Centralizes URL and other validation logic used across multiple handlers
 //! and services so that SSRF / injection rules are defined in one place.
+//!
+//! # Defense layers
+//!
+//! 1. [`validate_outbound_url`] is the entry point for handlers/services that
+//!    receive a URL from a client (e.g. webhook URL, remote repo URL,
+//!    upstream config.json `dl` field). Reject before the request ever
+//!    issues.
+//! 2. The redirect policy on the shared HTTP client (see
+//!    `crate::services::http_client::base_client_builder`) calls
+//!    [`is_blocked_url`] on every redirect hop. This closes the
+//!    redirect-follow bypass — without it, an upstream returning
+//!    `302 Location: http://[::ffff:127.0.0.1]/` would defeat layer 1.
+//! 3. Egress NetworkPolicy at the cluster layer is a defense-in-depth
+//!    follow-up tracked separately.
+//!
+//! # Residual gaps
+//!
+//! DNS rebinding: a hostname that resolves to a public IP at validation
+//! time and a private IP at fetch time is not caught by string-based
+//! validation. Mitigation requires a custom DNS resolver or pinning the
+//! resolved IP via `reqwest`'s `resolve_to_addrs`. Tracked as a follow-up.
 
 use crate::error::{AppError, Result};
+
+/// IPv6 link-local prefix `fe80::/10`. The mask covers the top 10 bits.
+const IPV6_LINK_LOCAL_MASK: u16 = 0xffc0;
+const IPV6_LINK_LOCAL_PREFIX: u16 = 0xfe80;
+
+/// IPv6 unique-local prefix `fc00::/7`. The mask covers the top 7 bits.
+const IPV6_UNIQUE_LOCAL_MASK: u16 = 0xfe00;
+const IPV6_UNIQUE_LOCAL_PREFIX: u16 = 0xfc00;
+
+/// IPv4 carrier-grade NAT prefix `100.64.0.0/10` (RFC 6598). The mask
+/// covers the top 10 bits (full first octet 100, plus top 2 bits of the
+/// second octet = 0b01).
+const CGNAT_SECOND_OCTET_MASK: u8 = 0xc0;
+const CGNAT_SECOND_OCTET_PREFIX: u8 = 0x40;
+
+/// Cloud-provider metadata IPs that fall outside RFC1918 / link-local.
+/// Each entry is a single-IP block. The full Alibaba CGNAT range is
+/// gated behind `BLOCK_CGNAT_OUTBOUND=true` (off by default) since
+/// `100.64.0.0/10` is also used by K8s pod CIDRs in some clusters and
+/// by CGNAT-served residential ISPs.
+const CLOUD_METADATA_IPS: &[[u8; 4]] = &[
+    [192, 0, 0, 192],     // Oracle Cloud Infrastructure
+    [100, 100, 100, 200], // Alibaba Cloud
+];
+
+/// Hostname blocklist. Both the literal entry and `*.<entry>` forms are
+/// blocked. Lowercased before comparison. IP literals (e.g.
+/// `169.254.169.254`) are deliberately NOT here — the IP check below
+/// covers them and includes their bypass forms (IPv4-mapped IPv6, etc).
+const BLOCKED_HOSTS: &[&str] = &[
+    "localhost",
+    "metadata.google.internal",
+    "metadata.azure.com",
+    "metadata.tencentyun.com",
+    "metadata.oraclecloud.com",
+    "metadata.platformequinix.com",
+    "backend",
+    "postgres",
+    "redis",
+    "meilisearch",
+    "trivy",
+];
+
+/// Reason a URL was blocked. Returned by [`is_blocked_url`] so callers
+/// (validators and the redirect policy) can surface a useful error
+/// message and emit a labeled metric.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BlockReason {
+    Hostname(String),
+    Ip(std::net::IpAddr),
+}
+
+impl BlockReason {
+    /// Short metric label, suitable for a Prometheus `reason` dimension.
+    pub(crate) fn metric_label(&self) -> &'static str {
+        match self {
+            BlockReason::Hostname(_) => "hostname",
+            BlockReason::Ip(_) => "ip",
+        }
+    }
+}
 
 /// Validate that a URL is safe for the server to contact (anti-SSRF).
 ///
@@ -22,67 +104,189 @@ pub fn validate_outbound_url(url_str: &str, label: &str) -> Result<()> {
         )));
     }
 
-    let host_str = parsed
-        .host_str()
-        .ok_or_else(|| AppError::Validation(format!("{} must have a host", label)))?;
-
-    // Block known internal/metadata hostnames
-    let blocked_hosts = [
-        "localhost",
-        "metadata.google.internal",
-        "metadata.azure.com",
-        "169.254.169.254",
-        "backend",
-        "postgres",
-        "redis",
-        "meilisearch",
-        "trivy",
-    ];
-    let host_lower = host_str.to_lowercase();
-    for blocked in &blocked_hosts {
-        if host_lower == *blocked || host_lower.ends_with(&format!(".{}", blocked)) {
-            return Err(AppError::Validation(format!(
-                "{} host '{}' is not allowed",
-                label, host_str
-            )));
-        }
+    if parsed.host_str().is_none() {
+        return Err(AppError::Validation(format!("{} must have a host", label)));
     }
 
-    // Block private/internal IP ranges.
-    // host_str() returns brackets for IPv6 (e.g. "[::1]"), so strip them
-    // before parsing as IpAddr.
-    let bare_host = host_str
-        .strip_prefix('[')
-        .and_then(|h| h.strip_suffix(']'))
-        .unwrap_or(host_str);
-    if let Ok(ip) = bare_host.parse::<std::net::IpAddr>() {
-        let is_blocked = match ip {
-            std::net::IpAddr::V4(v4) => {
-                v4.is_loopback()
-                    || v4.is_private()
-                    || v4.is_link_local()
-                    || v4.is_unspecified()
-                    || v4.is_broadcast()
+    if let Some(reason) = is_blocked_url(&parsed) {
+        record_block(label, &reason);
+        return Err(match reason {
+            BlockReason::Hostname(host) => {
+                AppError::Validation(format!("{} host '{}' is not allowed", label, host))
             }
-            std::net::IpAddr::V6(v6) => v6.is_loopback() || v6.is_unspecified(),
-        };
-        if is_blocked {
-            return Err(AppError::Validation(format!(
+            BlockReason::Ip(ip) => AppError::Validation(format!(
                 "{} IP '{}' is not allowed (private/internal network)",
                 label, ip
-            )));
-        }
+            )),
+        });
     }
 
     Ok(())
 }
 
+/// Decide whether a parsed URL targets a blocked address. Used by both
+/// [`validate_outbound_url`] and the redirect policy on the shared HTTP
+/// client. Returning `Some(_)` means the request must not be issued.
+pub(crate) fn is_blocked_url(url: &reqwest::Url) -> Option<BlockReason> {
+    let host = url.host_str()?;
+    let host_lower = host.to_lowercase();
+    // Strip a trailing dot so `localhost.` is treated like `localhost`.
+    let host_normalized = host_lower.trim_end_matches('.');
+
+    for blocked in BLOCKED_HOSTS {
+        if host_normalized == *blocked || host_normalized.ends_with(&format!(".{}", blocked)) {
+            return Some(BlockReason::Hostname(host.to_string()));
+        }
+    }
+
+    // host_str() returns brackets for IPv6 (e.g. "[::1]"), so strip them
+    // before parsing as IpAddr.
+    let bare_host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    if let Ok(ip) = bare_host.parse::<std::net::IpAddr>() {
+        if is_blocked_ip(ip) {
+            return Some(BlockReason::Ip(ip));
+        }
+    }
+
+    None
+}
+
+/// Return true when an IP must not be contacted from server-side requests.
+///
+/// Covers:
+/// - IPv4 loopback / RFC1918 private / link-local / unspecified / broadcast
+/// - Specific cloud metadata IPs that fall outside RFC1918 (Oracle
+///   `192.0.0.192`, Alibaba `100.100.100.200`)
+/// - Optionally (gated by `BLOCK_CGNAT_OUTBOUND=true`) the entire
+///   `100.64.0.0/10` CGNAT range. Off by default because K8s pod CIDRs
+///   and CGNAT-served ISPs legitimately occupy this range
+/// - IPv6 loopback (`::1`), unspecified (`::`), link-local (`fe80::/10`),
+///   unique-local (`fc00::/7`)
+/// - IPv4-mapped IPv6 (`::ffff:0:0/96`) and the deprecated
+///   IPv4-compatible IPv6 (`::a.b.c.d`) — both reduce to IPv4 rules so
+///   `http://[::ffff:169.254.169.254]/` cannot bypass the IPv4 metadata
+///   block. IPv6 own-properties (loopback, link-local, etc.) are
+///   evaluated *first* so `::1` is correctly classified as IPv6 loopback
+///   rather than IPv4 alias `0.0.0.1`.
+pub(crate) fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        std::net::IpAddr::V6(v6) => is_blocked_ipv6(v6),
+    }
+}
+
+fn is_blocked_ipv4(v4: std::net::Ipv4Addr) -> bool {
+    if v4.is_loopback()
+        || v4.is_private()
+        || v4.is_link_local()
+        || v4.is_unspecified()
+        || v4.is_broadcast()
+    {
+        return true;
+    }
+    let octets = v4.octets();
+    if CLOUD_METADATA_IPS.contains(&octets) {
+        return true;
+    }
+    if cgnat_block_enabled()
+        && octets[0] == 100
+        && (octets[1] & CGNAT_SECOND_OCTET_MASK) == CGNAT_SECOND_OCTET_PREFIX
+    {
+        return true;
+    }
+    false
+}
+
+fn is_blocked_ipv6(v6: std::net::Ipv6Addr) -> bool {
+    // Evaluate IPv6 own properties first so `::1` is caught as IPv6
+    // loopback before the IPv4-alias fallthrough re-interprets it.
+    if v6.is_loopback() || v6.is_unspecified() {
+        return true;
+    }
+    let segs = v6.segments();
+    if segs[0] & IPV6_LINK_LOCAL_MASK == IPV6_LINK_LOCAL_PREFIX {
+        return true;
+    }
+    if segs[0] & IPV6_UNIQUE_LOCAL_MASK == IPV6_UNIQUE_LOCAL_PREFIX {
+        return true;
+    }
+    // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d)
+    // forms must obey the IPv4 rules so attackers cannot bypass them
+    // by writing the v4 address inside a v6 literal.
+    if let Some(v4) = v6.to_ipv4_mapped() {
+        return is_blocked_ipv4(v4);
+    }
+    if let Some(v4) = v6.to_ipv4() {
+        return is_blocked_ipv4(v4);
+    }
+    false
+}
+
+/// Whether to block the entire `100.64.0.0/10` CGNAT range. Off by
+/// default. Operators serving artifact-keeper from a CGNAT-served
+/// network or a K8s cluster that uses CGNAT for pod CIDRs would
+/// otherwise lose the ability to fetch from those addresses. When set
+/// to `true`, every CGNAT IP is rejected as if it were RFC1918.
+fn cgnat_block_enabled() -> bool {
+    std::env::var("BLOCK_CGNAT_OUTBOUND")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "True" | "TRUE"))
+        .unwrap_or(false)
+}
+
+fn record_block(label: &str, reason: &BlockReason) {
+    let detail = match reason {
+        BlockReason::Hostname(host) => host.clone(),
+        BlockReason::Ip(ip) => ip.to_string(),
+    };
+    tracing::warn!(
+        target: "security",
+        label = label,
+        reason = reason.metric_label(),
+        target_address = %detail,
+        "outbound URL blocked"
+    );
+    crate::services::metrics_service::record_outbound_url_blocked(reason.metric_label(), label);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Tests that mutate `BLOCK_CGNAT_OUTBOUND` must serialize to avoid
+    /// racing parallel test threads. `cargo test` runs tests in
+    /// parallel; without this lock, an env-var-mutating test can flip
+    /// state under another test's nose.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: assert that `validate_outbound_url(url, ...)` rejects with
+    /// an error whose message contains both `label_part` (proving the
+    /// validator path that fired) and the URL's offending address.
+    /// Pinning the message guards against silent regressions where a
+    /// future change makes the URL fail for a different reason.
+    fn assert_blocked(url: &str, label_part: &str) {
+        let err =
+            validate_outbound_url(url, "Test URL").expect_err(&format!("expected error for {url}"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains(label_part),
+            "for {url}, expected error message to contain '{label_part}', got: {msg}"
+        );
+    }
+
+    fn assert_blocked_ip(url: &str) {
+        assert_blocked(url, "private/internal network");
+    }
+
+    fn assert_blocked_host(url: &str) {
+        assert_blocked(url, "is not allowed");
+    }
 
     // -----------------------------------------------------------------------
-    // Valid URLs
+    // Valid URLs (negative baseline — these must still pass)
     // -----------------------------------------------------------------------
 
     #[test]
@@ -98,6 +302,14 @@ mod tests {
     #[test]
     fn test_allows_public_ip() {
         assert!(validate_outbound_url("https://93.184.216.34/api", "Test URL").is_ok());
+    }
+
+    #[test]
+    fn test_allows_public_ipv6() {
+        // Cloudflare DNS — verify the validator does not over-block IPv6.
+        assert!(
+            validate_outbound_url("https://[2606:4700:4700::1111]/dns-query", "Test URL").is_ok()
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -125,44 +337,194 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Private / internal IPs
+    // Private / internal IPs (assertion strength: pin the error message)
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_rejects_loopback() {
-        assert!(validate_outbound_url("http://127.0.0.1:9090", "Test URL").is_err());
+        assert_blocked_ip("http://127.0.0.1:9090");
     }
 
     #[test]
     fn test_rejects_10_network() {
-        assert!(validate_outbound_url("http://10.0.0.1/api", "Test URL").is_err());
+        assert_blocked_ip("http://10.0.0.1/api");
     }
 
     #[test]
     fn test_rejects_172_16_network() {
-        assert!(validate_outbound_url("http://172.16.0.1/api", "Test URL").is_err());
+        assert_blocked_ip("http://172.16.0.1/api");
     }
 
     #[test]
     fn test_rejects_192_168_network() {
-        assert!(validate_outbound_url("http://192.168.1.1/api", "Test URL").is_err());
+        assert_blocked_ip("http://192.168.1.1/api");
     }
 
     #[test]
     fn test_rejects_link_local() {
-        assert!(
-            validate_outbound_url("http://169.254.169.254/latest/meta-data", "Test URL").is_err()
-        );
+        assert_blocked_ip("http://169.254.169.254/latest/meta-data");
     }
 
     #[test]
     fn test_rejects_zero_ip() {
-        assert!(validate_outbound_url("http://0.0.0.0/api", "Test URL").is_err());
+        assert_blocked_ip("http://0.0.0.0/api");
     }
 
     #[test]
     fn test_rejects_ipv6_loopback() {
-        assert!(validate_outbound_url("http://[::1]:8080/api", "Test URL").is_err());
+        assert_blocked_ip("http://[::1]:8080/api");
+    }
+
+    #[test]
+    fn test_rejects_ipv6_unspecified() {
+        assert_blocked_ip("http://[::]:8080/api");
+    }
+
+    // -----------------------------------------------------------------------
+    // SSRF bypasses via IPv4-mapped / compatible IPv6 addresses.
+    // Without explicit handling, `::ffff:169.254.169.254` parses as an
+    // IPv6 address whose `is_loopback()` / `is_unspecified()` are false,
+    // slipping past the private-IP check.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rejects_ipv4_mapped_loopback() {
+        assert_blocked_ip("http://[::ffff:127.0.0.1]/api");
+    }
+
+    #[test]
+    fn test_rejects_ipv4_mapped_aws_metadata() {
+        assert_blocked_ip("http://[::ffff:169.254.169.254]/latest/meta-data");
+    }
+
+    #[test]
+    fn test_rejects_ipv4_mapped_private_10() {
+        assert_blocked_ip("http://[::ffff:10.0.0.1]/api");
+    }
+
+    #[test]
+    fn test_rejects_ipv4_compatible_aws_metadata() {
+        // Deprecated IPv4-compatible IPv6 form (::a.b.c.d). Must also
+        // reduce to the IPv4 ruleset.
+        assert_blocked_ip("http://[::169.254.169.254]/latest/meta-data");
+    }
+
+    #[test]
+    fn test_rejects_ipv6_link_local() {
+        assert_blocked_ip("http://[fe80::1]/api");
+    }
+
+    #[test]
+    fn test_rejects_ipv6_unique_local() {
+        assert_blocked_ip("http://[fc00::1]/api");
+        assert_blocked_ip("http://[fd12:3456:789a::1]/api");
+    }
+
+    // Range-boundary tests so an off-by-one in the mask logic gets caught.
+
+    #[test]
+    fn test_ipv6_link_local_top_of_range_blocked() {
+        // febf:ffff:: is the last address of fe80::/10.
+        assert_blocked_ip("http://[febf:ffff::1]/api");
+    }
+
+    #[test]
+    fn test_ipv6_just_above_link_local_allowed() {
+        // fec0:: is fec0::/10 (deprecated site-local). The PR does not
+        // claim coverage; pin current behavior so a future widening is
+        // an explicit decision.
+        assert!(
+            validate_outbound_url("http://[fec0::1]/api", "Test URL").is_ok(),
+            "fec0::/10 (deprecated site-local) is currently NOT blocked"
+        );
+    }
+
+    #[test]
+    fn test_ipv6_unique_local_top_of_range_blocked() {
+        // fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff is the last address of fc00::/7.
+        assert_blocked_ip("http://[fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]/api");
+    }
+
+    #[test]
+    fn test_ipv6_just_above_unique_local_allowed() {
+        // fe00:: is just above fc00::/7 and just below fe80::/10.
+        assert!(
+            validate_outbound_url("http://[fe00::1]/api", "Test URL").is_ok(),
+            "fe00::1 sits between unique-local and link-local; must not be over-blocked"
+        );
+    }
+
+    #[test]
+    fn test_rejects_oracle_cloud_metadata_ip() {
+        assert_blocked_ip("http://192.0.0.192/opc/v2/instance");
+    }
+
+    #[test]
+    fn test_oracle_cloud_metadata_neighbor_allowed() {
+        assert!(
+            validate_outbound_url("http://192.0.0.191/x", "Test URL").is_ok(),
+            "192.0.0.191 must not be blocked; only the specific 192.0.0.192 is"
+        );
+    }
+
+    #[test]
+    fn test_rejects_alibaba_metadata_ip() {
+        // Alibaba's specific metadata IP is blocked by default even when
+        // the broader CGNAT block is disabled.
+        assert_blocked_ip("http://100.100.100.200/latest/meta-data");
+    }
+
+    #[test]
+    fn test_alibaba_metadata_neighbor_allowed_by_default() {
+        // 100.100.100.199 is in CGNAT but not the specific Alibaba IP.
+        // With BLOCK_CGNAT_OUTBOUND off (default) it must be allowed,
+        // otherwise K8s pod CIDRs in CGNAT and homelab/CGNAT ISPs break.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("BLOCK_CGNAT_OUTBOUND").ok();
+        std::env::remove_var("BLOCK_CGNAT_OUTBOUND");
+        let result = validate_outbound_url("http://100.100.100.199/x", "Test URL");
+        if let Some(v) = prev {
+            std::env::set_var("BLOCK_CGNAT_OUTBOUND", v);
+        }
+        assert!(
+            result.is_ok(),
+            "100.100.100.199 (CGNAT but not Alibaba) must be allowed by default; got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_cgnat_block_when_opted_in() {
+        // With BLOCK_CGNAT_OUTBOUND=true, the entire 100.64.0.0/10 range
+        // must be rejected. Range-boundary cases pin off-by-one bugs in
+        // the mask.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("BLOCK_CGNAT_OUTBOUND").ok();
+        std::env::set_var("BLOCK_CGNAT_OUTBOUND", "true");
+        let low_in = validate_outbound_url("http://100.64.0.1/x", "Test URL");
+        let high_in = validate_outbound_url("http://100.127.255.254/x", "Test URL");
+        let low_out = validate_outbound_url("http://100.63.255.255/x", "Test URL");
+        let high_out = validate_outbound_url("http://100.128.0.1/x", "Test URL");
+        match prev {
+            Some(v) => std::env::set_var("BLOCK_CGNAT_OUTBOUND", v),
+            None => std::env::remove_var("BLOCK_CGNAT_OUTBOUND"),
+        }
+        assert!(
+            low_in.is_err(),
+            "100.64.0.1 must be blocked when CGNAT block is on"
+        );
+        assert!(
+            high_in.is_err(),
+            "100.127.255.254 must be blocked when CGNAT block is on"
+        );
+        assert!(
+            low_out.is_ok(),
+            "100.63.255.255 must remain allowed (just below CGNAT)"
+        );
+        assert!(
+            high_out.is_ok(),
+            "100.128.0.1 must remain allowed (just above CGNAT)"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -171,31 +533,43 @@ mod tests {
 
     #[test]
     fn test_rejects_localhost() {
-        assert!(validate_outbound_url("http://localhost:8080/api", "Test URL").is_err());
+        assert_blocked_host("http://localhost:8080/api");
+    }
+
+    #[test]
+    fn test_rejects_localhost_trailing_dot() {
+        // FQDN trailing-dot form must not slip past the suffix match.
+        assert_blocked_host("http://localhost./api");
     }
 
     #[test]
     fn test_rejects_gcp_metadata() {
-        assert!(validate_outbound_url(
-            "http://metadata.google.internal/computeMetadata",
-            "Test URL"
-        )
-        .is_err());
+        assert_blocked_host("http://metadata.google.internal/computeMetadata");
+    }
+
+    #[test]
+    fn test_rejects_tencent_metadata() {
+        assert_blocked_host("http://metadata.tencentyun.com/latest/meta-data");
+    }
+
+    #[test]
+    fn test_rejects_oracle_metadata_hostname() {
+        assert_blocked_host("http://metadata.oraclecloud.com/opc/v2/instance");
     }
 
     #[test]
     fn test_rejects_docker_backend() {
-        assert!(validate_outbound_url("http://backend:8080/api", "Test URL").is_err());
+        assert_blocked_host("http://backend:8080/api");
     }
 
     #[test]
     fn test_rejects_docker_postgres() {
-        assert!(validate_outbound_url("http://postgres:5432", "Test URL").is_err());
+        assert_blocked_host("http://postgres:5432");
     }
 
     #[test]
     fn test_rejects_docker_redis() {
-        assert!(validate_outbound_url("http://redis:6379", "Test URL").is_err());
+        assert_blocked_host("http://redis:6379");
     }
 
     // -----------------------------------------------------------------------
@@ -209,8 +583,6 @@ mod tests {
 
     #[test]
     fn test_allows_k8s_service_name() {
-        // K8s deployments use single-label hostnames for intra-namespace services.
-        // These must be allowed for remote repos pointing at other services.
         assert!(validate_outbound_url("http://nexus:8081/repository/pypi", "Test URL").is_ok());
     }
 
@@ -230,5 +602,32 @@ mod tests {
         let result = validate_outbound_url("ftp://example.com", "Remote instance URL");
         let err_msg = format!("{}", result.unwrap_err());
         assert!(err_msg.contains("Remote instance URL"));
+    }
+
+    // -----------------------------------------------------------------------
+    // is_blocked_url contract — used by the redirect policy on
+    // base_client_builder.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_blocked_url_returns_ip_reason_for_metadata() {
+        let url = reqwest::Url::parse("http://[::ffff:169.254.169.254]/").unwrap();
+        let reason = is_blocked_url(&url).expect("must block IPv4-mapped AWS metadata");
+        assert!(matches!(reason, BlockReason::Ip(_)));
+        assert_eq!(reason.metric_label(), "ip");
+    }
+
+    #[test]
+    fn test_is_blocked_url_returns_hostname_reason_for_localhost() {
+        let url = reqwest::Url::parse("http://localhost/").unwrap();
+        let reason = is_blocked_url(&url).expect("must block localhost");
+        assert!(matches!(reason, BlockReason::Hostname(_)));
+        assert_eq!(reason.metric_label(), "hostname");
+    }
+
+    #[test]
+    fn test_is_blocked_url_passes_public_address() {
+        let url = reqwest::Url::parse("https://crates.io/api/v1/crates/serde").unwrap();
+        assert!(is_blocked_url(&url).is_none());
     }
 }

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -6,8 +6,14 @@
 //! custom CA certificates (configured via `CUSTOM_CA_CERT_PATH`) are loaded
 //! consistently across the application.
 
+use reqwest::redirect::Policy;
 use reqwest::tls::Certificate;
 use reqwest::ClientBuilder;
+
+/// Maximum number of redirects we will follow even if every hop passes
+/// the SSRF check. Matches reqwest's historical default and prevents
+/// loops or pathological chains from tying up workers.
+const MAX_REDIRECTS: usize = 10;
 
 /// Return a [`ClientBuilder`] pre-loaded with custom CA certificates when
 /// the `CUSTOM_CA_CERT_PATH` environment variable is set.
@@ -52,7 +58,7 @@ fn log_proxy_env() {
 pub fn base_client_builder() -> ClientBuilder {
     log_proxy_env();
 
-    let mut builder = reqwest::Client::builder();
+    let mut builder = reqwest::Client::builder().redirect(ssrf_redirect_policy());
 
     if let Ok(ca_path) = std::env::var("CUSTOM_CA_CERT_PATH") {
         match std::fs::read(&ca_path) {
@@ -97,6 +103,32 @@ pub fn default_client() -> reqwest::Client {
     base_client_builder()
         .build()
         .expect("failed to build default HTTP client")
+}
+
+/// Redirect policy that re-runs the SSRF allow-list on every hop. An
+/// upstream returning `302 Location: http://[::ffff:127.0.0.1]/` would
+/// otherwise defeat the entry-point validator. Caps at
+/// [`MAX_REDIRECTS`] hops so a redirect loop cannot tie up a worker.
+fn ssrf_redirect_policy() -> Policy {
+    Policy::custom(|attempt| {
+        if let Some(reason) = crate::api::validation::is_blocked_url(attempt.url()) {
+            tracing::warn!(
+                target: "security",
+                redirect_url = %attempt.url(),
+                reason = reason.metric_label(),
+                "blocking redirect to disallowed address"
+            );
+            crate::services::metrics_service::record_outbound_url_blocked(
+                reason.metric_label(),
+                "http-client redirect",
+            );
+            return attempt.error("redirect target rejected by SSRF policy");
+        }
+        if attempt.previous().len() >= MAX_REDIRECTS {
+            return attempt.error("too many redirects");
+        }
+        attempt.follow()
+    })
 }
 
 #[cfg(test)]
@@ -165,5 +197,57 @@ mod tests {
         let client = base_client_builder().build();
         assert!(client.is_ok());
         std::env::remove_var("CUSTOM_CA_CERT_PATH");
+    }
+
+    /// Regression test for the SSRF redirect-follow bypass: any redirect
+    /// hop pointing at a blocked address must abort the request, not
+    /// silently follow. A bare `reqwest::Client` would tolerate such a
+    /// redirect; the policy installed by `base_client_builder` must not.
+    #[tokio::test]
+    async fn test_redirect_to_blocked_ip_is_refused() {
+        // Spin up a tiny TCP listener that always returns
+        // `302 Location: http://[::ffff:127.0.0.1]/` and tear down
+        // after one connection.
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            // Accept one connection, ignore the request, send a 302 to
+            // an SSRF-bypass target. The client should refuse to
+            // follow.
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let _ = sock
+                    .write_all(
+                        b"HTTP/1.1 302 Found\r\n\
+                          Location: http://[::ffff:127.0.0.1]/admin\r\n\
+                          Content-Length: 0\r\n\
+                          Connection: close\r\n\r\n",
+                    )
+                    .await;
+            }
+        });
+
+        let client = base_client_builder().build().unwrap();
+        let url = format!("http://127.0.0.1:{}/start", addr.port());
+        // Bypassing `validate_outbound_url` deliberately — this test
+        // exercises the redirect policy specifically. A request that
+        // starts at 127.0.0.1 and is refused for THAT reason wouldn't
+        // tell us anything about redirect protection. To target only
+        // the redirect path, point at the listener and assert the
+        // failure mentions the redirect.
+        let result = client.get(&url).send().await;
+
+        // Drain the server task.
+        let _ = server.await;
+
+        let err = result.expect_err("redirect to ::ffff:127.0.0.1 must be refused");
+        assert!(
+            err.to_string().contains("SSRF") || err.is_redirect(),
+            "expected redirect-rejection error, got: {err}"
+        );
     }
 }

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -49,6 +49,20 @@ pub fn record_webhook_delivery(event: &str, success: bool) {
     counter!("ak_webhook_deliveries_total", "event" => event.to_string(), "status" => status.to_string()).increment(1);
 }
 
+/// Record an outbound URL that was rejected by SSRF validation, either
+/// at handler entry (`validate_outbound_url`) or on a redirect hop
+/// inside the shared HTTP client. `reason` is `"hostname"` or `"ip"`,
+/// `label` identifies the calling site (e.g. `"Webhook URL"`,
+/// `"Cargo upstream download URL"`, `"http-client redirect"`).
+pub fn record_outbound_url_blocked(reason: &str, label: &str) {
+    counter!(
+        "ak_outbound_url_blocked_total",
+        "reason" => reason.to_string(),
+        "label" => label.to_string()
+    )
+    .increment(1);
+}
+
 /// Update storage gauge metrics from database stats.
 pub fn set_storage_gauge(total_bytes: i64, total_artifacts: i64, total_repos: i64) {
     gauge!("ak_storage_used_bytes").set(total_bytes as f64);
@@ -116,6 +130,12 @@ mod tests {
     fn test_record_webhook_delivery_does_not_panic() {
         record_webhook_delivery("artifact.created", true);
         record_webhook_delivery("artifact.deleted", false);
+    }
+
+    #[test]
+    fn test_record_outbound_url_blocked_does_not_panic() {
+        record_outbound_url_blocked("hostname", "Webhook URL");
+        record_outbound_url_blocked("ip", "http-client redirect");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cherry-picks #881 to release/1.1.x. Closes the same SSRF bypass classes on the maintenance branch:
- IPv4-mapped IPv6 (\`::ffff:0:0/96\`)
- IPv6 link-local (\`fe80::/10\`) and unique-local (\`fc00::/7\`)
- Oracle Cloud metadata (\`192.0.0.192\`)
- Alibaba Cloud metadata (\`100.100.100.200\`)
- The redirect-follow bypass (load-bearing): reqwest's default Policy::limited(10) follows 302s blindly, defeating the entry-point validator. The new redirect::Policy::custom on base_client_builder re-runs is_blocked_url on every hop.

The cherry-pick is the squashed main commit 40017e3, which bundles both ff8c813 (original IPv6 SSRF + cloud metadata) and e86620e (redirect policy + observability + refactor). Same security fix, same test coverage.

## Why this is not deferred (unlike #864/#891/#892)

This is a security fix. Customers running release/1.1.x are exposed to identical SSRF bypass classes. Beads issue ak-j85q tracks this work.

## Cherry-pick conflicts

backend/src/api/validation.rs: release/1.1.x had the unrefactored validator with an inline hostname blocklist that included \"meilisearch\" (release/1.1.x is pre-OpenSearch-migration). The cherry-pick refactors to the BlockReason / is_blocked_url architecture. Resolved by accepting the new structure and adjusting the BLOCKED_HOSTS const to keep \"meilisearch\" instead of main's \"opensearch\". Other affected files (metrics_service.rs, http_client.rs, goproxy.rs, cargo.rs) auto-merged.

## Bundled fmt fix

Includes cargo fmt on backend/src/api/handlers/oci_v2.rs (same pre-existing drift handled by #864/#899). When #899 lands first, this commit is dropped on rebase.

## Verification
- cargo fmt --check: pass
- cargo clippy --workspace --all-targets -- -D warnings: pass
- cargo test --workspace --lib: 7513 passed, 0 failed
- Redirect regression test (test_redirect_to_blocked_ip_is_refused): passes — local TCP listener returning 302 -> ::ffff:127.0.0.1 is correctly refused
- Validation tests (73 passed): boundary cases, IPv4-compat, hostname trailing dot, all metric/observability tests

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable) — N/A
- [x] Manually tested locally (full suite green)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Refs ak-j85q (beads). Tracks the original CVE/advisory referenced on PR #881.