### PR TITLE
fix(security): list_findings returns 404 (not 200-empty) for unknown scan_id

### DIFF
--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -610,6 +610,14 @@ async fn list_findings(
     Query(query): Query<ListFindingsQuery>,
 ) -> Result<Json<FindingListResponse>> {
     let svc = ScanResultService::new(state.db.clone());
+
+    // Verify the scan exists. Without this check, an unknown scan_id falls
+    // through the `WHERE scan_result_id = $1` query and returns a 200 with
+    // an empty envelope, contradicting the 404 documented in the OpenAPI
+    // annotation above. Clients can't distinguish "unknown scan" from "real
+    // scan with zero findings" without this pre-check.
+    svc.get_scan(scan_id).await?;
+
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(50).min(200);
     let offset = (page - 1) * per_page;

--- a/backend/tests/integration_tests.rs
+++ b/backend/tests/integration_tests.rs
@@ -1373,4 +1373,37 @@ mod tests {
             "Private repo packages should not appear in anonymous listing"
         );
     }
+
+    // ============= Security: list_findings =============
+
+    /// Regression test for #914: GET /api/v1/security/scans/{unknown}/findings
+    /// must return 404, not a 200 with an empty envelope. Without the
+    /// existence check in `list_findings`, the SQL `WHERE scan_result_id = $1`
+    /// returned zero rows and the handler responded 200 with `{items:[],
+    /// total:0}` -- contradicting the OpenAPI annotation that documents 404
+    /// for "Scan not found" and forcing clients to assume any zero-finding
+    /// response could be either an unknown scan or a clean scan.
+    #[tokio::test]
+    #[ignore = "requires running HTTP server"]
+    async fn test_list_findings_unknown_scan_returns_404() {
+        let server = get_server().await;
+        let client = Client::new();
+        let unknown_scan_id = "00000000-0000-0000-0000-000000000000";
+
+        let resp = client
+            .get(format!(
+                "{}/api/v1/security/scans/{}/findings",
+                server.base_url, unknown_scan_id
+            ))
+            .header("Authorization", format!("Bearer {}", server.access_token))
+            .send()
+            .await
+            .expect("list_findings request failed");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            404,
+            "unknown scan_id must return 404 (was 200 before #914 fix)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/security/scans/{id}/findings` advertised HTTP 404 in its OpenAPI annotation but the handler never produced it. The query `SELECT ... FROM findings WHERE scan_result_id = $1` returned zero rows for any unknown scan_id and the handler responded `200 {items:[], total:0}`. Clients couldn't tell "you typed the wrong scan_id" apart from "this is a real, clean scan with no findings". OpenAPI spec and reality drifted apart.

This PR adds an explicit existence check via `ScanResultService::get_scan(scan_id).await?` before listing findings. `get_scan` already returns `AppError::NotFound` for unknown ids, which the existing error mapping renders as HTTP 404. The annotation now matches the implementation.

Closes #914.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

`backend/tests/integration_tests.rs::test_list_findings_unknown_scan_returns_404` — `#[ignore]`d integration test (runs against TEST_BASE_URL). Hits an all-zeros UUID and asserts 404. On `main` today this test sees 200 and fails; on this PR it sees 404 and passes. Run manually with:

```sh
cargo test --test integration_tests test_list_findings_unknown_scan_returns_404 -- --ignored
```

## Test Checklist
- [ ] Unit tests added/updated — N/A: bug is at HTTP-handler level; the closest unit test (`ScanResultService::get_scan` returning NotFound) is exercised by the new integration test
- [x] Integration tests added/updated (`backend/tests/integration_tests.rs` — 1 test, `#[ignore]`d per repo convention)
- [ ] E2E tests added/updated (if applicable) — `artifact-keeper-test` PR #81 already accepts both 200-empty and 404 as a defensive measure; once this lands the test there can be tightened to 404-only (follow-up)
- [x] Manually tested locally (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` all pass — 8494 tests passed, 0 failed)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations — N/A
- [ ] Request/response types have `#[derive(ToSchema)]` — N/A
- [x] OpenAPI spec validates: covered by workspace `cargo test --workspace --lib`. The annotation at `security.rs:605` already declared 404; this PR makes the implementation match.
- [ ] Migration is reversible (if applicable) — N/A
- [x] Behavior change for existing endpoint: `GET /api/v1/security/scans/{id}/findings` now returns HTTP 404 (with body `{"code":"NOT_FOUND","message":"Scan result not found"}`) when the scan doesn't exist. Previously returned 200 with an empty envelope.