### PR TITLE
fix(goproxy): backport sumdb SSRF allowlist to 1.1.x (#879)

### DIFF
--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -228,12 +228,44 @@ async fn handle_get(
 // GET sumdb/... — Proxy to upstream checksum database
 // ---------------------------------------------------------------------------
 
+/// Hostnames the sumdb proxy is permitted to forward to.
+///
+/// SECURITY: `proxy_sumdb` builds `https://{host}/{path}` from URL path
+/// components controlled by the caller. Without an allowlist this is an
+/// SSRF vector — an attacker can request `sumdb/169.254.169.254/...`
+/// to make the server fetch cloud metadata. Only well-known Go
+/// checksum-database hosts may be proxied.
+const SUMDB_ALLOWLIST: &[&str] = &["sum.golang.org", "sum.golang.google.cn"];
+
+/// Returns true iff `host` is a permitted upstream sumdb hostname.
+/// Comparison is case-insensitive per RFC 1035.
+fn is_sumdb_host_allowed(host: &str) -> bool {
+    SUMDB_ALLOWLIST
+        .iter()
+        .any(|allowed| host.eq_ignore_ascii_case(allowed))
+}
+
 /// Proxy a sumdb request to the upstream checksum database.
 ///
 /// The Go toolchain performs go.sum verification by querying
 /// `$GOPROXY/sumdb/sum.golang.org/{path}`. We forward these requests
 /// to `https://{host}/{path}` (defaulting to sum.golang.org).
 async fn proxy_sumdb(host: &str, path: &str) -> Result<Response, Response> {
+    if !is_sumdb_host_allowed(host) {
+        tracing::warn!(
+            host = %host,
+            "Rejected sumdb proxy request to disallowed host (SSRF prevention)"
+        );
+        return Err((
+            StatusCode::FORBIDDEN,
+            format!(
+                "sumdb host '{}' is not in the allowlist of permitted upstreams",
+                host
+            ),
+        )
+            .into_response());
+    }
+
     let url = format!("https://{}/{}", host, path);
 
     tracing::debug!("Proxying sumdb request to {}", url);
@@ -1730,5 +1762,74 @@ mod tests {
             decode_module_path("github.com/!a!b/pkg"),
             "github.com/AB/pkg"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Sumdb host allowlist (SSRF prevention)
+    //
+    // proxy_sumdb forwards requests to https://{host}/{path} where {host}
+    // comes from the URL path component sumdb/{host}/.... Without an
+    // allowlist this is a textbook SSRF: an attacker can request
+    // /goproxy/{repo}/sumdb/169.254.169.254/latest/meta-data/iam/...
+    // and the server will fetch cloud metadata on their behalf.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_proxy_sumdb_rejects_aws_metadata_ssrf() {
+        // SECURITY: must reject SSRF attempts to AWS metadata service.
+        let result = proxy_sumdb("169.254.169.254", "latest/meta-data/").await;
+        let response = result.expect_err("proxy_sumdb must reject SSRF; instead it allowed it");
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "expected FORBIDDEN for SSRF attempt, got {}",
+            response.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_sumdb_rejects_internal_service_ssrf() {
+        // SECURITY: must reject SSRF attempts to internal cluster services.
+        let result = proxy_sumdb("internal-postgres.svc.cluster.local", "anything").await;
+        let response = result.expect_err("proxy_sumdb must reject internal-service SSRF");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_accepts_known_hosts() {
+        assert!(is_sumdb_host_allowed("sum.golang.org"));
+        assert!(is_sumdb_host_allowed("sum.golang.google.cn"));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_is_case_insensitive() {
+        // Hostnames are case-insensitive per RFC 1035.
+        assert!(is_sumdb_host_allowed("SUM.GOLANG.ORG"));
+        assert!(is_sumdb_host_allowed("Sum.Golang.Org"));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_rejects_cloud_metadata_endpoints() {
+        // SECURITY: cloud metadata endpoints are common SSRF targets.
+        assert!(!is_sumdb_host_allowed("169.254.169.254"));
+        assert!(!is_sumdb_host_allowed("metadata.google.internal"));
+        assert!(!is_sumdb_host_allowed("metadata.azure.com"));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_rejects_internal_services() {
+        assert!(!is_sumdb_host_allowed("localhost"));
+        assert!(!is_sumdb_host_allowed("127.0.0.1"));
+        assert!(!is_sumdb_host_allowed(
+            "internal-postgres.svc.cluster.local"
+        ));
+    }
+
+    #[test]
+    fn test_sumdb_allowlist_rejects_typosquatting() {
+        // SECURITY: prevent attacks via near-miss domain names.
+        assert!(!is_sumdb_host_allowed("sum.golang.org.evil.com"));
+        assert!(!is_sumdb_host_allowed("evil.com.sum.golang.org"));
+        assert!(!is_sumdb_host_allowed("sum-golang-org.evil.com"));
     }
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #879 (commit 3e529938) from main to release/1.1.x.

Closes the SSRF gap in `proxy_sumdb` where the upstream `sumdb` host was taken from a path segment without validation, letting an attacker redirect Go proxy verification traffic to arbitrary internal services or cloud-metadata endpoints. The handler now restricts `sumdb` to a hardcoded allowlist (`sum.golang.org`, `sum.golang.google.cn`) and rejects any other host with HTTP 403. Comparison is case-insensitive per RFC 1035.

This is one of the v1.1.9 release blockers per #886.

## Test Checklist
- [x] Unit tests added/updated (7 new tests covering accepts/rejects, case-insensitivity, cloud-metadata blocking, internal-service blocking, typosquatting blocking)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo check --workspace --tests` clean against release/1.1.x)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (security tightening on existing endpoint)