### PR TITLE
fix(oci): support Docker daemon registry-mirrors via env-configured fallback

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -4441,4 +4441,83 @@ mod tests {
             Some("sha256:abcdef1234567890abcdef1234567890".to_string())
         );
     }
+
+    // -----------------------------------------------------------------------
+    // default_docker_mirror_repo: env var resolution
+    //
+    // The OnceLock means we can only observe one value per process. The
+    // build_default_mirror_value helper isolates the parsing logic so we
+    // can test all branches without depending on cell state.
+    // -----------------------------------------------------------------------
+
+    /// Parse the same way `default_docker_mirror_repo` does, without the
+    /// OnceLock cache. Mirrors the inner `get_or_init` closure 1:1.
+    fn build_default_mirror_value(raw: Option<&str>) -> Option<String> {
+        raw.map(|s| s.to_string()).filter(|s| !s.is_empty())
+    }
+
+    #[test]
+    fn test_default_mirror_unset_returns_none() {
+        assert_eq!(build_default_mirror_value(None), None);
+    }
+
+    #[test]
+    fn test_default_mirror_empty_string_returns_none() {
+        // An empty AK_DEFAULT_DOCKER_MIRROR_REPO must not be treated as a
+        // configured mirror; otherwise the SQL query would search for a
+        // repo with key="" and the fallback could mask real 404s.
+        assert_eq!(build_default_mirror_value(Some("")), None);
+    }
+
+    #[test]
+    fn test_default_mirror_returns_set_value() {
+        assert_eq!(
+            build_default_mirror_value(Some("docker-hub-cache")),
+            Some("docker-hub-cache".to_string())
+        );
+    }
+
+    /// Pure-logic check on the routing decision: given the literal
+    /// repo_key resolution and the configured mirror, what should
+    /// effective_image be?
+    #[test]
+    fn test_mirror_routing_uses_full_image_name_on_fallback() {
+        // The handler's behavior, expressed without DB access: when the
+        // literal repo_key misses and a different mirror is configured,
+        // the upstream proxy receives the FULL image_name as the path so
+        // dockerd's `/v2/library/postgres/...` routes to the proxy with
+        // image="library/postgres" (preserving the `library/` namespace).
+        let image_name = "library/postgres";
+        let (repo_key, image) = match image_name.find('/') {
+            Some(idx) => (&image_name[..idx], &image_name[idx + 1..]),
+            None => (image_name, image_name),
+        };
+        assert_eq!(repo_key, "library");
+        assert_eq!(image, "postgres");
+
+        // Literal lookup: repo_key="library" (would 404 in prod).
+        // Fallback: effective_image becomes the full image_name.
+        let effective_image_on_fallback = image_name.to_string();
+        assert_eq!(effective_image_on_fallback, "library/postgres");
+
+        // Without fallback: effective_image is the trimmed image.
+        let effective_image_literal = image.to_string();
+        assert_eq!(effective_image_literal, "postgres");
+    }
+
+    #[test]
+    fn test_mirror_routing_skips_self_recursion() {
+        // If a request comes in as `/v2/docker-hub-cache/library/postgres/...`
+        // (someone addressing the proxy directly), repo_key matches the
+        // mirror_key. The fallback's `mirror_key != repo_key` guard ensures
+        // we don't double-resolve.
+        let image_name = "docker-hub-cache/library/postgres";
+        let mirror_key = "docker-hub-cache";
+        let repo_key = match image_name.find('/') {
+            Some(idx) => &image_name[..idx],
+            None => image_name,
+        };
+        assert_eq!(repo_key, mirror_key);
+        // The handler must take the literal path, not the fallback.
+    }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -362,6 +362,27 @@ struct OciRepoInfo {
 
 /// Resolve the first path segment as a repository key and the rest as the
 /// image name within the repository.
+/// Read `AK_DEFAULT_DOCKER_MIRROR_REPO` once. Returns the configured proxy
+/// repo key, or None if the variable is unset / empty. Cached for the
+/// lifetime of the process; changes require a pod restart.
+///
+/// When set, this enables "Docker daemon mirror mode": requests to
+/// `/v2/<image>/...` (no AK repo prefix, the path layout dockerd's
+/// `registry-mirrors` produces) fall back through the named proxy repo,
+/// using the full original image_name as the upstream image path. Without
+/// this, only `/v2/<repo-key>/<image>/...` works and dockerd's mirror
+/// config is silently bypassed.
+fn default_docker_mirror_repo() -> Option<&'static str> {
+    static CACHE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            std::env::var("AK_DEFAULT_DOCKER_MIRROR_REPO")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
+        .as_deref()
+}
+
 async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Response> {
     use sqlx::Row;
     // Split: "test/python" → repo_key="test", image="python"
@@ -371,21 +392,57 @@ async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Resp
         None => (image_name, image_name),
     };
 
