### PR TITLE
ci(coverage): fix Docker Hub rate-limit on postgres pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
     runs-on: ak-ci-runners
     services:
       postgres:
-        image: postgres:16-alpine
+        # Use the GHCR mirror maintained by .github/workflows/mirror-images.yml
+        # to avoid Docker Hub anonymous-pull rate limits, which were aborting
+        # the coverage job before tests could compile.
+        image: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
         env:
           POSTGRES_USER: registry
           POSTGRES_PASSWORD: registry
@@ -318,7 +321,8 @@ jobs:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     services:
       postgres:
-        image: postgres:16-alpine
+        # Use the GHCR mirror to avoid Docker Hub anonymous-pull rate limits.
+        image: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
         env:
           POSTGRES_USER: registry
           POSTGRES_PASSWORD: registry


### PR DESCRIPTION
## Summary

The Code Coverage and Backend Integration Tests jobs in `.github/workflows/ci.yml` pull `postgres:16-alpine` directly from Docker Hub as a service container. Recent runs have hit Docker Hub's anonymous-pull rate limit:

```
Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit.
```

After three retries the job aborts before `cargo` can even compile, failing the coverage gate on every affected PR. This is currently blocking PRs #932, #934, and #935.

This PR switches both service container references to the GHCR mirror that `.github/workflows/mirror-images.yml` already maintains weekly:

- `postgres:16-alpine` -> `ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine`

The mirror package is public (no registry credentials required) and is the same image already used by `docker-compose.test.yml`, so this just brings `ci.yml` in line with the established pattern. No new secrets, no new infrastructure.

After this lands, the user will need to re-run the failed Code Coverage jobs on PRs #932, #934, #935 (and any other open PR that hit the rate limit) so they pick up the new workflow definition from main once those PRs rebase.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A - this is not a bug fix (CI infra change, not application code)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (verified `docker pull ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine` succeeds and the GHCR package visibility is `public`)
- [x] No regressions in existing tests (only changes the registry the postgres image is pulled from; image tag and digest behavior identical)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes