### PR TITLE
feat(webhooks): v2 wire contract scaffolding (E1+E3+E6 combined)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,8 +182,18 @@ JWT_EXPIRATION_SECS=86400
 
 # Webhook signing-secret encryption key. 32 bytes, base64 encoded. Generate
 # with: openssl rand -base64 32. Required for the webhooks v2 create and
-# rotate-secret endpoints; without it those calls fail with HTTP 500.
+# rotate-secret endpoints; without it those calls fail with HTTP 500. The
+# backend validates the value at boot (ensure_configured) so a malformed
+# key fails fast instead of failing on the first webhook write.
 # AK_WEBHOOK_SECRET_KEY=
+
+# Webhooks v2 EventBus producer toggle. Off by default. Set to "true" or "1"
+# to subscribe to the in-process EventBus and enqueue rows into
+# webhook_deliveries for the retry scheduler to ship. Operators should leave
+# this off until migrated webhook rows have been re-rotated via the
+# /rotate-secret endpoint, otherwise System A (webhooks v2) and System B
+# (notification_subscriptions) deliver the same event twice.
+# WEBHOOKS_V2_PRODUCER_ENABLED=false
 
 # --- OIDC (optional) ---
 # OIDC_ISSUER=https://auth.example.com

--- a/.env.example
+++ b/.env.example
@@ -180,6 +180,11 @@ JWT_EXPIRATION_SECS=86400
 # SSO encryption key for encrypting stored OIDC/LDAP/SAML secrets in the database
 # SSO_ENCRYPTION_KEY=
 
+# Webhook signing-secret encryption key. 32 bytes, base64 encoded. Generate
+# with: openssl rand -base64 32. Required for the webhooks v2 create and
+# rotate-secret endpoints; without it those calls fail with HTTP 500.
+# AK_WEBHOOK_SECRET_KEY=
+
 # --- OIDC (optional) ---
 # OIDC_ISSUER=https://auth.example.com
 # OIDC_CLIENT_ID=artifact-registry

--- a/.env.local-dev
+++ b/.env.local-dev
@@ -7,3 +7,10 @@ JWT_SECRET=local-dev-secret-not-for-production
 RUST_LOG=info,artifact_keeper=debug
 HOST=127.0.0.1
 PORT=8080
+# Webhooks v2 signing-secret encryption key (32 bytes base64).
+# This is the literal "dev-key-not-for-prod-use-in-prod" base64-encoded.
+AK_WEBHOOK_SECRET_KEY=ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q=
+# Webhooks v2 EventBus producer. Off by default; flip to "true" after
+# rotating migrated webhook secrets so System A and System B do not
+# double-deliver the same event.
+WEBHOOKS_V2_PRODUCER_ENABLED=false

--- a/.env.local-dev
+++ b/.env.local-dev
@@ -8,8 +8,10 @@ RUST_LOG=info,artifact_keeper=debug
 HOST=127.0.0.1
 PORT=8080
 # Webhooks v2 signing-secret encryption key (32 bytes base64).
-# This is the literal "dev-key-not-for-prod-use-in-prod" base64-encoded.
-AK_WEBHOOK_SECRET_KEY=ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q=
+# Generate with: openssl rand -base64 32, then replace the placeholder.
+# The placeholder below is intentionally invalid base64 so the backend's
+# ensure_configured check fails fast with a clear error.
+AK_WEBHOOK_SECRET_KEY=REPLACE_ME_WITH_OUTPUT_OF_openssl_rand_base64_32
 # Webhooks v2 EventBus producer. Off by default; flip to "true" after
 # rotating migrated webhook secrets so System A and System B do not
 # double-deliver the same event.

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -45,13 +45,6 @@ secret:
       match: "test-api-key"
     - name: "Test webhook secret in unit tests"
       match: "my-secret-key"
-    # AK_WEBHOOK_SECRET_KEY dev fixture in docker-compose / .env.local-dev.
-    # Decodes to literal "dev-key-not-for-prod-use-in-prod" — self-labeled,
-    # 32 bytes, used only for local docker compose up. Production must
-    # provision via the IaC chart (artifact-keeper-iac, tracked in
-    # artifact-keeper#950).
-    - name: "AK_WEBHOOK_SECRET_KEY local-dev placeholder"
-      match: "ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q="
 
     # GCS test service account
     - name: "Test GCS service account email"

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -45,6 +45,13 @@ secret:
       match: "test-api-key"
     - name: "Test webhook secret in unit tests"
       match: "my-secret-key"
+    # AK_WEBHOOK_SECRET_KEY dev fixture in docker-compose / .env.local-dev.
+    # Decodes to literal "dev-key-not-for-prod-use-in-prod" — self-labeled,
+    # 32 bytes, used only for local docker compose up. Production must
+    # provision via the IaC chart (artifact-keeper-iac, tracked in
+    # artifact-keeper#950).
+    - name: "AK_WEBHOOK_SECRET_KEY local-dev placeholder"
+      match: "ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q="
 
     # GCS test service account
     - name: "Test GCS service account email"

--- a/backend/migrations/080_webhook_secrets_encrypted.sql
+++ b/backend/migrations/080_webhook_secrets_encrypted.sql
@@ -1,0 +1,23 @@
+-- Webhooks v2: encrypted-at-rest secrets, write-once display, rotation support.
+--
+-- Replaces the legacy bcrypt secret_hash with reversible AES-256-GCM ciphertext
+-- so the backend can sign delivery payloads (HMAC signing arrives in a later
+-- ticket; this migration only lays the storage foundation).
+--
+-- secret_hash is intentionally retained during the transition. Existing rows
+-- have only a bcrypt hash, which is unrecoverable. Operators must call
+-- POST /api/v1/webhooks/{id}/rotate-secret to obtain a new signable secret.
+-- Until then, deliveries for those rows remain unsigned (matches existing
+-- behavior in the retry path, which previously emitted a placeholder header).
+-- A follow-up migration drops secret_hash once all rows are rotated.
+
+ALTER TABLE webhooks ADD COLUMN secret_encrypted bytea;
+ALTER TABLE webhooks ADD COLUMN secret_digest text;
+ALTER TABLE webhooks ADD COLUMN secret_rotation_started_at timestamptz;
+ALTER TABLE webhooks ADD COLUMN secret_previous_encrypted bytea;
+ALTER TABLE webhooks ADD COLUMN secret_previous_expires_at timestamptz;
+
+-- Partial index used by the previous-secret cleanup tick (see scheduler_service).
+CREATE INDEX idx_webhooks_secret_previous_expires_at
+    ON webhooks (secret_previous_expires_at)
+    WHERE secret_previous_encrypted IS NOT NULL;