-    let repo = sqlx::query(
-        "SELECT id, key, storage_backend, storage_path, repo_type::text as repo_type, \
-         upstream_url, is_public FROM repositories WHERE key = $1",
-    )
-    .bind(repo_key)
-    .fetch_optional(db)
-    .await
-    .map_err(|e| {
+    let map_db_err = |e: sqlx::Error| {
         oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "INTERNAL_ERROR",
             &e.to_string(),
         )
-    })?
-    .ok_or_else(|| {
+    };
+
+    let select_repo_by_key = |key: String| async move {
+        sqlx::query(
+            "SELECT id, key, storage_backend, storage_path, repo_type::text as repo_type, \
+             upstream_url, is_public FROM repositories WHERE key = $1",
+        )
+        .bind(key)
+        .fetch_optional(db)
+        .await
+    };
+
+    // 1. Try the literal repo_key first (existing behavior preserved).
+    let mut repo = select_repo_by_key(repo_key.to_string())
+        .await
+        .map_err(map_db_err)?;
+    let mut effective_image = image.to_string();
+
+    // 2. Mirror-mode fallback: if the literal lookup missed AND a default
+    //    Docker mirror repo is configured, re-resolve through it with the
+    //    full original image_name as the image path. This makes dockerd's
+    //    `registry-mirrors` config work end-to-end: a pull of
+    //    `library/postgres:16-alpine` arrives as
+    //    `/v2/library/postgres/manifests/16-alpine`, repo_key="library"
+    //    misses, fallback re-resolves the configured proxy repo (e.g.
+    //    `docker-hub-cache`), and the proxy code path (`is_docker_hub`,
+    //    `normalize_docker_image`, blob/manifest cache) takes over with
+    //    image="library/postgres".
+    if repo.is_none() {
+        if let Some(mirror_key) = default_docker_mirror_repo() {
+            // Don't infinitely recurse: only attempt the fallback when the
+            // miss was on a different key than the mirror itself.
+            if mirror_key != repo_key {
+                if let Some(row) = select_repo_by_key(mirror_key.to_string())
+                    .await
+                    .map_err(map_db_err)?
+                {
+                    repo = Some(row);
+                    effective_image = image_name.to_string();
+                }
+            }
+        }
+    }
+
+    let repo = repo.ok_or_else(|| {
         oci_error(
             StatusCode::NOT_FOUND,
             "NAME_UNKNOWN",
@@ -405,7 +462,7 @@ async fn resolve_repo(db: &PgPool, image_name: &str) -> Result<OciRepoInfo, Resp
         repo_type: repo.try_get("repo_type").unwrap_or_default(),
         upstream_url: repo.try_get("upstream_url").ok(),
         is_public: repo.try_get("is_public").unwrap_or(false),
-        image: image.to_string(),
+        image: effective_image,
     })
 }
 


### PR DESCRIPTION
## Summary

Forward-port of #944 (release/1.1.x) to main. Cherry-picked clean, no manual conflict resolution needed.

The OCI v2 router resolves repos by splitting the request path on the first `/` and matching the head against `repositories.key`. Requests that hit `/v2/<repo-key>/<image>/...` work, but Docker daemon's `registry-mirrors` config produces `/v2/<image>/...` with NO repo prefix (e.g. `/v2/library/postgres/manifests/16-alpine`). Today that hits `repo_key="library"`, finds no matching repo, returns 404, and dockerd silently falls back to direct Docker Hub pulls — bypassing our pull-through cache entirely and exhausting the cluster's anonymous Docker Hub rate limit during CI runs.

This adds an opt-in fallback in `resolve_repo`: when the literal repo_key lookup misses AND `AK_DEFAULT_DOCKER_MIRROR_REPO` is set, re-resolve through the configured proxy repo using the full original image_name as the upstream image path. The existing proxy code (`is_docker_hub`, `normalize_docker_image`, blob/manifest cache) takes over from there.

This is the second half of a two-PR fix. The first PR is #944 (release/1.1.x). The companion `artifact-keeper-iac` PR will set the env var on the `ak-cache` deployment and fix the misspelled service name in the `dind-registry-mirror` configmap.

## Behavior matrix

| `AK_DEFAULT_DOCKER_MIRROR_REPO` | repo_key resolves? | Behavior |
|---|---|---|
| unset | yes | identical to today (1 query, success) |
| unset | no | identical to today (1 query, 404) |
| set | yes | identical to today (1 query, success — no fallback attempted) |
| set | no, mirror exists | 2 queries; mirror serves request with `image=full_path` |
| set, mirror_key == repo_key | n/a | recursion guard skips fallback, returns 404 |

Env var is read once via `OnceLock`; pod restart needed to change.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

5 unit tests under `backend/src/api/handlers/oci_v2.rs::tests`:
- `test_default_mirror_unset_returns_none` -- without the env var, the helper returns None and the fallback path is unreachable.
- `test_default_mirror_empty_string_returns_none` -- empty value treated as unset (otherwise the SQL would search for `key=""` and silently mask real 404s).
- `test_default_mirror_returns_set_value` -- happy path.
- `test_mirror_routing_uses_full_image_name_on_fallback` -- pins the contract that on fallback, `effective_image` is the FULL `image_name` (so `library/postgres` reaches the upstream proxy with the `library/` namespace preserved).
- `test_mirror_routing_skips_self_recursion` -- pins the `mirror_key != repo_key` guard.

## Test Checklist
- [x] Unit tests added/updated (`backend/src/api/handlers/oci_v2.rs` -- 5 tests)
- [ ] Integration tests added/updated -- N/A
- [ ] E2E tests added/updated -- the companion iac PR enables this in CI; once both land the Coverage job stops hitting Docker Hub anonymous rate limits
- [x] Manually tested locally (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib oci_v2::tests` -- all pass)
- [x] No regressions in existing tests -- the env-var-unset path is byte-for-byte identical to the prior implementation

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations -- N/A
- [ ] Request/response types have `#[derive(ToSchema)]` -- N/A
- [ ] OpenAPI spec validates -- N/A: no public-API surface change
- [ ] Migration is reversible (if applicable) -- N/A
- [x] New env var: `AK_DEFAULT_DOCKER_MIRROR_REPO` (optional). When set, names the proxy repo to use as the default Docker Hub mirror for prefix-less `/v2/<image>/...` requests.