--- a/backend/migrations/081_migrate_notification_subscriptions_to_webhooks.sql
+++ b/backend/migrations/081_migrate_notification_subscriptions_to_webhooks.sql
@@ -2,7 +2,10 @@
 -- into the webhooks table (System A) as part of the v1.1.9 webhooks v2 work
 -- (artifact-keeper#919, #927).
 --
--- Idempotency: re-running this migration produces no duplicate webhooks.
+-- Idempotency: enforced by a unique partial index on (url, repository_id)
+-- created BEFORE the INSERT below. The INSERT uses ON CONFLICT DO NOTHING
+-- so re-running this migration is a no-op even under concurrent runs. The
+-- prior NOT EXISTS guard was probabilistic; this is a hard constraint.
 -- A subscription is treated as already-migrated if a webhooks row exists
 -- with the same URL and the same repository_id (or both NULL for
 -- global-scoped subscriptions).
@@ -13,19 +16,29 @@
 -- they migrate. The actual System B removal lands in v1.2.0
 -- (artifact-keeper#920) once the deprecation window closes.
 --
--- Secrets: secret_hash is intentionally left empty. The notification
--- subscription's plaintext config.secret cannot safely be transcribed
--- into the webhooks.secret_hash column (which expects a hash, not a
--- plaintext secret), so customers must re-rotate the secret via the
--- webhooks rotate-secret endpoint to enable HMAC signing on the
--- migrated row. Webhooks with an empty secret still deliver, just
--- without a signature header.
+-- Secrets: secret_hash is intentionally left NULL. Migrated rows have
+-- NEITHER a bcrypt secret_hash NOR a secret_encrypted value. The
+-- notification subscription's plaintext config.secret cannot safely be
+-- transcribed into either column, so customers must call
+-- /api/v1/webhooks/{id}/rotate-secret to mint a fresh signing secret on
+-- the migrated row. Webhooks where both forms are NULL still deliver, but
+-- the retry path emits NO X-Webhook-Signature header so receivers can
+-- distinguish "configured but legacy/unsigned" from "actively signed".
 --
 -- Event-type mapping: notifications use dot-separated names
 -- (artifact.uploaded), webhooks use underscore-separated names
 -- (artifact_uploaded). The CASE expression below mirrors
 -- backend/src/services/notification_dispatcher.rs::
--- NOTIFICATION_TO_WEBHOOK_EVENT_MAP. Keep both in sync.
+-- NOTIFICATION_TO_WEBHOOK_EVENT_MAP. Keep both in sync; the unit test
+-- `notification_dispatcher::tests::test_migration_081_case_matches_rust_map`
+-- regex-extracts the WHEN/THEN pairs from this file and asserts they equal
+-- the Rust constant.
+
+-- Idempotency guard: hard uniqueness on (url, repository_id) treating NULL
+-- repository_id as a synthetic zero-UUID so the constraint covers both
+-- repo-scoped and global-scoped webhooks.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhooks_url_repo_unique
+    ON webhooks (url, COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::uuid));
 
 INSERT INTO webhooks (
     id,
@@ -44,7 +57,7 @@ SELECT
     gen_random_uuid(),
     'Migrated from notification ' || ns.id::text AS name,
     (ns.config->>'url')::text AS url,
-    '' AS secret_hash,
+    NULL AS secret_hash,
     ARRAY(
         SELECT
             CASE
@@ -69,10 +82,4 @@ SELECT
 FROM notification_subscriptions ns
 WHERE ns.channel = 'webhook'
   AND (ns.config->>'url') IS NOT NULL
-  AND NOT EXISTS (
-      SELECT 1
-      FROM webhooks w
-      WHERE w.url = (ns.config->>'url')::text
-        AND COALESCE(w.repository_id, '00000000-0000-0000-0000-000000000000'::uuid)
-            = COALESCE(ns.repository_id, '00000000-0000-0000-0000-000000000000'::uuid)
-  );
+ON CONFLICT DO NOTHING;

--- a/backend/migrations/081_migrate_notification_subscriptions_to_webhooks.sql
+++ b/backend/migrations/081_migrate_notification_subscriptions_to_webhooks.sql
@@ -1,0 +1,78 @@
+-- Migrate notification_subscriptions (System B) rows where channel='webhook'
+-- into the webhooks table (System A) as part of the v1.1.9 webhooks v2 work
+-- (artifact-keeper#919, #927).
+--
+-- Idempotency: re-running this migration produces no duplicate webhooks.
+-- A subscription is treated as already-migrated if a webhooks row exists
+-- with the same URL and the same repository_id (or both NULL for
+-- global-scoped subscriptions).
+--
+-- Retention: existing notification_subscriptions rows are NOT deleted by
+-- this migration. System B continues to deliver notifications during the
+-- v1.1.9 deprecation window so customers do not lose deliveries while
+-- they migrate. The actual System B removal lands in v1.2.0
+-- (artifact-keeper#920) once the deprecation window closes.
+--
+-- Secrets: secret_hash is intentionally left empty. The notification
+-- subscription's plaintext config.secret cannot safely be transcribed
+-- into the webhooks.secret_hash column (which expects a hash, not a
+-- plaintext secret), so customers must re-rotate the secret via the
+-- webhooks rotate-secret endpoint to enable HMAC signing on the
+-- migrated row. Webhooks with an empty secret still deliver, just
+-- without a signature header.
+--
+-- Event-type mapping: notifications use dot-separated names
+-- (artifact.uploaded), webhooks use underscore-separated names
+-- (artifact_uploaded). The CASE expression below mirrors
+-- backend/src/services/notification_dispatcher.rs::
+-- NOTIFICATION_TO_WEBHOOK_EVENT_MAP. Keep both in sync.
+
+INSERT INTO webhooks (
+    id,
+    name,
+    url,
+    secret_hash,
+    events,
+    is_enabled,
+    repository_id,
+    headers,
+    payload_template,
+    created_at,
+    updated_at
+)
+SELECT
+    gen_random_uuid(),
+    'Migrated from notification ' || ns.id::text AS name,
+    (ns.config->>'url')::text AS url,
+    '' AS secret_hash,
+    ARRAY(
+        SELECT
+            CASE
+                WHEN e = 'artifact.uploaded' THEN 'artifact_uploaded'
+                WHEN e = 'artifact.deleted' THEN 'artifact_deleted'
+                WHEN e = 'scan.completed' THEN 'scan_completed'
+                WHEN e = 'scan.vulnerability_found' THEN 'scan_vulnerability_found'
+                WHEN e = 'repository.updated' THEN 'repository_updated'
+                WHEN e = 'repository.deleted' THEN 'repository_deleted'
+                WHEN e = 'build.completed' THEN 'build_completed'
+                WHEN e = 'build.failed' THEN 'build_failed'
+                ELSE e
+            END
+        FROM unnest(ns.event_types) AS e
+    ) AS events,
+    ns.enabled AS is_enabled,
+    ns.repository_id,
+    '{}'::jsonb AS headers,
+    'generic' AS payload_template,
+    ns.created_at,
+    NOW() AS updated_at
+FROM notification_subscriptions ns
+WHERE ns.channel = 'webhook'
+  AND (ns.config->>'url') IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM webhooks w
+      WHERE w.url = (ns.config->>'url')::text
+        AND COALESCE(w.repository_id, '00000000-0000-0000-0000-000000000000'::uuid)
+            = COALESCE(ns.repository_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  );

--- a/backend/migrations/082_email_subscriptions_table.sql
+++ b/backend/migrations/082_email_subscriptions_table.sql
@@ -1,0 +1,59 @@
+-- Create the dedicated email_subscriptions table and seed it from the
+-- existing notification_subscriptions rows where channel='email'
+-- (artifact-keeper#919, #927).
+--
+-- Schema mirrors notification_subscriptions but trims the channel column
+-- (always email) and lifts the recipients array out of the jsonb config
+-- column for cheaper indexing and validation. The notification_dispatcher
+-- continues to read from notification_subscriptions in v1.1.9, so this
+-- table is populated but not yet authoritative. The dedicated email
+-- producer that consumes this table will land alongside the v1.2.0
+-- System B removal (artifact-keeper#920).
+--
+-- Idempotency: the seed step uses the existing subscription id as the
+-- email_subscriptions id, so re-running this migration is a no-op via
+-- the NOT EXISTS guard.
+
+CREATE TABLE email_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repository_id UUID REFERENCES repositories(id) ON DELETE CASCADE,
+    recipients TEXT[] NOT NULL,
+    event_types TEXT[] NOT NULL DEFAULT '{}',
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_email_subscriptions_repo
+    ON email_subscriptions(repository_id)
+    WHERE repository_id IS NOT NULL;
+
+CREATE INDEX idx_email_subscriptions_enabled
+    ON email_subscriptions(enabled)
+    WHERE enabled = true;
+
+-- Seed from notification_subscriptions where channel='email'.
+INSERT INTO email_subscriptions (
+    id,
+    repository_id,
+    recipients,
+    event_types,
+    enabled,
+    created_at,
+    updated_at
+)
+SELECT
+    ns.id,
+    ns.repository_id,
+    ARRAY(SELECT jsonb_array_elements_text(ns.config->'recipients')) AS recipients,
+    ns.event_types,
+    ns.enabled,
+    ns.created_at,
+    ns.updated_at
+FROM notification_subscriptions ns
+WHERE ns.channel = 'email'
+  AND ns.config ? 'recipients'
+  AND jsonb_typeof(ns.config->'recipients') = 'array'
+  AND NOT EXISTS (
+      SELECT 1 FROM email_subscriptions es WHERE es.id = ns.id
+  );

--- a/backend/src/api/handlers/notifications.rs
+++ b/backend/src/api/handlers/notifications.rs
@@ -4,9 +4,18 @@
 //! subscriptions scoped to a repository. Each subscription specifies a delivery
 //! channel (email or webhook), a set of event types to listen for, and
 //! channel-specific configuration (recipient addresses, webhook URLs, etc.).
+//!
+//! # Deprecation
+//!
+//! These endpoints are deprecated as of v1.1.9 in favour of the dedicated
+//! `/api/v1/webhooks` API (System A). Every response carries RFC 8594
+//! deprecation headers (`Deprecation`, `Sunset`, `Link`) so clients can detect
+//! the migration window programmatically. Removal is tracked under
+//! artifact-keeper#920 (v1.2.0).
 
 use axum::{
     extract::{Path, State},
+    response::Response,
     routing::get,
     Json, Router,
 };
@@ -22,10 +31,33 @@ use crate::error::{AppError, Result};
 use crate::services::repository_service::RepositoryService;
 
 // ---------------------------------------------------------------------------
+// Deprecation header constants (RFC 8594)
+// ---------------------------------------------------------------------------
+
+/// `Deprecation` header value. Per RFC 8594, the value `true` indicates the
+/// resource is deprecated without specifying when the deprecation took effect.
+pub(crate) const DEPRECATION_HEADER_VALUE: &str = "true";
+
+/// `Sunset` header value. The notifications subscription endpoints are
+/// scheduled for removal in v1.2.0 (target: 2026-08-01). Date is fixed at
+/// compile time, not derived at runtime, so the header is stable across
+/// requests and instances.
+pub(crate) const SUNSET_HEADER_VALUE: &str = "Sat, 01 Aug 2026 00:00:00 GMT";
+
+/// `Link` header pointing at the successor API. Clients should migrate to the
+/// `/api/v1/webhooks` endpoints documented at the linked URL.
+pub(crate) const SUCCESSOR_LINK_HEADER_VALUE: &str =
+    "<https://artifactkeeper.com/docs/advanced/webhooks>; rel=\"successor-version\"";
+
+// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
-/// Routes nested under /api/v1/repositories/:key/notifications
+/// Routes nested under /api/v1/repositories/:key/notifications.
+///
+/// Every response from these routes carries RFC 8594 deprecation headers
+/// (`Deprecation`, `Sunset`, `Link`) advertising the v1.2.0 sunset window and
+/// the successor API.
 pub fn repo_notifications_router() -> Router<SharedState> {
     Router::new()
         .route(
@@ -36,6 +68,29 @@ pub fn repo_notifications_router() -> Router<SharedState> {
             "/:key/notifications/:subscription_id",
             axum::routing::delete(delete_subscription),
         )
+        .layer(axum::middleware::map_response(deprecation_headers))
+}
+
+/// Inject RFC 8594 deprecation headers on every response.
+///
+/// Applied as a `tower::map_response` layer over the notifications router so
+/// every endpoint (POST/GET/DELETE) and every status code (2xx, 4xx, 5xx)
+/// surfaces the same `Deprecation`, `Sunset`, and `Link` headers.
+async fn deprecation_headers(mut response: Response) -> Response {
+    let headers = response.headers_mut();
+    // .parse() on these &'static str values cannot fail because they are
+    // valid header values, but unwrap_or keeps the response on the happy path
+    // even if a future edit introduces an invalid byte.
+    if let Ok(v) = DEPRECATION_HEADER_VALUE.parse() {
+        headers.insert("deprecation", v);
+    }
+    if let Ok(v) = SUNSET_HEADER_VALUE.parse() {
+        headers.insert("sunset", v);
+    }
+    if let Ok(v) = SUCCESSOR_LINK_HEADER_VALUE.parse() {
+        headers.insert("link", v);
+    }
+    response
 }
 
 // ---------------------------------------------------------------------------
@@ -610,5 +665,109 @@ mod tests {
         let req: CreateNotificationSubscriptionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.channel, "webhook");
         assert_eq!(req.event_types.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Deprecation headers (RFC 8594)
+    // -----------------------------------------------------------------------
+
+    use axum::{body::Body, http::Request, routing::get as axum_get, Router};
+    use tower::ServiceExt;
+
+    /// Build a no-DB router that mirrors how the deprecation middleware is
+    /// layered in `repo_notifications_router` so we can assert headers
+    /// without standing up SharedState. Every test handler returns a fixed
+    /// status, then the middleware should overlay the headers regardless.
+    fn deprecation_test_router() -> Router {
+        Router::new()
+            .route("/:key/notifications", axum_get(|| async { "ok-list" }))
+            .route(
+                "/:key/notifications/post",
+                axum::routing::post(|| async { "ok-create" }),
+            )
+            .route(
+                "/:key/notifications/:subscription_id",
+                axum::routing::delete(|| async { axum::http::StatusCode::NO_CONTENT }),
+            )
+            .route(
+                "/:key/notifications/error",
+                axum_get(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
+            )
+            .layer(axum::middleware::map_response(deprecation_headers))
+    }
+
+    async fn fetch(method: &str, uri: &str) -> axum::response::Response {
+        let req = Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+        deprecation_test_router().oneshot(req).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_header_present_on_get() {
+        let resp = fetch("GET", "/myrepo/notifications").await;
+        assert_eq!(resp.headers().get("deprecation").unwrap(), "true");
+    }
+
+    #[tokio::test]
+    async fn test_sunset_header_present_on_get() {
+        let resp = fetch("GET", "/myrepo/notifications").await;
+        assert_eq!(
+            resp.headers().get("sunset").unwrap(),
+            "Sat, 01 Aug 2026 00:00:00 GMT"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_link_header_present_on_get() {
+        let resp = fetch("GET", "/myrepo/notifications").await;
+        let link = resp.headers().get("link").unwrap().to_str().unwrap();
+        assert!(link.contains("rel=\"successor-version\""));
+        assert!(link.contains("artifactkeeper.com/docs/advanced/webhooks"));
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_headers_present_on_post() {
+        let resp = fetch("POST", "/myrepo/notifications/post").await;
+        assert_eq!(resp.headers().get("deprecation").unwrap(), "true");
+        assert!(resp.headers().get("sunset").is_some());
+        assert!(resp.headers().get("link").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_headers_present_on_delete() {
+        let resp = fetch(
+            "DELETE",
+            "/myrepo/notifications/00000000-0000-0000-0000-000000000000",
+        )
+        .await;
+        assert_eq!(resp.headers().get("deprecation").unwrap(), "true");
+        assert!(resp.headers().get("sunset").is_some());
+        assert!(resp.headers().get("link").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_headers_present_on_error_responses() {
+        // Per RFC 8594, deprecation signalling must apply to error responses too
+        // so a client probing a deprecated endpoint can detect deprecation
+        // even if the request fails.
+        let resp = fetch("GET", "/myrepo/notifications/error").await;
+        assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.headers().get("deprecation").unwrap(), "true");
+        assert!(resp.headers().get("sunset").is_some());
+        assert!(resp.headers().get("link").is_some());
+    }
+
+    #[test]
+    fn test_deprecation_constants_are_stable() {
+        // These values are part of the public deprecation contract. Changing
+        // them is a breaking change for clients that pin on the sunset date,
+        // so guard them with a unit test.
+        assert_eq!(DEPRECATION_HEADER_VALUE, "true");
+        assert_eq!(SUNSET_HEADER_VALUE, "Sat, 01 Aug 2026 00:00:00 GMT");
+        assert!(SUCCESSOR_LINK_HEADER_VALUE.starts_with('<'));
+        assert!(SUCCESSOR_LINK_HEADER_VALUE.contains("rel=\"successor-version\""));
     }
 }

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -798,6 +798,24 @@ pub async fn redeliver(
 /// current secret are accepted by the retry path during this window.
 const SECRET_ROTATION_OVERLAP: chrono::Duration = chrono::Duration::hours(24);
 
+/// Pure helper that mirrors the SQL WHERE clause guarding the rotate
+/// endpoint. Returns `true` iff a rotation should be allowed for a row
+/// whose `secret_previous_expires_at` column currently holds `previous`.
+///
+/// This exists so the unit tests can pin the rotation-window semantics
+/// without standing up a Postgres test harness. The SQL UPDATE in
+/// `rotate_webhook_secret` and this helper must agree.
+#[cfg(test)]
+pub(crate) fn rotation_guard_allows(
+    previous: Option<chrono::DateTime<chrono::Utc>>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    match previous {
+        None => true,
+        Some(expires_at) => expires_at < now,
+    }
+}
+
 /// Rotate the signing secret for a webhook.
 ///
 /// Generates a new raw secret, encrypts it, moves the existing
@@ -806,6 +824,13 @@ const SECRET_ROTATION_OVERLAP: chrono::Duration = chrono::Duration::hours(24);
 /// response body **once**. The HMAC signing path (added in a later ticket)
 /// signs deliveries with both secrets while the previous one is within
 /// its expiry window so consumers can rotate without dropped events.
+///
+/// If a previous-secret window is still active when the rotate request
+/// arrives, the request is REJECTED with HTTP 409 Conflict. This prevents
+/// two near-simultaneous rotations from clobbering the original
+/// `secret_previous_encrypted` material before the operator has finished
+/// distributing the previous new key. The 409 body is structured:
+/// `{"error": "rotation_already_in_progress", "expires_at": "<RFC3339>"}`.
 #[utoipa::path(
     post,
     path = "/{id}/rotate-secret",
@@ -817,6 +842,7 @@ const SECRET_ROTATION_OVERLAP: chrono::Duration = chrono::Duration::hours(24);
     responses(
         (status = 200, description = "Secret rotated. Body includes the new raw secret exactly once.", body = RotateWebhookSecretResponse),
         (status = 404, description = "Webhook not found"),
+        (status = 409, description = "A previous rotation overlap window is still active"),
         (status = 500, description = "Encryption key not configured")
     ),
     security(("bearer_auth" = []))
@@ -825,7 +851,9 @@ pub async fn rotate_webhook_secret(
     State(state): State<SharedState>,
     Extension(_auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
-) -> Result<Json<RotateWebhookSecretResponse>> {
+) -> Result<axum::response::Response> {
+    use axum::response::IntoResponse;
+
     let new_secret = webhook_secret_crypto::generate_secret();
     let new_encrypted = webhook_secret_crypto::encrypt_secret(&new_secret).map_err(|e| {
         tracing::error!("webhook secret encryption failed during rotation: {}", e);
@@ -835,6 +863,11 @@ pub async fn rotate_webhook_secret(
     let now = chrono::Utc::now();
     let previous_expires_at = now + SECRET_ROTATION_OVERLAP;
 
+    // Conditional UPDATE: only proceed if no rotation overlap is currently
+    // active. A row passes the guard when its `secret_previous_expires_at`
+    // is NULL (never rotated, or the cleanup job has already cleared it)
+    // or already in the past. If the WHERE clause excludes the row we get
+    // 0 rows updated and respond 409 with the active expiry timestamp.
     let updated = sqlx::query_scalar::<_, Uuid>(
         r#"
         UPDATE webhooks
@@ -849,6 +882,7 @@ pub async fn rotate_webhook_secret(
             secret_rotation_started_at  = $5,
             updated_at                  = NOW()
         WHERE id = $1
+          AND (secret_previous_expires_at IS NULL OR secret_previous_expires_at < NOW())
         RETURNING id
         "#,
     )
@@ -862,7 +896,39 @@ pub async fn rotate_webhook_secret(
     .map_err(|e| AppError::Database(e.to_string()))?;
 
     if updated.is_none() {
-        return Err(AppError::NotFound("Webhook not found".to_string()));
+        // Either the row is missing or the rotation guard failed. Disambiguate
+        // by reading the row's `secret_previous_expires_at` directly; the read
+        // is cheap and the 409 body needs the active expiry timestamp anyway.
+        let active = sqlx::query_scalar::<_, Option<chrono::DateTime<chrono::Utc>>>(
+            "SELECT secret_previous_expires_at FROM webhooks WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        return match active {
+            None => Err(AppError::NotFound("Webhook not found".to_string())),
+            Some(maybe_expires) => match maybe_expires {
+                Some(expires_at) if expires_at >= chrono::Utc::now() => {
+                    let body = serde_json::json!({
+                        "error": "rotation_already_in_progress",
+                        "expires_at": expires_at,
+                    });
+                    Ok((axum::http::StatusCode::CONFLICT, Json(body)).into_response())
+                }
+                // Should not happen: a NULL or past expiry means the UPDATE
+                // would have succeeded. Fall back to a generic 409 rather
+                // than racing again automatically.
+                _ => {
+                    let body = serde_json::json!({
+                        "error": "rotation_already_in_progress",
+                        "expires_at": serde_json::Value::Null,
+                    });
+                    Ok((axum::http::StatusCode::CONFLICT, Json(body)).into_response())
+                }
+            },
+        };
     }
 
     Ok(Json(RotateWebhookSecretResponse {
@@ -870,7 +936,8 @@ pub async fn rotate_webhook_secret(
         secret: new_secret,
         secret_digest: new_digest,
         previous_secret_expires_at: previous_expires_at,
-    }))
+    })
+    .into_response())
 }
 
 /// Background-task entry point: clear expired previous-secret material so
@@ -901,6 +968,24 @@ pub async fn cleanup_expired_previous_secrets(
 /// link-local addresses (AWS/cloud metadata), and known internal hostnames.
 pub(crate) fn validate_webhook_url(url_str: &str) -> Result<()> {
     crate::api::validation::validate_outbound_url(url_str, "Webhook URL")
+}
+
+/// Whether a webhook row carries any form of signing secret.
+///
+/// `secret_encrypted` (AES-GCM, E1) is the authoritative new form. The
+/// legacy bcrypt `secret_hash` column is kept around so pre-v1.1.9 rows
+/// that have not yet been rotated continue to advertise that they are
+/// configured for signing. Returns `true` iff at least one form is set
+/// to a non-empty value. Rows where both are NULL or empty are treated
+/// as "no signing configured" and the retry path omits the
+/// `X-Webhook-Signature` header entirely.
+pub(crate) fn has_signing_secret(
+    secret_hash: &Option<String>,
+    secret_encrypted: Option<&[u8]>,
+) -> bool {
+    let hash_present = secret_hash.as_deref().is_some_and(|s| !s.is_empty());
+    let enc_present = secret_encrypted.is_some_and(|b| !b.is_empty());
+    hash_present || enc_present
 }
 
 /// Calculate retry delay in seconds for webhook delivery.
@@ -1013,10 +1098,16 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
         .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
 
     for delivery in &rows {
-        // Look up the webhook URL and headers (using sqlx::query, not the macro,
-        // because the WHERE clause differs from the cached version)
+        // Look up the webhook URL, headers, and both signing-secret forms
+        // (using sqlx::query, not the macro, because the WHERE clause differs
+        // from the cached version). The retry path treats `secret_encrypted`
+        // (E1, AES-GCM) as authoritative for new rows and falls back to the
+        // legacy bcrypt `secret_hash` for un-rotated pre-v1.1.9 webhooks.
+        // Migration 081 leaves both NULL on rows it migrates so the operator
+        // is forced to rotate before signatures resume.
         let webhook_row = sqlx::query(
-            "SELECT url, headers, secret_hash FROM webhooks WHERE id = $1 AND is_enabled = true",
+            "SELECT url, headers, secret_hash, secret_encrypted \
+             FROM webhooks WHERE id = $1 AND is_enabled = true",
         )
         .bind(delivery.webhook_id)
         .fetch_optional(db)
@@ -1039,6 +1130,7 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
         let url: String = webhook_row.get("url");
         let headers: Option<serde_json::Value> = webhook_row.get("headers");
         let secret_hash: Option<String> = webhook_row.get("secret_hash");
+        let secret_encrypted: Option<Vec<u8>> = webhook_row.get("secret_encrypted");
 
         // Validate URL before delivery (SSRF prevention)
         if validate_webhook_url(&url).is_err() {
@@ -1074,7 +1166,14 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
             }
         }
 
-        if secret_hash.is_some() {
+        // Emit the signature header iff EITHER form of signing secret is
+        // configured. The actual HMAC is wired up in E2; today we still
+        // emit the placeholder string so the wire contract (header presence
+        // means "signing configured") is stable. Rows where BOTH forms are
+        // NULL (e.g. notifications migrated by migration 081 before the
+        // operator rotates) MUST NOT emit this header so receivers can
+        // distinguish "signing configured" from "legacy unsigned".
+        if has_signing_secret(&secret_hash, secret_encrypted.as_deref()) {
             request = request.header("X-Webhook-Signature", "hmac-signature");
         }
 
@@ -1427,6 +1526,49 @@ mod tests {
     }
 
     #[test]
+    fn test_webhook_response_omits_secret_material_keys() {
+        // Write-once contract: GET/LIST responses must NEVER include the
+        // raw secret, the encrypted blob, the previous-secret blob, or the
+        // legacy bcrypt hash. The serialized form is allowed to carry
+        // `secret_digest` (a non-reversible last-4 indicator) and
+        // `secret_rotation_active` (a boolean), nothing else secret-related.
+        let resp = WebhookResponse {
+            id: Uuid::nil(),
+            name: "test".to_string(),
+            url: "https://example.com/hook".to_string(),
+            events: vec!["artifact_uploaded".to_string()],
+            is_enabled: true,
+            repository_id: None,
+            headers: None,
+            payload_template: PayloadTemplate::Generic,
+            secret_digest: Some("whsec_...abcd".to_string()),
+            secret_rotation_active: false,
+            last_triggered_at: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        let obj = json
+            .as_object()
+            .expect("WebhookResponse serializes to object");
+        let forbidden_keys = [
+            "secret",
+            "secret_encrypted",
+            "secret_previous_encrypted",
+            "secret_hash",
+            "secret_previous_expires_at",
+            "secret_rotation_started_at",
+        ];
+        for key in forbidden_keys {
+            assert!(
+                !obj.contains_key(key),
+                "WebhookResponse must not serialize key `{}`; got keys: {:?}",
+                key,
+                obj.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
     fn test_test_webhook_response_serialization() {
         let resp = TestWebhookResponse {
             success: true,
@@ -1613,5 +1755,146 @@ mod tests {
     #[test]
     fn test_is_delivery_success_199() {
         assert!(!is_webhook_delivery_success(199));
+    }
+
+    // -----------------------------------------------------------------------
+    // has_signing_secret: unified gate for X-Webhook-Signature header
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_has_signing_secret_neither_form() {
+        // Migration 081 leaves both NULL. The retry path must NOT advertise
+        // a signature header for these rows.
+        assert!(!has_signing_secret(&None, None));
+    }
+
+    #[test]
+    fn test_has_signing_secret_legacy_bcrypt_only() {
+        // Pre-v1.1.9 rows that have not been rotated yet have only the
+        // legacy bcrypt hash; the gate still considers them configured.
+        let bcrypt_hash = Some("$2b$12$abcdefghijklmnop".to_string());
+        assert!(has_signing_secret(&bcrypt_hash, None));
+    }
+
+    #[test]
+    fn test_has_signing_secret_encrypted_only() {
+        // New rows from `create_webhook` populate `secret_encrypted` only.
+        let ct: &[u8] = b"\x00\x01\x02ciphertext";
+        assert!(has_signing_secret(&None, Some(ct)));
+    }
+
+    #[test]
+    fn test_has_signing_secret_both_forms() {
+        // Mid-migration rows can briefly carry both. Still configured.
+        let bcrypt_hash = Some("$2b$12$abcdefghijklmnop".to_string());
+        let ct: &[u8] = b"ciphertext";
+        assert!(has_signing_secret(&bcrypt_hash, Some(ct)));
+    }
+
+    #[test]
+    fn test_has_signing_secret_empty_strings_treated_as_absent() {
+        // Defensive: an empty string in secret_hash (e.g. older rows from
+        // the prior migration variant) is not a valid hash and must NOT
+        // count as signing-configured.
+        let empty_hash = Some(String::new());
+        let empty_bytes: &[u8] = b"";
+        assert!(!has_signing_secret(&empty_hash, Some(empty_bytes)));
+        assert!(!has_signing_secret(&empty_hash, None));
+        assert!(!has_signing_secret(&None, Some(empty_bytes)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Rotation overlap window: pure-function semantics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rotation_overlap_constant_is_24_hours() {
+        // The integration contract documented in the PR body and the
+        // operator docs says 24 hours. Tying it down here means a future
+        // edit cannot silently change the window from under callers.
+        assert_eq!(SECRET_ROTATION_OVERLAP, chrono::Duration::hours(24));
+    }
+
+    #[test]
+    fn test_rotation_guard_allows_when_no_previous() {
+        // A row that has never been rotated has NULL previous-expiry.
+        let now = chrono::Utc::now();
+        assert!(rotation_guard_allows(None, now));
+    }
+
+    #[test]
+    fn test_rotation_guard_allows_when_previous_already_expired() {
+        // The cleanup tick may not have fired yet, but logically the
+        // overlap window has closed: rotation is fine.
+        let now = chrono::Utc::now();
+        let an_hour_ago = now - chrono::Duration::hours(1);
+        assert!(rotation_guard_allows(Some(an_hour_ago), now));
+    }
+
+    #[test]
+    fn test_rotation_guard_blocks_when_previous_still_active() {
+        // Mid-overlap: a second rotation must NOT be allowed; the API
+        // returns 409 Conflict.
+        let now = chrono::Utc::now();
+        let in_three_hours = now + chrono::Duration::hours(3);
+        assert!(!rotation_guard_allows(Some(in_three_hours), now));
+    }
+
+    #[test]
+    fn test_rotation_guard_boundary_now_is_blocked() {
+        // Strict `<` in the SQL means a row whose previous expiry equals
+        // now is still considered active. Mirror that here.
+        let now = chrono::Utc::now();
+        assert!(!rotation_guard_allows(Some(now), now));
+    }
+
+    #[test]
+    fn test_rotation_overlap_window_math() {
+        // The `previous_expires_at = now + SECRET_ROTATION_OVERLAP` formula
+        // used in the rotate handler. Lock the math down so a future
+        // refactor cannot accidentally use minutes vs hours.
+        let now = chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let previous_expires_at = now + SECRET_ROTATION_OVERLAP;
+        assert_eq!(
+            previous_expires_at,
+            chrono::DateTime::parse_from_rfc3339("2026-04-28T12:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)
+        );
+        // Second rotate within the window is blocked.
+        assert!(!rotation_guard_allows(Some(previous_expires_at), now));
+        // After the window closes, rotate is allowed again.
+        let after = previous_expires_at + chrono::Duration::seconds(1);
+        assert!(rotation_guard_allows(Some(previous_expires_at), after));
+    }
+
+    // -----------------------------------------------------------------------
+    // Cleanup tick semantics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cleanup_predicate_matches_only_expired_rows() {
+        // The SQL in `cleanup_expired_previous_secrets` uses the predicate
+        // `secret_previous_expires_at <= NOW()`. Pure-function expression
+        // of that predicate so callers can unit-test their inputs without
+        // a database. A row is cleared iff it has a previous expiry AND
+        // that expiry is in the past or now.
+        fn would_clear(
+            expires_at: Option<chrono::DateTime<chrono::Utc>>,
+            now: chrono::DateTime<chrono::Utc>,
+        ) -> bool {
+            matches!(expires_at, Some(t) if t <= now)
+        }
+        let now = chrono::Utc::now();
+        // Row with no previous: never cleared.
+        assert!(!would_clear(None, now));
+        // Row with future expiry: not cleared.
+        assert!(!would_clear(Some(now + chrono::Duration::hours(1)), now));
+        // Row at exactly now: cleared (<=).
+        assert!(would_clear(Some(now), now));
+        // Row in the past: cleared.
+        assert!(would_clear(Some(now - chrono::Duration::seconds(1)), now));
     }
 }

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -13,6 +13,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::webhook_payloads::{self, PayloadTemplate};
+use crate::services::webhook_secret_crypto;
 
 /// Create webhook routes
 pub fn router() -> Router<SharedState> {
@@ -22,6 +23,7 @@ pub fn router() -> Router<SharedState> {
         .route("/:id/enable", post(enable_webhook))
         .route("/:id/disable", post(disable_webhook))
         .route("/:id/test", post(test_webhook))
+        .route("/:id/rotate-secret", post(rotate_webhook_secret))
         .route("/:id/deliveries", get(list_deliveries))
         .route("/:id/deliveries/:delivery_id/redeliver", post(redeliver))
 }
@@ -70,6 +72,9 @@ pub struct CreateWebhookRequest {
     pub name: String,
     pub url: String,
     pub events: Vec<String>,
+    /// Optional caller-supplied secret. When omitted the server generates a
+    /// fresh `whsec_*` secret. Either way the raw value is returned in the
+    /// 201 response body exactly once and is unrecoverable thereafter.
     pub secret: Option<String>,
     pub repository_id: Option<Uuid>,
     #[schema(value_type = Option<Object>)]
@@ -90,8 +95,40 @@ pub struct WebhookResponse {
     #[schema(value_type = Option<Object>)]
     pub headers: Option<serde_json::Value>,
     pub payload_template: PayloadTemplate,
+    /// Short non-reversible identifier for the current signing secret
+    /// (`whsec_...abcd`), suitable for display in operator UIs. The raw
+    /// secret is never returned by GET or LIST.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_digest: Option<String>,
+    /// True while a previous secret is still accepted by the retry path
+    /// during a rotation overlap window.
+    #[serde(default)]
+    pub secret_rotation_active: bool,
     pub last_triggered_at: Option<chrono::DateTime<chrono::Utc>>,
     pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Response returned exactly once when a webhook is created or its secret
+/// is rotated. The raw `secret` value is not retrievable afterwards.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WebhookSecretCreatedResponse {
+    #[serde(flatten)]
+    pub webhook: WebhookResponse,
+    /// Raw signing secret. Display this to the operator immediately and
+    /// instruct them to record it; the server retains only the encrypted
+    /// form and a short digest.
+    pub secret: String,
+}
+
+/// Response returned by the rotate-secret endpoint.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RotateWebhookSecretResponse {
+    pub id: Uuid,
+    /// Raw signing secret produced by this rotation. Shown exactly once.
+    pub secret: String,
+    pub secret_digest: String,
+    /// When the previously active secret stops being accepted.
+    pub previous_secret_expires_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -126,7 +163,8 @@ pub async fn list_webhooks(
     let webhooks = sqlx::query(
         r#"
         SELECT id, name, url, events, is_enabled, repository_id, headers,
-               payload_template, last_triggered_at, created_at
+               payload_template, secret_digest, secret_previous_expires_at,
+               last_triggered_at, created_at
         FROM webhooks
         WHERE ($1::uuid IS NULL OR repository_id = $1)
           AND ($2::boolean IS NULL OR is_enabled = $2)
@@ -162,6 +200,8 @@ pub async fn list_webhooks(
         .into_iter()
         .map(|w| {
             let tpl: String = w.get("payload_template");
+            let prev_expires: Option<chrono::DateTime<chrono::Utc>> =
+                w.get("secret_previous_expires_at");
             WebhookResponse {
                 id: w.get("id"),
                 name: w.get("name"),
@@ -171,6 +211,10 @@ pub async fn list_webhooks(
                 repository_id: w.get("repository_id"),
                 headers: w.get("headers"),
                 payload_template: PayloadTemplate::from_str_lossy(&tpl),
+                secret_digest: w.get("secret_digest"),
+                secret_rotation_active: prev_expires
+                    .map(|e| e > chrono::Utc::now())
+                    .unwrap_or(false),
                 last_triggered_at: w.get("last_triggered_at"),
                 created_at: w.get("created_at"),
             }
@@ -180,7 +224,12 @@ pub async fn list_webhooks(
     Ok(Json(WebhookListResponse { items, total }))
 }
 
-/// Create webhook
+/// Create webhook.
+///
+/// Generates a fresh signing secret (or accepts a caller-supplied one),
+/// encrypts it at rest, and returns the raw secret in the response body
+/// **once**. After this call, GET on the webhook returns only
+/// `secret_digest`, never the raw secret.
 #[utoipa::path(
     post,
     path = "",
@@ -188,7 +237,7 @@ pub async fn list_webhooks(
     tag = "webhooks",
     request_body = CreateWebhookRequest,
     responses(
-        (status = 200, description = "Webhook created successfully", body = WebhookResponse),
+        (status = 200, description = "Webhook created. Body includes the raw secret exactly once.", body = WebhookSecretCreatedResponse),
         (status = 422, description = "Validation error"),
         (status = 500, description = "Internal server error")
     ),
@@ -198,7 +247,7 @@ pub async fn create_webhook(
     State(state): State<SharedState>,
     Extension(_auth): Extension<AuthExtension>,
     Json(payload): Json<CreateWebhookRequest>,
-) -> Result<Json<WebhookResponse>> {
+) -> Result<Json<WebhookSecretCreatedResponse>> {
     // Validate URL (SSRF prevention)
     validate_webhook_url(&payload.url)?;
 
@@ -209,37 +258,49 @@ pub async fn create_webhook(
         ));
     }
 
-    // Hash secret if provided
-    let secret_hash = if let Some(ref secret) = payload.secret {
-        Some(crate::services::auth_service::AuthService::hash_password(secret).await?)
-    } else {
-        None
-    };
+    // Use the caller-provided secret if any, otherwise generate one.
+    let raw_secret = payload
+        .secret
+        .clone()
+        .unwrap_or_else(webhook_secret_crypto::generate_secret);
+
+    // Encrypt at rest.
+    let secret_encrypted = webhook_secret_crypto::encrypt_secret(&raw_secret).map_err(|e| {
+        tracing::error!("webhook secret encryption failed: {}", e);
+        AppError::Internal("webhook secret encryption is not configured".to_string())
+    })?;
+    let secret_digest = webhook_secret_crypto::digest_for_display(&raw_secret);
 
     use sqlx::Row;
 
     let template_str = payload.payload_template.to_string();
     let webhook = sqlx::query(
         r#"
-        INSERT INTO webhooks (name, url, events, secret_hash, repository_id, headers, payload_template)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        INSERT INTO webhooks
+            (name, url, events, repository_id, headers, payload_template,
+             secret_encrypted, secret_digest)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING id, name, url, events, is_enabled, repository_id, headers,
-                  payload_template, last_triggered_at, created_at
+                  payload_template, secret_digest, secret_previous_expires_at,
+                  last_triggered_at, created_at
         "#,
     )
     .bind(&payload.name)
     .bind(&payload.url)
     .bind(&payload.events)
-    .bind(&secret_hash)
     .bind(payload.repository_id)
     .bind(&payload.headers)
     .bind(&template_str)
+    .bind(&secret_encrypted)
+    .bind(&secret_digest)
     .fetch_one(&state.db)
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
 
     let tpl: String = webhook.get("payload_template");
-    Ok(Json(WebhookResponse {
+    let prev_expires: Option<chrono::DateTime<chrono::Utc>> =
+        webhook.get("secret_previous_expires_at");
+    let response = WebhookResponse {
         id: webhook.get("id"),
         name: webhook.get("name"),
         url: webhook.get("url"),
@@ -248,8 +309,17 @@ pub async fn create_webhook(
         repository_id: webhook.get("repository_id"),
         headers: webhook.get("headers"),
         payload_template: PayloadTemplate::from_str_lossy(&tpl),
+        secret_digest: webhook.get("secret_digest"),
+        secret_rotation_active: prev_expires
+            .map(|e| e > chrono::Utc::now())
+            .unwrap_or(false),
         last_triggered_at: webhook.get("last_triggered_at"),
         created_at: webhook.get("created_at"),
+    };
+
+    Ok(Json(WebhookSecretCreatedResponse {
+        webhook: response,
+        secret: raw_secret,
     }))
 }
 
@@ -277,7 +347,8 @@ pub async fn get_webhook(
     let webhook = sqlx::query(
         r#"
         SELECT id, name, url, events, is_enabled, repository_id, headers,
-               payload_template, last_triggered_at, created_at
+               payload_template, secret_digest, secret_previous_expires_at,
+               last_triggered_at, created_at
         FROM webhooks
         WHERE id = $1
         "#,
@@ -289,6 +360,8 @@ pub async fn get_webhook(
     .ok_or_else(|| AppError::NotFound("Webhook not found".to_string()))?;
 
     let tpl: String = webhook.get("payload_template");
+    let prev_expires: Option<chrono::DateTime<chrono::Utc>> =
+        webhook.get("secret_previous_expires_at");
     Ok(Json(WebhookResponse {
         id: webhook.get("id"),
         name: webhook.get("name"),
@@ -298,6 +371,10 @@ pub async fn get_webhook(
         repository_id: webhook.get("repository_id"),
         headers: webhook.get("headers"),
         payload_template: PayloadTemplate::from_str_lossy(&tpl),
+        secret_digest: webhook.get("secret_digest"),
+        secret_rotation_active: prev_expires
+            .map(|e| e > chrono::Utc::now())
+            .unwrap_or(false),
         last_triggered_at: webhook.get("last_triggered_at"),
         created_at: webhook.get("created_at"),
     }))
@@ -717,6 +794,107 @@ pub async fn redeliver(
     }))
 }
 
+/// Length of the rotation overlap window. Both the previous and the
+/// current secret are accepted by the retry path during this window.
+const SECRET_ROTATION_OVERLAP: chrono::Duration = chrono::Duration::hours(24);
+
+/// Rotate the signing secret for a webhook.
+///
+/// Generates a new raw secret, encrypts it, moves the existing
+/// `secret_encrypted` into `secret_previous_encrypted`, and stamps an
+/// expiry 24 hours in the future. The new raw secret is returned in the
+/// response body **once**. The HMAC signing path (added in a later ticket)
+/// signs deliveries with both secrets while the previous one is within
+/// its expiry window so consumers can rotate without dropped events.
+#[utoipa::path(
+    post,
+    path = "/{id}/rotate-secret",
+    context_path = "/api/v1/webhooks",
+    tag = "webhooks",
+    params(
+        ("id" = Uuid, Path, description = "Webhook ID")
+    ),
+    responses(
+        (status = 200, description = "Secret rotated. Body includes the new raw secret exactly once.", body = RotateWebhookSecretResponse),
+        (status = 404, description = "Webhook not found"),
+        (status = 500, description = "Encryption key not configured")
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn rotate_webhook_secret(
+    State(state): State<SharedState>,
+    Extension(_auth): Extension<AuthExtension>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<RotateWebhookSecretResponse>> {
+    let new_secret = webhook_secret_crypto::generate_secret();
+    let new_encrypted = webhook_secret_crypto::encrypt_secret(&new_secret).map_err(|e| {
+        tracing::error!("webhook secret encryption failed during rotation: {}", e);
+        AppError::Internal("webhook secret encryption is not configured".to_string())
+    })?;
+    let new_digest = webhook_secret_crypto::digest_for_display(&new_secret);
+    let now = chrono::Utc::now();
+    let previous_expires_at = now + SECRET_ROTATION_OVERLAP;
+
+    let updated = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        UPDATE webhooks
+        SET
+            secret_previous_encrypted   = secret_encrypted,
+            secret_previous_expires_at  = CASE
+                WHEN secret_encrypted IS NOT NULL THEN $2
+                ELSE NULL
+            END,
+            secret_encrypted            = $3,
+            secret_digest               = $4,
+            secret_rotation_started_at  = $5,
+            updated_at                  = NOW()
+        WHERE id = $1
+        RETURNING id
+        "#,
+    )
+    .bind(id)
+    .bind(previous_expires_at)
+    .bind(&new_encrypted)
+    .bind(&new_digest)
+    .bind(now)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    if updated.is_none() {
+        return Err(AppError::NotFound("Webhook not found".to_string()));
+    }
+
+    Ok(Json(RotateWebhookSecretResponse {
+        id,
+        secret: new_secret,
+        secret_digest: new_digest,
+        previous_secret_expires_at: previous_expires_at,
+    }))
+}
+
+/// Background-task entry point: clear expired previous-secret material so
+/// stale ciphertext does not linger past the rotation overlap window.
+///
+/// Returns the number of rows updated. Safe to call from a scheduler tick.
+pub async fn cleanup_expired_previous_secrets(
+    db: &sqlx::PgPool,
+) -> std::result::Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        r#"
+        UPDATE webhooks
+        SET secret_previous_encrypted  = NULL,
+            secret_previous_expires_at = NULL
+        WHERE secret_previous_encrypted IS NOT NULL
+          AND secret_previous_expires_at IS NOT NULL
+          AND secret_previous_expires_at <= NOW()
+        "#,
+    )
+    .execute(db)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Validate a webhook URL to prevent SSRF attacks.
 ///
 /// Blocks URLs pointing to private/internal networks, loopback addresses,
@@ -998,6 +1176,7 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
         enable_webhook,
         disable_webhook,
         test_webhook,
+        rotate_webhook_secret,
         list_deliveries,
         redeliver,
     ),
@@ -1006,6 +1185,8 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
         PayloadTemplate,
         CreateWebhookRequest,
         WebhookResponse,
+        WebhookSecretCreatedResponse,
+        RotateWebhookSecretResponse,
         WebhookListResponse,
         TestWebhookResponse,
         DeliveryResponse,
@@ -1233,6 +1414,8 @@ mod tests {
             repository_id: None,
             headers: None,
             payload_template: PayloadTemplate::Generic,
+            secret_digest: Some("whsec_...abcd".to_string()),
+            secret_rotation_active: false,
             last_triggered_at: None,
             created_at: chrono::Utc::now(),
         };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -472,6 +472,15 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     );
     tracing::info!("Notification dispatcher started");
 
+    // Start webhooks v2 producer: subscribes to EventBus and enqueues rows
+    // into webhook_deliveries. The retry scheduler (every 30s) drives
+    // actual HTTP delivery. See backend/src/services/webhook_producer.rs.
+    artifact_keeper_backend::services::webhook_producer::start_webhook_producer(
+        app_state.event_bus.clone(),
+        app_state.db.clone(),
+    );
+    tracing::info!("Webhook producer started");
+
     app_state
         .setup_required
         .store(setup_required, std::sync::atomic::Ordering::Relaxed);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -108,6 +108,24 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         .install_default()
         .expect("Failed to install rustls CryptoProvider");
 
+    // Resolve the shutdown token early so background workers spawned during
+    // startup (notification dispatcher, webhook producer) share the same
+    // cancellation source as the HTTP/gRPC servers spawned later. If the
+    // caller did not pass one (console mode) we create our own and bind it
+    // to the OS signal listener.
+    let runtime_shutdown_token = match shutdown_token {
+        Some(token) => token,
+        None => {
+            let token = CancellationToken::new();
+            let signal_token = token.clone();
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                signal_token.cancel();
+            });
+            token
+        }
+    };
+
     // Load environment variables
     if let Ok(env_file) = std::env::var("AK_ENV_FILE") {
         dotenvy::from_path(&env_file).ok();
@@ -464,6 +482,30 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         }
     }
 
+    // Validate the webhook signing-secret encryption key at boot. If the
+    // operator has set AK_WEBHOOK_SECRET_KEY but it is malformed, fail loud
+    // and early instead of letting create/rotate-secret return HTTP 500
+    // hours later. A missing key is also fatal: webhooks v2 cannot create
+    // or rotate secrets without it. Operators who want to run the backend
+    // without webhook support entirely can omit the key by also disabling
+    // the producer (WEBHOOKS_V2_PRODUCER_ENABLED=false, the default).
+    match artifact_keeper_backend::services::webhook_secret_crypto::ensure_configured() {
+        Ok(()) => tracing::info!("Webhook secret encryption key validated"),
+        Err(artifact_keeper_backend::services::webhook_secret_crypto::WebhookSecretError::KeyMissing) => {
+            tracing::warn!(
+                "AK_WEBHOOK_SECRET_KEY is not configured; webhook create and \
+                 rotate-secret endpoints will return HTTP 500 until it is set"
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                "AK_WEBHOOK_SECRET_KEY is set but invalid: {}; refusing to start",
+                e
+            );
+            std::process::exit(1);
+        }
+    }
+
     // Start notification dispatcher (subscribes to EventBus for email/webhook delivery)
     artifact_keeper_backend::services::notification_dispatcher::start_dispatcher(
         app_state.event_bus.clone(),
@@ -475,11 +517,25 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     // Start webhooks v2 producer: subscribes to EventBus and enqueues rows
     // into webhook_deliveries. The retry scheduler (every 30s) drives
     // actual HTTP delivery. See backend/src/services/webhook_producer.rs.
-    artifact_keeper_backend::services::webhook_producer::start_webhook_producer(
-        app_state.event_bus.clone(),
-        app_state.db.clone(),
-    );
-    tracing::info!("Webhook producer started");
+    //
+    // Gated behind WEBHOOKS_V2_PRODUCER_ENABLED (default off) so v1.1.9
+    // ships the dual-write code path dark. Operators flip the flag once
+    // they have rotated migrated webhook secrets and verified delivery.
+    let producer_enabled = std::env::var("WEBHOOKS_V2_PRODUCER_ENABLED")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+    if producer_enabled {
+        artifact_keeper_backend::services::webhook_producer::start_webhook_producer(
+            app_state.event_bus.clone(),
+            app_state.db.clone(),
+            runtime_shutdown_token.clone(),
+        );
+        tracing::info!("Webhook producer started (WEBHOOKS_V2_PRODUCER_ENABLED=true)");
+    } else {
+        tracing::info!(
+            "Webhook producer disabled (set WEBHOOKS_V2_PRODUCER_ENABLED=true to enable)"
+        );
+    }
 
     app_state
         .setup_required
@@ -605,23 +661,11 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
             }),
         );
 
-    // Shared cancellation token: when the shutdown signal fires, both the
-    // HTTP and gRPC servers are notified to stop accepting new connections
-    // and drain in-flight requests before the process exits.
-    let shutdown_token = match shutdown_token {
-        Some(token) => token,
-        None => {
-            // No external token provided (console mode). Create our own and
-            // spawn the signal listener that cancels it on SIGTERM / Ctrl+C.
-            let token = CancellationToken::new();
-            let signal_token = token.clone();
-            tokio::spawn(async move {
-                shutdown_signal().await;
-                signal_token.cancel();
-            });
-            token
-        }
-    };
+    // The concrete shutdown token used by all servers and background tasks
+    // is resolved earlier in run_server (see `runtime_shutdown_token`) so
+    // that long-lived workers (notification dispatcher, webhook producer)
+    // share the same cancellation source as the HTTP/gRPC servers.
+    let shutdown_token = runtime_shutdown_token.clone();
 
     // Start HTTP server
     let addr: SocketAddr = config.bind_address.parse()?;

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -62,6 +62,14 @@ pub fn record_webhook_delivery(event: &str, success: bool) {
     counter!("ak_webhook_deliveries_total", "event" => event.to_string(), "status" => status.to_string()).increment(1);
 }
 
+/// Record a webhook delivery row enqueued by the EventBus producer.
+/// Distinct from `record_webhook_delivery` so dashboards can separate
+/// "events that had matching subscribers" (enqueue count) from
+/// "actual HTTP deliveries" (delivery count, success+failure).
+pub fn record_webhook_delivery_enqueued(event: &str) {
+    counter!("ak_webhook_deliveries_enqueued_total", "event" => event.to_string()).increment(1);
+}
+
 /// Record an outbound URL that was rejected by SSRF validation, either
 /// at handler entry (`validate_outbound_url`) or on a redirect hop
 /// inside the shared HTTP client. `reason` is `"hostname"` or `"ip"`,

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -70,6 +70,20 @@ pub fn record_webhook_delivery_enqueued(event: &str) {
     counter!("ak_webhook_deliveries_enqueued_total", "event" => event.to_string()).increment(1);
 }
 
+/// Record a webhook delivery row that the producer failed to insert into
+/// `webhook_deliveries`. Counted distinctly from `enqueued_total` so an
+/// alert can fire on persistent insert failures (DB down, constraint
+/// violation, pool exhaustion) without polluting the success metric.
+/// `reason` is a short tag classifying the failure (e.g. `"db_error"`).
+pub fn record_webhook_delivery_enqueue_failed(event: &str, reason: &str) {
+    counter!(
+        "ak_webhook_deliveries_enqueue_failed_total",
+        "event" => event.to_string(),
+        "reason" => reason.to_string()
+    )
+    .increment(1);
+}
+
 /// Record an outbound URL that was rejected by SSRF validation, either
 /// at handler entry (`validate_outbound_url`) or on a redirect hop
 /// inside the shared HTTP client. `reason` is `"hostname"` or `"ip"`,

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -68,6 +68,7 @@ pub mod wasm_bindings;
 pub mod wasm_plugin_service;
 pub mod wasm_runtime;
 pub mod webhook_payloads;
+pub mod webhook_secret_crypto;
 
 // Observability & lifecycle
 pub mod analytics_service;

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -68,6 +68,7 @@ pub mod wasm_bindings;
 pub mod wasm_plugin_service;
 pub mod wasm_runtime;
 pub mod webhook_payloads;
+pub mod webhook_producer;
 pub mod webhook_secret_crypto;
 
 // Observability & lifecycle

--- a/backend/src/services/notification_dispatcher.rs
+++ b/backend/src/services/notification_dispatcher.rs
@@ -35,6 +35,29 @@ pub fn map_event_type(event_type: &str) -> &str {
     }
 }
 
+/// Lookup table used by the v1.1.9 data migration that copies
+/// `notification_subscriptions` rows (System B) into the `webhooks` table
+/// (System A).
+///
+/// Notification event types use dot-separated names
+/// (e.g. `artifact.uploaded`) while webhook event types use underscore
+/// names (e.g. `artifact_uploaded`). Each tuple is
+/// `(notification_event_type, webhook_event_type)`. This constant is the
+/// authoritative source for the equivalent SQL `CASE` expression in
+/// `migrations/081_migrate_notification_subscriptions_to_webhooks.sql`;
+/// keeping both in sync prevents migrated rows from drifting out of the
+/// webhook event vocabulary.
+pub const NOTIFICATION_TO_WEBHOOK_EVENT_MAP: &[(&str, &str)] = &[
+    ("artifact.uploaded", "artifact_uploaded"),
+    ("artifact.deleted", "artifact_deleted"),
+    ("scan.completed", "scan_completed"),
+    ("scan.vulnerability_found", "scan_vulnerability_found"),
+    ("repository.updated", "repository_updated"),
+    ("repository.deleted", "repository_deleted"),
+    ("build.completed", "build_completed"),
+    ("build.failed", "build_failed"),
+];
+
 /// Row type for notification subscription lookups.
 #[derive(Debug)]
 struct SubscriptionRow {
@@ -429,6 +452,57 @@ mod tests {
     #[test]
     fn test_map_event_type_empty_string() {
         assert_eq!(map_event_type(""), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // NOTIFICATION_TO_WEBHOOK_EVENT_MAP
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_notification_to_webhook_event_map_covers_all_valid_event_types() {
+        // Every event type the notifications API accepts must have a
+        // webhook equivalent so the data migration cannot drop events.
+        use crate::api::handlers::notifications::VALID_EVENT_TYPES;
+        for et in VALID_EVENT_TYPES {
+            assert!(
+                NOTIFICATION_TO_WEBHOOK_EVENT_MAP
+                    .iter()
+                    .any(|(n, _)| n == et),
+                "missing webhook mapping for notification event '{}'",
+                et
+            );
+        }
+    }
+
+    #[test]
+    fn test_notification_to_webhook_event_map_uses_underscore_names() {
+        // Webhook events use underscore-separated names; verify the map
+        // does not accidentally store a dot-form value on the webhook side.
+        for (_, webhook_name) in NOTIFICATION_TO_WEBHOOK_EVENT_MAP {
+            assert!(
+                !webhook_name.contains('.'),
+                "webhook event name '{}' must not contain a dot",
+                webhook_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_notification_to_webhook_event_map_artifact_uploaded() {
+        let webhook_name = NOTIFICATION_TO_WEBHOOK_EVENT_MAP
+            .iter()
+            .find(|(n, _)| *n == "artifact.uploaded")
+            .map(|(_, w)| *w);
+        assert_eq!(webhook_name, Some("artifact_uploaded"));
+    }
+
+    #[test]
+    fn test_notification_to_webhook_event_map_no_duplicate_keys() {
+        let mut seen: Vec<&str> = Vec::new();
+        for (n, _) in NOTIFICATION_TO_WEBHOOK_EVENT_MAP {
+            assert!(!seen.contains(n), "duplicate key in mapping: {}", n);
+            seen.push(n);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/notification_dispatcher.rs
+++ b/backend/src/services/notification_dispatcher.rs
@@ -505,6 +505,78 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_migration_081_case_matches_rust_map() {
+        // Drift fence: regex-extract every WHEN '<x>' THEN '<y>' pair from
+        // the migration's CASE expression and assert the set equals the
+        // Rust constant. Without this, a future migration edit can silently
+        // drop a mapping (or rename one) and the build will not catch it
+        // until customers report missing deliveries on the migrated rows.
+        const SQL: &str =
+            include_str!("../../migrations/081_migrate_notification_subscriptions_to_webhooks.sql");
+
+        // Hand-rolled scanner (no regex dep): line-oriented walk over the
+        // migration. For each line that starts (after trimming) with the
+        // word `WHEN`, find the first single-quoted literal and the first
+        // single-quoted literal AFTER the word `THEN`. The migration's CASE
+        // arms are written one per line; this pattern matches them and
+        // ignores any other quoted text in the file.
+        fn extract_pairs(sql: &str) -> Vec<(String, String)> {
+            let mut out = Vec::new();
+            for raw in sql.lines() {
+                let line = raw.trim_start();
+                if !line.to_ascii_uppercase().starts_with("WHEN") {
+                    continue;
+                }
+                // Split on `THEN` (case-insensitive) so we can pick the
+                // quoted literal in each half independently.
+                let upper = line.to_ascii_uppercase();
+                let then_idx = match upper.find("THEN") {
+                    Some(i) => i,
+                    None => continue,
+                };
+                let (lhs, rhs) = line.split_at(then_idx);
+                let when_lit = match extract_first_quoted(lhs) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                let then_lit = match extract_first_quoted(&rhs[4..]) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                out.push((when_lit, then_lit));
+            }
+            out
+        }
+
+        fn extract_first_quoted(s: &str) -> Option<String> {
+            let bytes = s.as_bytes();
+            let start = bytes.iter().position(|&b| b == b'\'')?;
+            let rest = &bytes[start + 1..];
+            let end = rest.iter().position(|&b| b == b'\'')?;
+            Some(String::from_utf8_lossy(&rest[..end]).into_owned())
+        }
+
+        let mut sql_pairs = extract_pairs(SQL);
+        sql_pairs.sort();
+        sql_pairs.dedup();
+
+        let mut rust_pairs: Vec<(String, String)> = NOTIFICATION_TO_WEBHOOK_EVENT_MAP
+            .iter()
+            .map(|(n, w)| ((*n).to_string(), (*w).to_string()))
+            .collect();
+        rust_pairs.sort();
+
+        assert!(
+            !sql_pairs.is_empty(),
+            "migration 081 contained no WHEN/THEN pairs; regex broken or file empty"
+        );
+        assert_eq!(
+            sql_pairs, rust_pairs,
+            "migration 081 CASE pairs drifted from NOTIFICATION_TO_WEBHOOK_EVENT_MAP"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // parse_email_recipients
     // -----------------------------------------------------------------------

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -258,6 +258,26 @@ pub fn spawn_all(
         });
     }
 
+    // Webhook previous-secret cleanup (every 10 minutes). Clears the
+    // overlap-window ciphertext once the rotation grace period expires.
+    {
+        let db = db.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            let mut ticker = interval(Duration::from_secs(600));
+            loop {
+                ticker.tick().await;
+                match crate::api::handlers::webhooks::cleanup_expired_previous_secrets(&db).await {
+                    Ok(0) => {}
+                    Ok(n) => {
+                        tracing::info!("Cleared {} expired webhook previous-secret entries", n)
+                    }
+                    Err(e) => tracing::warn!("Webhook previous-secret cleanup failed: {}", e),
+                }
+            }
+        });
+    }
+
     // Curation upstream metadata sync (checks every 5 minutes for repos due for sync)
     {
         let db = db.clone();

--- a/backend/src/services/webhook_producer.rs
+++ b/backend/src/services/webhook_producer.rs
@@ -1,0 +1,419 @@
+//! Webhook producer service.
+//!
+//! Subscribes to the EventBus and writes a row into `webhook_deliveries` for
+//! every webhook whose `events` array contains the mapped event type and whose
+//! `repository_id` matches (or is NULL, meaning "global"). The row is enqueued
+//! with `next_retry_at = NOW()`, `attempts = 0`, `success = false`. The retry
+//! scheduler in `crate::api::handlers::webhooks::process_webhook_retries`
+//! (driven from `scheduler_service`) picks rows up on its 30-second tick and
+//! performs the actual HTTP POST.
+//!
+//! This module is the missing producer in v1.1.9. Before it existed, the
+//! retry scheduler had nothing to retry: no code path inserted into
+//! `webhook_deliveries`. The result was that webhook delivery was dead code.
+//!
+//! Companion ticket E2 (HMAC signing) and E4 (richer payload schema) are
+//! independent and can land before or after this PR. This module emits a
+//! minimal v1 payload. HMAC signing happens at delivery time, not enqueue
+//! time, so it is the retry scheduler's responsibility, not this producer's.
+
+use std::sync::Arc;
+
+use sqlx::{PgPool, Row};
+use tokio::sync::broadcast;
+
+use crate::services::event_bus::{DomainEvent, EventBus};
+
+/// Map an EventBus event type (e.g. "artifact.created", "repository.deleted")
+/// to the underscore-form string used in the `webhooks.events` text array
+/// (e.g. "artifact_uploaded", "repository_deleted").
+///
+/// The webhook system uses snake_case underscore identifiers to match
+/// `WebhookEvent::Display` in `crate::api::handlers::webhooks`. The EventBus
+/// uses dotted, lower-case identifiers. This function bridges the two.
+///
+/// Returns `None` for events that do not have a corresponding `WebhookEvent`
+/// variant. Such events are silently skipped (no rows are enqueued).
+pub fn map_event_type(event_type: &str) -> Option<&'static str> {
+    match event_type {
+        // Artifact uploads: both ".created" (legacy) and ".uploaded" (new) emit
+        // the artifact_uploaded webhook. Mirrors the alias in
+        // notification_dispatcher::map_event_type.
+        "artifact.created" | "artifact.uploaded" => Some("artifact_uploaded"),
+        "artifact.deleted" => Some("artifact_deleted"),
+        "repository.created" => Some("repository_created"),
+        "repository.deleted" => Some("repository_deleted"),
+        "user.created" => Some("user_created"),
+        "user.deleted" => Some("user_deleted"),
+        "build.started" => Some("build_started"),
+        "build.completed" => Some("build_completed"),
+        "build.failed" => Some("build_failed"),
+        _ => None,
+    }
+}
+
+/// Build the v1 JSON payload that gets stored in `webhook_deliveries.payload`.
+///
+/// The shape is intentionally minimal in v1.1.9. E4 will add
+/// `event_schema_version` and richer event-specific fields. Consumers that
+/// rely on these fields today should pin to a specific producer version.
+pub fn build_event_payload(event: &DomainEvent, mapped_event: &str) -> serde_json::Value {
+    serde_json::json!({
+        "event": mapped_event,
+        "entity_id": event.entity_id,
+        "actor": event.actor,
+        "timestamp": event.timestamp,
+        "payload": serde_json::Value::Null,
+    })
+}
+
+/// Row type for the webhook lookup query.
+#[derive(Debug)]
+struct MatchingWebhookRow {
+    id: uuid::Uuid,
+}
+
+/// Start the webhook producer background task.
+///
+/// Spawns a tokio task that subscribes to the EventBus and, for each received
+/// event, looks up all enabled matching webhooks and enqueues a row into
+/// `webhook_deliveries`. The task runs until the broadcast channel is closed
+/// (i.e. the EventBus is dropped at shutdown).
+///
+/// # Idempotency
+///
+/// Tokio broadcast channels can deliver duplicates if a slow subscriber lags
+/// the buffer. This module accepts rare duplicates rather than adding a
+/// migration to dedupe at insert time. The downstream retry scheduler is
+/// idempotent at the row level: a duplicate row just produces one extra
+/// delivery. Correctness is preserved; the cost is at-most-once becomes
+/// at-least-once. This is the standard tradeoff for Postgres-backed work
+/// queues and it matches what other Artifact Keeper consumers expect.
+pub fn start_webhook_producer(event_bus: Arc<EventBus>, db: PgPool) {
+    let mut rx = event_bus.subscribe();
+
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if let Err(e) = enqueue_for_event(&db, &event).await {
+                        tracing::warn!(
+                            event_type = %event.event_type,
+                            entity_id = %event.entity_id,
+                            error = %e,
+                            "Failed to enqueue webhook deliveries for event"
+                        );
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        skipped = n,
+                        "Webhook producer lagged, some events were dropped"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("EventBus closed, webhook producer shutting down");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Enqueue webhook_deliveries rows for a single domain event.
+///
+/// Looks up enabled webhooks whose `events` array contains the mapped event
+/// type and whose `repository_id` is either NULL (global) or matches the
+/// event's entity_id when interpretable as a UUID. For each match, INSERTs a
+/// row into `webhook_deliveries` with `attempts = 0`, `next_retry_at = NOW()`,
+/// `success = false`. The retry scheduler picks these up on its tick.
+///
+/// Uses `sqlx::query()` (not the macro) to avoid contention on the offline
+/// SQLx query cache while parallel webhook PRs are in flight (E1, E2, E4).
+async fn enqueue_for_event(db: &PgPool, event: &DomainEvent) -> std::result::Result<(), String> {
+    let mapped_event = match map_event_type(&event.event_type) {
+        Some(m) => m,
+        None => {
+            // No webhook subscribers for this event type. Silently skip.
+            return Ok(());
+        }
+    };
+
+    // Try to parse entity_id as a UUID for repository scoping. If it is not
+    // a UUID, only global webhooks (repository_id IS NULL) match.
+    let repo_id: Option<uuid::Uuid> = uuid::Uuid::parse_str(&event.entity_id).ok();
+
+    let raw_rows = sqlx::query(
+        r#"
+        SELECT id
+        FROM webhooks
+        WHERE is_enabled = true
+          AND $1 = ANY(events)
+          AND (repository_id IS NULL OR repository_id = $2)
+        "#,
+    )
+    .bind(mapped_event)
+    .bind(repo_id)
+    .fetch_all(db)
+    .await
+    .map_err(|e| format!("Failed to query webhooks: {}", e))?;
+
+    let webhooks: Vec<MatchingWebhookRow> = raw_rows
+        .into_iter()
+        .map(|row| MatchingWebhookRow { id: row.get("id") })
+        .collect();
+
+    if webhooks.is_empty() {
+        return Ok(());
+    }
+
+    let payload = build_event_payload(event, mapped_event);
+
+    for webhook in &webhooks {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO webhook_deliveries
+                (webhook_id, event, payload, attempts, next_retry_at, success)
+            VALUES ($1, $2, $3, 0, NOW(), false)
+            "#,
+        )
+        .bind(webhook.id)
+        .bind(mapped_event)
+        .bind(&payload)
+        .execute(db)
+        .await;
+
+        match result {
+            Ok(_) => {
+                crate::services::metrics_service::record_webhook_delivery_enqueued(mapped_event);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    webhook_id = %webhook.id,
+                    event = mapped_event,
+                    error = %e,
+                    "Failed to insert webhook_deliveries row"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event(event_type: &str) -> DomainEvent {
+        DomainEvent {
+            event_type: event_type.to_string(),
+            entity_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            actor: Some("alice".into()),
+            timestamp: "2026-04-08T12:00:00Z".into(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // map_event_type: every WebhookEvent variant must map
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_map_artifact_uploaded() {
+        assert_eq!(
+            map_event_type("artifact.uploaded"),
+            Some("artifact_uploaded")
+        );
+    }
+
+    #[test]
+    fn test_map_artifact_created_aliases_uploaded() {
+        // The EventBus uses ".created"; the webhook system uses "uploaded".
+        // This alias mirrors notification_dispatcher::map_event_type.
+        assert_eq!(
+            map_event_type("artifact.created"),
+            Some("artifact_uploaded")
+        );
+    }
+
+    #[test]
+    fn test_map_artifact_deleted() {
+        assert_eq!(map_event_type("artifact.deleted"), Some("artifact_deleted"));
+    }
+
+    #[test]
+    fn test_map_repository_created() {
+        assert_eq!(
+            map_event_type("repository.created"),
+            Some("repository_created")
+        );
+    }
+
+    #[test]
+    fn test_map_repository_deleted() {
+        assert_eq!(
+            map_event_type("repository.deleted"),
+            Some("repository_deleted")
+        );
+    }
+
+    #[test]
+    fn test_map_user_created() {
+        assert_eq!(map_event_type("user.created"), Some("user_created"));
+    }
+
+    #[test]
+    fn test_map_user_deleted() {
+        assert_eq!(map_event_type("user.deleted"), Some("user_deleted"));
+    }
+
+    #[test]
+    fn test_map_build_started() {
+        assert_eq!(map_event_type("build.started"), Some("build_started"));
+    }
+
+    #[test]
+    fn test_map_build_completed() {
+        assert_eq!(map_event_type("build.completed"), Some("build_completed"));
+    }
+
+    #[test]
+    fn test_map_build_failed() {
+        assert_eq!(map_event_type("build.failed"), Some("build_failed"));
+    }
+
+    #[test]
+    fn test_map_unknown_returns_none() {
+        // Unmapped events are silently skipped, not panicked over.
+        assert_eq!(map_event_type("permission.created"), None);
+        assert_eq!(map_event_type("group.member_added"), None);
+        assert_eq!(map_event_type(""), None);
+        assert_eq!(map_event_type("totally.bogus"), None);
+    }
+
+    #[test]
+    fn test_map_covers_all_webhook_event_variants() {
+        // This is a fence test: the WebhookEvent enum has 9 variants.
+        // We must produce a mapping for each one. If a new variant is added,
+        // update this list and the match arm above.
+        let expected_outputs = [
+            "artifact_uploaded",
+            "artifact_deleted",
+            "repository_created",
+            "repository_deleted",
+            "user_created",
+            "user_deleted",
+            "build_started",
+            "build_completed",
+            "build_failed",
+        ];
+        let event_bus_inputs = [
+            "artifact.uploaded",
+            "artifact.deleted",
+            "repository.created",
+            "repository.deleted",
+            "user.created",
+            "user.deleted",
+            "build.started",
+            "build.completed",
+            "build.failed",
+        ];
+        for (input, expected) in event_bus_inputs.iter().zip(expected_outputs.iter()) {
+            assert_eq!(map_event_type(input), Some(*expected), "input: {}", input);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // build_event_payload
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_event_payload_shape() {
+        let event = sample_event("artifact.created");
+        let payload = build_event_payload(&event, "artifact_uploaded");
+        let obj = payload.as_object().unwrap();
+
+        assert_eq!(obj.len(), 5);
+        assert_eq!(payload["event"], "artifact_uploaded");
+        assert_eq!(payload["entity_id"], "550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(payload["actor"], "alice");
+        assert_eq!(payload["timestamp"], "2026-04-08T12:00:00Z");
+        assert!(payload["payload"].is_null());
+    }
+
+    #[test]
+    fn test_build_event_payload_uses_mapped_event_name() {
+        // The payload's "event" field is the underscore (mapped) form, not
+        // the dotted EventBus form. Consumers see snake_case identifiers.
+        let event = sample_event("artifact.created");
+        let payload = build_event_payload(&event, "artifact_uploaded");
+        assert_eq!(payload["event"], "artifact_uploaded");
+        assert_ne!(payload["event"], "artifact.created");
+    }
+
+    #[test]
+    fn test_build_event_payload_no_actor() {
+        let event = DomainEvent {
+            event_type: "user.deleted".into(),
+            entity_id: "u-7".into(),
+            actor: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+        };
+        let payload = build_event_payload(&event, "user_deleted");
+        assert!(payload["actor"].is_null());
+    }
+
+    #[test]
+    fn test_build_event_payload_is_valid_json() {
+        let event = sample_event("artifact.deleted");
+        let payload = build_event_payload(&event, "artifact_deleted");
+        let serialized = serde_json::to_string(&payload).unwrap();
+        let reparsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(reparsed, payload);
+    }
+
+    #[test]
+    fn test_build_event_payload_preserves_timestamp_format() {
+        // The timestamp is passed through verbatim. Consumers parse RFC 3339.
+        let event = DomainEvent {
+            event_type: "build.failed".into(),
+            entity_id: "build-99".into(),
+            actor: Some("ci".into()),
+            timestamp: "2026-04-27T16:30:00.123456789Z".into(),
+        };
+        let payload = build_event_payload(&event, "build_failed");
+        assert_eq!(payload["timestamp"], "2026-04-27T16:30:00.123456789Z");
+    }
+
+    // -----------------------------------------------------------------------
+    // Skipped event types: producer must not panic
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_unmapped_event_returns_none_safely() {
+        // A handful of permission/group events fire but have no webhook
+        // counterpart. Make sure the mapper is total over a representative
+        // sample we observe in production grep.
+        let unmapped = [
+            "permission.created",
+            "permission.updated",
+            "permission.deleted",
+            "group.created",
+            "group.updated",
+            "group.deleted",
+            "group.member_added",
+            "group.member_removed",
+            "service_account.created",
+            "service_account.deleted",
+            "quality_gate.created",
+            "quality_gate.updated",
+            "quality_gate.deleted",
+            "quarantine.added",
+            "scan.completed",
+            "scan.vulnerability_found",
+        ];
+        for ev in unmapped {
+            assert_eq!(map_event_type(ev), None, "{} should be unmapped", ev);
+        }
+    }
+}

--- a/backend/src/services/webhook_producer.rs
+++ b/backend/src/services/webhook_producer.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use sqlx::{PgPool, Row};
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 
 use crate::services::event_bus::{DomainEvent, EventBus};
 
@@ -57,14 +58,34 @@ pub fn map_event_type(event_type: &str) -> Option<&'static str> {
 /// The shape is intentionally minimal in v1.1.9. E4 will add
 /// `event_schema_version` and richer event-specific fields. Consumers that
 /// rely on these fields today should pin to a specific producer version.
+///
+/// v1 OMITS the `payload` key entirely (rather than serialising it as
+/// `null`) when no enriched payload is available yet, so receivers can
+/// distinguish "v1 producer with no enrichment" from "v2 producer that
+/// chose to emit a null payload". E4 will populate the key.
 pub fn build_event_payload(event: &DomainEvent, mapped_event: &str) -> serde_json::Value {
-    serde_json::json!({
-        "event": mapped_event,
-        "entity_id": event.entity_id,
-        "actor": event.actor,
-        "timestamp": event.timestamp,
-        "payload": serde_json::Value::Null,
-    })
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "event".into(),
+        serde_json::Value::String(mapped_event.into()),
+    );
+    map.insert(
+        "entity_id".into(),
+        serde_json::Value::String(event.entity_id.clone()),
+    );
+    map.insert(
+        "actor".into(),
+        match &event.actor {
+            Some(a) => serde_json::Value::String(a.clone()),
+            None => serde_json::Value::Null,
+        },
+    );
+    map.insert(
+        "timestamp".into(),
+        serde_json::Value::String(event.timestamp.clone()),
+    );
+    // v1 omits `payload` when not yet enriched; v2 (E4) will populate it.
+    serde_json::Value::Object(map)
 }
 
 /// Row type for the webhook lookup query.
@@ -77,43 +98,62 @@ struct MatchingWebhookRow {
 ///
 /// Spawns a tokio task that subscribes to the EventBus and, for each received
 /// event, looks up all enabled matching webhooks and enqueues a row into
-/// `webhook_deliveries`. The task runs until the broadcast channel is closed
-/// (i.e. the EventBus is dropped at shutdown).
+/// `webhook_deliveries`. The task runs until either the broadcast channel is
+/// closed (the EventBus was dropped) or `shutdown_token` is cancelled by the
+/// HTTP/gRPC server lifecycle.
 ///
-/// # Idempotency
+/// # Delivery semantics: at-most-once with explicit lag drops
 ///
-/// Tokio broadcast channels can deliver duplicates if a slow subscriber lags
-/// the buffer. This module accepts rare duplicates rather than adding a
-/// migration to dedupe at insert time. The downstream retry scheduler is
-/// idempotent at the row level: a duplicate row just produces one extra
-/// delivery. Correctness is preserved; the cost is at-most-once becomes
-/// at-least-once. This is the standard tradeoff for Postgres-backed work
-/// queues and it matches what other Artifact Keeper consumers expect.
-pub fn start_webhook_producer(event_bus: Arc<EventBus>, db: PgPool) {
+/// Tokio broadcast channels DO NOT duplicate events. On subscriber lag they
+/// surface `RecvError::Lagged(n)` which means the n oldest events were
+/// silently DROPPED from this subscriber's view. The producer logs lag at
+/// warn-level but cannot recover the dropped events: at-most-once is the
+/// best the in-process bus can offer. Customers requiring at-least-once for
+/// missed deliveries must fall back to the polling/manual-replay UI on
+/// `/api/v1/webhooks/{id}/deliveries` (or the GET-then-redeliver flow).
+/// This is acceptable for v1.1.9; v1.2.0 will introduce a durable event log
+/// if reviewers determine in-process broadcast is insufficient.
+pub fn start_webhook_producer(
+    event_bus: Arc<EventBus>,
+    db: PgPool,
+    shutdown_token: CancellationToken,
+) {
     let mut rx = event_bus.subscribe();
 
     tokio::spawn(async move {
         loop {
-            match rx.recv().await {
-                Ok(event) => {
-                    if let Err(e) = enqueue_for_event(&db, &event).await {
-                        tracing::warn!(
-                            event_type = %event.event_type,
-                            entity_id = %event.entity_id,
-                            error = %e,
-                            "Failed to enqueue webhook deliveries for event"
-                        );
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!(
-                        skipped = n,
-                        "Webhook producer lagged, some events were dropped"
+            tokio::select! {
+                _ = shutdown_token.cancelled() => {
+                    tracing::info!(
+                        "Shutdown signalled, webhook producer draining and exiting"
                     );
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    tracing::info!("EventBus closed, webhook producer shutting down");
                     break;
+                }
+                recv = rx.recv() => {
+                    match recv {
+                        Ok(event) => {
+                            if let Err(e) = enqueue_for_event(&db, &event).await {
+                                tracing::warn!(
+                                    event_type = %event.event_type,
+                                    entity_id = %event.entity_id,
+                                    error = %e,
+                                    "Failed to enqueue webhook deliveries for event"
+                                );
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                skipped = n,
+                                "Webhook producer lagged; events were dropped (at-most-once)"
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::info!(
+                                "EventBus closed, webhook producer shutting down"
+                            );
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -127,6 +167,22 @@ pub fn start_webhook_producer(event_bus: Arc<EventBus>, db: PgPool) {
 /// event's entity_id when interpretable as a UUID. For each match, INSERTs a
 /// row into `webhook_deliveries` with `attempts = 0`, `next_retry_at = NOW()`,
 /// `success = false`. The retry scheduler picks these up on its tick.
+///
+/// # Repository scoping limitation
+///
+/// `event.entity_id` is parsed as a `repository_id`. This works correctly
+/// for `repository.*` events because the EventBus carries the repo UUID in
+/// `entity_id`. It is a category error for `user.*`, `build.*`, and
+/// `artifact.*` events: their `entity_id` is the user/build/artifact UUID
+/// respectively, not the owning repository. For those events, the
+/// `repository_id = $2` arm of the WHERE clause never matches, so only
+/// global-scoped webhooks (repository_id IS NULL) fire. The same flaw
+/// exists in `notification_dispatcher.rs::dispatch_event`.
+///
+/// FIXME(#948): Thread an explicit `repository_id: Option<Uuid>` through
+/// `DomainEvent` so this scoping is correct for non-repo events. Until
+/// then, scoping non-repo events requires the operator to use a global
+/// webhook subscription.
 ///
 /// Uses `sqlx::query()` (not the macro) to avoid contention on the offline
 /// SQLx query cache while parallel webhook PRs are in flight (E1, E2, E4).
@@ -193,6 +249,10 @@ async fn enqueue_for_event(db: &PgPool, event: &DomainEvent) -> std::result::Res
                     event = mapped_event,
                     error = %e,
                     "Failed to insert webhook_deliveries row"
+                );
+                crate::services::metrics_service::record_webhook_delivery_enqueue_failed(
+                    mapped_event,
+                    "db_error",
                 );
             }
         }
@@ -293,33 +353,57 @@ mod tests {
 
     #[test]
     fn test_map_covers_all_webhook_event_variants() {
-        // This is a fence test: the WebhookEvent enum has 9 variants.
-        // We must produce a mapping for each one. If a new variant is added,
-        // update this list and the match arm above.
-        let expected_outputs = [
-            "artifact_uploaded",
-            "artifact_deleted",
-            "repository_created",
-            "repository_deleted",
-            "user_created",
-            "user_deleted",
-            "build_started",
-            "build_completed",
-            "build_failed",
+        // Compile-time fence: an exhaustive match over `WebhookEvent`
+        // produces the (event_bus_input, expected_output) pair for every
+        // variant. If a new variant is added to `WebhookEvent`, this match
+        // FAILS TO COMPILE until both the match arm here AND the runtime
+        // dispatch in `map_event_type` above are updated. That is the
+        // entire point: hand-maintained lists drift silently.
+        use crate::api::handlers::webhooks::WebhookEvent;
+
+        fn expected_pair(v: &WebhookEvent) -> (&'static str, &'static str) {
+            match v {
+                WebhookEvent::ArtifactUploaded => ("artifact.uploaded", "artifact_uploaded"),
+                WebhookEvent::ArtifactDeleted => ("artifact.deleted", "artifact_deleted"),
+                WebhookEvent::RepositoryCreated => ("repository.created", "repository_created"),
+                WebhookEvent::RepositoryDeleted => ("repository.deleted", "repository_deleted"),
+                WebhookEvent::UserCreated => ("user.created", "user_created"),
+                WebhookEvent::UserDeleted => ("user.deleted", "user_deleted"),
+                WebhookEvent::BuildStarted => ("build.started", "build_started"),
+                WebhookEvent::BuildCompleted => ("build.completed", "build_completed"),
+                WebhookEvent::BuildFailed => ("build.failed", "build_failed"),
+            }
+        }
+
+        // Hand-listed for the body of the test; the exhaustive match above
+        // is what the fence relies on. If you add a variant, the compiler
+        // forces you to extend `expected_pair`, and you should also extend
+        // this list so the runtime side actually exercises every variant.
+        let all_variants = [
+            WebhookEvent::ArtifactUploaded,
+            WebhookEvent::ArtifactDeleted,
+            WebhookEvent::RepositoryCreated,
+            WebhookEvent::RepositoryDeleted,
+            WebhookEvent::UserCreated,
+            WebhookEvent::UserDeleted,
+            WebhookEvent::BuildStarted,
+            WebhookEvent::BuildCompleted,
+            WebhookEvent::BuildFailed,
         ];
-        let event_bus_inputs = [
-            "artifact.uploaded",
-            "artifact.deleted",
-            "repository.created",
-            "repository.deleted",
-            "user.created",
-            "user.deleted",
-            "build.started",
-            "build.completed",
-            "build.failed",
-        ];
-        for (input, expected) in event_bus_inputs.iter().zip(expected_outputs.iter()) {
-            assert_eq!(map_event_type(input), Some(*expected), "input: {}", input);
+
+        for variant in &all_variants {
+            let (bus_input, expected) = expected_pair(variant);
+            assert_eq!(
+                map_event_type(bus_input),
+                Some(expected),
+                "variant {:?} maps {} -> {}",
+                variant,
+                bus_input,
+                expected
+            );
+            // Also assert the WebhookEvent::Display matches the mapped form
+            // so the wire identifier stays in lockstep with the Rust enum.
+            assert_eq!(variant.to_string(), expected);
         }
     }
 
@@ -333,12 +417,35 @@ mod tests {
         let payload = build_event_payload(&event, "artifact_uploaded");
         let obj = payload.as_object().unwrap();
 
-        assert_eq!(obj.len(), 5);
+        // v1 emits exactly four keys: event, entity_id, actor, timestamp.
+        // The `payload` key is OMITTED (not serialized as null) until E4
+        // wires up the per-event enrichment. Receivers see a missing key,
+        // not a null value, so they can tell v1 apart from a deliberate
+        // v2-null-payload.
+        assert_eq!(obj.len(), 4);
         assert_eq!(payload["event"], "artifact_uploaded");
         assert_eq!(payload["entity_id"], "550e8400-e29b-41d4-a716-446655440000");
         assert_eq!(payload["actor"], "alice");
         assert_eq!(payload["timestamp"], "2026-04-08T12:00:00Z");
-        assert!(payload["payload"].is_null());
+        assert!(
+            obj.get("payload").is_none(),
+            "v1 must omit the payload key entirely, not emit null"
+        );
+    }
+
+    #[test]
+    fn test_build_event_payload_omits_payload_key_not_null() {
+        // Explicit fence: serialising-then-parsing must not introduce a
+        // payload key. If a future change writes `"payload": null` instead
+        // of omitting it, this test fails loudly.
+        let event = sample_event("artifact.created");
+        let payload = build_event_payload(&event, "artifact_uploaded");
+        let serialized = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !serialized.contains("\"payload\""),
+            "serialized v1 payload must not contain a payload key, got: {}",
+            serialized
+        );
     }
 
     #[test]

--- a/backend/src/services/webhook_secret_crypto.rs
+++ b/backend/src/services/webhook_secret_crypto.rs
@@ -76,6 +76,17 @@ fn encryptor() -> Result<CredentialEncryption> {
     Ok(CredentialEncryption::new(&key)?)
 }
 
+/// Validate that `AK_WEBHOOK_SECRET_KEY` is configured and well-formed.
+///
+/// Intended for use at process startup so the operator gets a fast, loud
+/// failure when the encryption key is missing, mistyped, or the wrong
+/// length, instead of discovering it only when the first webhook create
+/// or rotate-secret request fails with HTTP 500. The decoded key is
+/// discarded immediately after validation.
+pub fn ensure_configured() -> Result<()> {
+    load_key().map(|_| ())
+}
+
 /// Generate a fresh webhook secret string of the form `whsec_<base64url>`.
 ///
 /// Uses the OS CSPRNG. The unprefixed body has at least 192 bits of entropy.
@@ -106,17 +117,26 @@ pub fn decrypt_secret(ciphertext: &[u8]) -> Result<String> {
 /// list/get responses so operators can distinguish secrets without exposing
 /// them. Format: `<prefix>...<last4>` where the prefix is the literal
 /// `whsec_` (or whatever prefix the secret already carries) and the last
-/// four characters of the secret body are the only material revealed.
+/// four *characters* of the secret body are the only material revealed.
 ///
 /// For secrets shorter than 8 characters the digest is the full secret;
-/// such inputs only occur in tests.
+/// such inputs only occur in tests. Operates over `char` boundaries (not
+/// raw byte indices) so a caller-supplied secret that contains multibyte
+/// UTF-8 cannot panic this function.
 pub fn digest_for_display(secret: &str) -> String {
-    if secret.len() < 8 {
+    let char_count = secret.chars().count();
+    if char_count < 8 {
         return secret.to_string();
     }
-    let last4 = &secret[secret.len() - 4..];
+    // Take the last 4 characters by iterating from the end, then reversing,
+    // so we never index into the middle of a multibyte UTF-8 sequence.
+    let last4: String = {
+        let mut tail: Vec<char> = secret.chars().rev().take(4).collect();
+        tail.reverse();
+        tail.into_iter().collect()
+    };
     if let Some(rest) = secret.strip_prefix(SECRET_PREFIX) {
-        if rest.len() <= 4 {
+        if rest.chars().count() <= 4 {
             return secret.to_string();
         }
         return format!("{}...{}", SECRET_PREFIX, last4);
@@ -184,6 +204,29 @@ mod tests {
         assert_ne!(a, b, "ciphertexts must differ due to random nonce");
         // First 12 bytes are the nonce; they should differ.
         assert_ne!(&a[..12], &b[..12]);
+    }
+
+    #[test]
+    fn test_nonce_uniqueness_at_scale() {
+        // Birthday-bound check: 1000 encryptions of the same plaintext
+        // must produce 1000 distinct nonces. AES-GCM is catastrophic on
+        // nonce reuse, so the bar is no collisions, ever.
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let plaintext = "same plaintext";
+        let mut nonces: std::collections::HashSet<[u8; 12]> = std::collections::HashSet::new();
+        for _ in 0..1000 {
+            let ct = encrypt_secret(plaintext).expect("encrypt");
+            let mut nonce = [0u8; 12];
+            nonce.copy_from_slice(&ct[..12]);
+            nonces.insert(nonce);
+        }
+        assert_eq!(
+            nonces.len(),
+            1000,
+            "expected 1000 unique nonces from 1000 encryptions, got {}",
+            nonces.len()
+        );
     }
 
     #[test]
@@ -264,5 +307,56 @@ mod tests {
     fn test_digest_non_prefixed_secret() {
         let digest = digest_for_display("hello-world-1234");
         assert_eq!(digest, "hell...1234");
+    }
+
+    #[test]
+    fn test_digest_does_not_panic_on_multibyte_utf8() {
+        // Regression: `&secret[secret.len() - 4..]` panics if the byte at
+        // that offset is mid-multibyte. Operate on chars and the function
+        // is total over any &str input.
+        let secret = "whsec_naïveöü";
+        let digest = digest_for_display(secret);
+        // Just make sure it does not panic and returns a non-empty result;
+        // the exact suffix is implementation-defined for non-ASCII tails.
+        assert!(!digest.is_empty());
+    }
+
+    #[test]
+    fn test_digest_handles_emoji_tail() {
+        // A pathological caller-supplied secret with a 4-byte char tail.
+        let secret = "whsec_abcdefghi😀";
+        let digest = digest_for_display(secret);
+        assert!(digest.starts_with(SECRET_PREFIX));
+    }
+
+    #[test]
+    fn test_ensure_configured_ok() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        assert!(ensure_configured().is_ok());
+    }
+
+    #[test]
+    fn test_ensure_configured_missing_key() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(ENV_KEY);
+        }
+        assert!(matches!(
+            ensure_configured(),
+            Err(WebhookSecretError::KeyMissing)
+        ));
+    }
+
+    #[test]
+    fn test_ensure_configured_wrong_length() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(ENV_KEY, B64.encode([0u8; 16]));
+        }
+        assert!(matches!(
+            ensure_configured(),
+            Err(WebhookSecretError::KeyWrongLength(16))
+        ));
     }
 }

--- a/backend/src/services/webhook_secret_crypto.rs
+++ b/backend/src/services/webhook_secret_crypto.rs
@@ -1,0 +1,268 @@
+//! Webhook secret encryption helpers.
+//!
+//! Stores webhook signing secrets at rest using AES-256-GCM. The raw secret
+//! is shown to the operator exactly once at creation or rotation time;
+//! afterwards only the ciphertext (and a short non-reversible digest, used
+//! for UI identification) is persisted.
+//!
+//! The 32-byte symmetric key is sourced from the `AK_WEBHOOK_SECRET_KEY`
+//! environment variable, base64 encoded. The encryption format is
+//! nonce-prefixed AES-256-GCM, identical to the layout used by
+//! [`crate::services::encryption::CredentialEncryption`]. Existing secrets
+//! that pre-date this module are stored as bcrypt hashes; those are
+//! unrecoverable and must be rotated by the operator before the backend
+//! can sign deliveries against them.
+//!
+//! This module is deliberately scoped to webhook secrets so that the key
+//! can be rotated independently from the SSO credential key.
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use rand::RngCore;
+use thiserror::Error;
+
+use crate::services::encryption::{CredentialEncryption, EncryptionError};
+
+/// Environment variable that holds the base64-encoded 32-byte AES key.
+pub const ENV_KEY: &str = "AK_WEBHOOK_SECRET_KEY";
+
+/// Length, in bytes, of a freshly generated webhook secret (before the
+/// `whsec_` prefix is added). Chosen to give 192 bits of entropy after
+/// URL-safe base64 encoding without padding.
+const RAW_SECRET_BYTES: usize = 24;
+
+/// Prefix advertised to operators so that webhook secrets are visually
+/// distinct from API tokens and other credentials.
+pub const SECRET_PREFIX: &str = "whsec_";
+
+/// Errors raised by the webhook secret crypto helpers.
+#[derive(Debug, Error)]
+pub enum WebhookSecretError {
+    #[error("AK_WEBHOOK_SECRET_KEY is not configured")]
+    KeyMissing,
+
+    #[error("AK_WEBHOOK_SECRET_KEY is not valid base64: {0}")]
+    KeyNotBase64(String),
+
+    #[error("AK_WEBHOOK_SECRET_KEY must decode to exactly 32 bytes, got {0}")]
+    KeyWrongLength(usize),
+
+    #[error("webhook secret encryption failed: {0}")]
+    Crypto(#[from] EncryptionError),
+
+    #[error("decrypted webhook secret is not valid UTF-8")]
+    NotUtf8,
+}
+
+/// Result type for webhook crypto operations.
+pub type Result<T> = std::result::Result<T, WebhookSecretError>;
+
+/// Load the 32-byte key from the environment, decoding base64.
+fn load_key() -> Result<[u8; 32]> {
+    let raw = std::env::var(ENV_KEY).map_err(|_| WebhookSecretError::KeyMissing)?;
+    let trimmed = raw.trim();
+    let bytes = B64
+        .decode(trimmed)
+        .map_err(|e| WebhookSecretError::KeyNotBase64(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(WebhookSecretError::KeyWrongLength(bytes.len()));
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&bytes);
+    Ok(key)
+}
+
+fn encryptor() -> Result<CredentialEncryption> {
+    let key = load_key()?;
+    Ok(CredentialEncryption::new(&key)?)
+}
+
+/// Generate a fresh webhook secret string of the form `whsec_<base64url>`.
+///
+/// Uses the OS CSPRNG. The unprefixed body has at least 192 bits of entropy.
+pub fn generate_secret() -> String {
+    let mut buf = [0u8; RAW_SECRET_BYTES];
+    rand::rng().fill_bytes(&mut buf);
+    let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(buf);
+    format!("{}{}", SECRET_PREFIX, body)
+}
+
+/// Encrypt a secret for at-rest storage.
+///
+/// Returns nonce-prefixed AES-256-GCM ciphertext. Callers should persist
+/// this directly into the `secret_encrypted` `bytea` column.
+pub fn encrypt_secret(plaintext: &str) -> Result<Vec<u8>> {
+    let enc = encryptor()?;
+    Ok(enc.encrypt(plaintext.as_bytes()))
+}
+
+/// Decrypt a previously stored webhook secret.
+pub fn decrypt_secret(ciphertext: &[u8]) -> Result<String> {
+    let enc = encryptor()?;
+    let plaintext = enc.decrypt(ciphertext)?;
+    String::from_utf8(plaintext).map_err(|_| WebhookSecretError::NotUtf8)
+}
+
+/// Compute a stable, non-reversible identifier suitable for surfacing in
+/// list/get responses so operators can distinguish secrets without exposing
+/// them. Format: `<prefix>...<last4>` where the prefix is the literal
+/// `whsec_` (or whatever prefix the secret already carries) and the last
+/// four characters of the secret body are the only material revealed.
+///
+/// For secrets shorter than 8 characters the digest is the full secret;
+/// such inputs only occur in tests.
+pub fn digest_for_display(secret: &str) -> String {
+    if secret.len() < 8 {
+        return secret.to_string();
+    }
+    let last4 = &secret[secret.len() - 4..];
+    if let Some(rest) = secret.strip_prefix(SECRET_PREFIX) {
+        if rest.len() <= 4 {
+            return secret.to_string();
+        }
+        return format!("{}...{}", SECRET_PREFIX, last4);
+    }
+    let head: String = secret.chars().take(4).collect();
+    format!("{}...{}", head, last4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env mutation across the tests in this module so that
+    /// they do not race each other (Rust runs unit tests on a thread pool
+    /// by default and `std::env::set_var` is process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn set_test_key() {
+        // 32 bytes of zeros, base64-encoded.
+        let key = B64.encode([0u8; 32]);
+        // SAFETY: ENV_LOCK serializes env access for tests in this module.
+        unsafe {
+            std::env::set_var(ENV_KEY, key);
+        }
+    }
+
+    fn set_alt_key() {
+        let mut k = [0u8; 32];
+        k[0] = 1;
+        let encoded = B64.encode(k);
+        unsafe {
+            std::env::set_var(ENV_KEY, encoded);
+        }
+    }
+
+    #[test]
+    fn test_generate_secret_has_prefix_and_entropy() {
+        let s1 = generate_secret();
+        let s2 = generate_secret();
+        assert!(s1.starts_with(SECRET_PREFIX));
+        assert!(s2.starts_with(SECRET_PREFIX));
+        assert_ne!(s1, s2);
+        // base64url of 24 bytes (no padding) is 32 chars.
+        assert_eq!(s1.len(), SECRET_PREFIX.len() + 32);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let plaintext = "whsec_super_secret_value";
+        let ct = encrypt_secret(plaintext).expect("encrypt");
+        let pt = decrypt_secret(&ct).expect("decrypt");
+        assert_eq!(pt, plaintext);
+    }
+
+    #[test]
+    fn test_nonce_uniqueness() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let plaintext = "same plaintext";
+        let a = encrypt_secret(plaintext).expect("encrypt a");
+        let b = encrypt_secret(plaintext).expect("encrypt b");
+        assert_ne!(a, b, "ciphertexts must differ due to random nonce");
+        // First 12 bytes are the nonce; they should differ.
+        assert_ne!(&a[..12], &b[..12]);
+    }
+
+    #[test]
+    fn test_wrong_key_rejected() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // Encrypt with key A.
+        set_test_key();
+        let ct = encrypt_secret("whsec_value").expect("encrypt");
+        // Switch to key B and try to decrypt.
+        set_alt_key();
+        let res = decrypt_secret(&ct);
+        assert!(matches!(res, Err(WebhookSecretError::Crypto(_))));
+    }
+
+    #[test]
+    fn test_bad_ciphertext_rejected() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let mut ct = encrypt_secret("whsec_value").expect("encrypt");
+        // Flip a byte in the AEAD tag region.
+        let last = ct.len() - 1;
+        ct[last] ^= 0xff;
+        let res = decrypt_secret(&ct);
+        assert!(matches!(res, Err(WebhookSecretError::Crypto(_))));
+    }
+
+    #[test]
+    fn test_truncated_ciphertext_rejected() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let res = decrypt_secret(&[0u8; 8]);
+        assert!(matches!(res, Err(WebhookSecretError::Crypto(_))));
+    }
+
+    #[test]
+    fn test_missing_key_yields_key_missing() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(ENV_KEY);
+        }
+        let res = encrypt_secret("x");
+        assert!(matches!(res, Err(WebhookSecretError::KeyMissing)));
+    }
+
+    #[test]
+    fn test_invalid_base64_key() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(ENV_KEY, "@@@not-base64@@@");
+        }
+        let res = encrypt_secret("x");
+        assert!(matches!(res, Err(WebhookSecretError::KeyNotBase64(_))));
+    }
+
+    #[test]
+    fn test_wrong_length_key() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(ENV_KEY, B64.encode([0u8; 16]));
+        }
+        let res = encrypt_secret("x");
+        assert!(matches!(res, Err(WebhookSecretError::KeyWrongLength(16))));
+    }
+
+    #[test]
+    fn test_digest_format() {
+        let secret = "whsec_abcdef0123456789";
+        let digest = digest_for_display(secret);
+        assert_eq!(digest, "whsec_...6789");
+    }
+
+    #[test]
+    fn test_digest_short_secret_returns_self() {
+        assert_eq!(digest_for_display("abc"), "abc");
+    }
+
+    #[test]
+    fn test_digest_non_prefixed_secret() {
+        let digest = digest_for_display("hello-world-1234");
+        assert_eq!(digest, "hell...1234");
+    }
+}

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -184,6 +184,13 @@ services:
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
       DEPENDENCY_TRACK_ENABLED: "true"
       ALLOW_HTTP_INTEGRATIONS: "1"
+      # Webhooks v2 signing-secret encryption key. 32 bytes, base64 encoded.
+      # The dev placeholder below is "dev-key-not-for-prod-use-in-prod"
+      # base64-encoded, stable across rebuilds so existing rows can decrypt.
+      AK_WEBHOOK_SECRET_KEY: ${AK_WEBHOOK_SECRET_KEY:-ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q=}
+      # Webhooks v2 producer is off by default; enable after rotating
+      # migrated webhook secrets to avoid duplicate delivery from System B.
+      WEBHOOKS_V2_PRODUCER_ENABLED: ${WEBHOOKS_V2_PRODUCER_ENABLED:-false}
       # Forward host proxy settings so the backend can reach external services
       # through a corporate proxy. reqwest honours these natively.
       HTTP_PROXY: ${HTTP_PROXY:-}

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -185,9 +185,12 @@ services:
       DEPENDENCY_TRACK_ENABLED: "true"
       ALLOW_HTTP_INTEGRATIONS: "1"
       # Webhooks v2 signing-secret encryption key. 32 bytes, base64 encoded.
-      # The dev placeholder below is "dev-key-not-for-prod-use-in-prod"
-      # base64-encoded, stable across rebuilds so existing rows can decrypt.
-      AK_WEBHOOK_SECRET_KEY: ${AK_WEBHOOK_SECRET_KEY:-ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q=}
+      # Generate once for your local stack with: openssl rand -base64 32,
+      # then export AK_WEBHOOK_SECRET_KEY before docker compose up. The
+      # placeholder below is intentionally invalid base64 so the backend
+      # ensure_configured check fails fast with a clear error rather than
+      # silently running with a shared dev key.
+      AK_WEBHOOK_SECRET_KEY: ${AK_WEBHOOK_SECRET_KEY:-REPLACE_ME_WITH_OUTPUT_OF_openssl_rand_base64_32}
       # Webhooks v2 producer is off by default; enable after rotating
       # migrated webhook secrets to avoid duplicate delivery from System B.
       WEBHOOKS_V2_PRODUCER_ENABLED: ${WEBHOOKS_V2_PRODUCER_ENABLED:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,16 @@ services:
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
       DEPENDENCY_TRACK_ENABLED: ${DEPENDENCY_TRACK_ENABLED:-true}
       ALLOW_HTTP_INTEGRATIONS: "1"
+      # Webhooks v2 signing-secret encryption key. 32 bytes, base64 encoded.
+      # Generate with: openssl rand -base64 32. The placeholder below is for
+      # evaluation only; replace it before exposing this stack to real
+      # webhook receivers. Without a key set, webhook create and
+      # rotate-secret endpoints return HTTP 500.
+      AK_WEBHOOK_SECRET_KEY: ${AK_WEBHOOK_SECRET_KEY:-ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q=}
+      # Toggle the webhooks v2 EventBus producer. Default off. Flip to true
+      # once you have rotated migrated webhook secrets via /rotate-secret
+      # and verified delivery against your receivers.
+      WEBHOOKS_V2_PRODUCER_ENABLED: ${WEBHOOKS_V2_PRODUCER_ENABLED:-false}
       # Forward host proxy settings so the backend can reach external services
       # (OIDC providers, remote registries, webhook endpoints) through a
       # corporate proxy. reqwest honours these natively.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,11 +182,13 @@ services:
       DEPENDENCY_TRACK_ENABLED: ${DEPENDENCY_TRACK_ENABLED:-true}
       ALLOW_HTTP_INTEGRATIONS: "1"
       # Webhooks v2 signing-secret encryption key. 32 bytes, base64 encoded.
-      # Generate with: openssl rand -base64 32. The placeholder below is for
-      # evaluation only; replace it before exposing this stack to real
-      # webhook receivers. Without a key set, webhook create and
+      # Generate with: openssl rand -base64 32, then set the variable in
+      # your shell or a .env file before docker compose up. The placeholder
+      # below is intentionally invalid base64 so the backend fails fast at
+      # boot (ensure_configured) with a clear error rather than running
+      # with a known-weak key. Without a key set, webhook create and
       # rotate-secret endpoints return HTTP 500.
-      AK_WEBHOOK_SECRET_KEY: ${AK_WEBHOOK_SECRET_KEY:-ZGV2LWtleS1ub3QtZm9yLXByb2QtdXNlLWluLXByb2Q=}
+      AK_WEBHOOK_SECRET_KEY: ${AK_WEBHOOK_SECRET_KEY:-REPLACE_ME_WITH_OUTPUT_OF_openssl_rand_base64_32}
       # Toggle the webhooks v2 EventBus producer. Default off. Flip to true
       # once you have rotated migrated webhook secrets via /rotate-secret
       # and verified delivery against your receivers.


### PR DESCRIPTION
## Summary

This PR replaces and supersedes the three v1.1.9 webhooks v2 PRs (#937, #939, #940). All three are merged onto this branch, and the 20 blocker findings from the multi-lens review have been applied. The result is a single coherent landing of E1 (encrypted-at-rest secrets + rotation API), E3 (EventBus producer), and E6 (notification deprecation + data migration), with a unified `secret_hash` policy that resolves the cross-PR consistency bug.

What lands:

- E1: AES-256-GCM at-rest encryption for webhook signing secrets, `whsec_*` prefix, 24h rotation overlap window, last-4 digest exposure.
- E3: in-process EventBus producer that subscribes to domain events and enqueues rows into `webhook_deliveries` for the existing retry scheduler. Gated behind `WEBHOOKS_V2_PRODUCER_ENABLED` (default off).
- E6: RFC 8594 deprecation headers on the legacy `/repositories/:id/notifications` endpoints, plus migration 081 that copies `notification_subscriptions` rows of channel='webhook' into the webhooks table.

The unified secret policy: `secret_encrypted` is the new authoritative form, `secret_hash` is the legacy bcrypt indicator kept only so un-rotated pre-v1.1.9 rows continue to advertise that signing is configured. Migration 081 leaves BOTH NULL on rows it migrates, forcing the operator to call `/rotate-secret` to enable signing; the retry path's `X-Webhook-Signature` header is gated on EITHER form being non-empty, so legacy/migrated rows are correctly distinguishable on the wire.

## Regression test (required for fix/* PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A - this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (cargo fmt, clippy -D warnings, cargo test --workspace --lib all green; 8556 tests passing)
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable - migration 081 is forward-only by design; the unique index it creates uses IF NOT EXISTS so re-runs are no-ops)
- [ ] N/A - no API changes

## Blockers fixed (from the combined fix brief)

### Universal (cross-PR consistency)
- [x] 1. Migration 081 emits `NULL` for `secret_hash` on migrated rows; comment block rewritten to document the unified policy.
- [x] 2. Retry path signature header gate now uses `has_signing_secret(secret_hash, secret_encrypted)`; rows where both are NULL/empty no longer emit `X-Webhook-Signature`.
- [x] 3. `create_webhook` confirmed: writes `secret_encrypted` only, no mirror to `secret_hash`.

### From PR #937
- [x] 4. `CREATE UNIQUE INDEX IF NOT EXISTS idx_webhooks_url_repo_unique` created BEFORE the INSERT, INSERT now uses `ON CONFLICT DO NOTHING` for hard idempotency.
- [x] 5. Drift test `test_migration_081_case_matches_rust_map` extracts WHEN/THEN pairs from migration 081 and asserts they equal `NOTIFICATION_TO_WEBHOOK_EVENT_MAP`.

### From PR #939
- [x] 6. `digest_for_display` now slices on char boundaries so non-ASCII inputs cannot panic; new tests cover multibyte and emoji tails.
- [x] 7. `rotate_webhook_secret` SQL UPDATE adds `AND (secret_previous_expires_at IS NULL OR secret_previous_expires_at < NOW())`. On 0 rows updated the handler returns 409 with body `{"error": "rotation_already_in_progress", "expires_at": "<RFC3339>"}`. Pure-function `rotation_guard_allows` documents the semantics and is unit-tested.
- [x] 8. `webhook_secret_crypto::ensure_configured()` added and called from `run_server`. Malformed key aborts boot via `std::process::exit(1)`; missing key warns and continues (create/rotate-secret will return 500 until set).
- [x] 9. `AK_WEBHOOK_SECRET_KEY` and `WEBHOOKS_V2_PRODUCER_ENABLED` added to `docker-compose.yml`, `docker-compose.local-dev.yml`, `.env.local-dev`, and documented in `.env.example`. Companion IaC PR is tracked at #950 and MUST land before staging deploy.

### From PR #940
- [x] 10. Producer start-up gated on `WEBHOOKS_V2_PRODUCER_ENABLED` (default off). Boot logs the producer state.
- [x] 11. `start_webhook_producer` now takes a `CancellationToken`; the recv loop is wrapped in `tokio::select!` with a `cancelled()` arm so the worker exits cleanly on shutdown.
- [x] 12. Idempotency comment rewritten: tokio broadcast `Lagged(n)` DROPS events, it does NOT duplicate them. Module is at-most-once; customers needing at-least-once use the polling/manual-replay UI.
- [x] 13. New `record_webhook_delivery_enqueue_failed(event, reason)` counter (`ak_webhook_deliveries_enqueue_failed_total`); wired from the per-row INSERT error branch with `reason="db_error"`.
- [x] 14. `build_event_payload` now OMITS the `payload` key when not enriched. Receivers see no key (v1) vs explicit null (future v2). New fence test `test_build_event_payload_omits_payload_key_not_null`.
- [x] 15. Compile-time fence: `test_map_covers_all_webhook_event_variants` is now an exhaustive match over `WebhookEvent` so adding a 10th variant fails compilation until the dispatch is updated.
- [x] 16. Repository-scoping limitation documented inline in `enqueue_for_event`. `FIXME(#948)` comment links the structural followup.

### Tests added
- [x] 17. Write-once contract: `test_webhook_response_omits_secret_material_keys` asserts `secret`, `secret_encrypted`, `secret_previous_encrypted`, `secret_hash`, `secret_previous_expires_at`, `secret_rotation_started_at` are absent from the serialized form.
- [x] 18. Rotation flow semantics covered by `rotation_guard_allows` table: no-previous, expired-previous, active-previous, boundary-equals-now, full overlap window math.
- [x] 19. Cleanup tick predicate covered by `test_cleanup_predicate_matches_only_expired_rows`.
- [x] 20. `test_nonce_uniqueness_at_scale` runs 1000 encryptions and asserts 1000 distinct nonces via HashSet.

## Deferred follow-ups (filed)

- #948 - Thread explicit `repository_id` through `DomainEvent` (referenced from a `FIXME(#948)` comment in webhook_producer.rs).
- #949 - Webhook producer perf: batch INSERT, GIN index on `webhooks.events`.
- #950 - IaC companion: provision `AK_WEBHOOK_SECRET_KEY` before staging deploy.
- #951 - Webhook test cleanup: deprecation middleware location, pub-crate consts, sunset env override, `NOTIFICATION_TO_WEBHOOK_EVENT_MAP` location.
- #952 - Integration tests gated on the embedded-Postgres harness (producer loop, migration replay, bcrypt back-compat GET).

## Quality gates

Local results on the head of this branch:

- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace --lib`: 8556 passed, 0 failed, 2 ignored.

## Closes / refs

Refs #919 (epic, NOT closed - E2/E4/E5/E7 remain).

Closes #922 (E1).
Closes #924 (E3).
Closes #927 (E6).

Supersedes #937, #939, #940 - those PRs should be closed in favour of this one.