### PR TITLE
ci(docker-publish): build :1.1-dev image on release/1.1.x pushes (backport of #890 to 1.1.x)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Publish
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/1.1.x']
     tags: ['v*']
     paths-ignore:
       - '**/*.md'
@@ -488,6 +488,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -503,6 +504,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -607,6 +609,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -622,6 +625,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -711,6 +715,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -728,6 +733,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
## Summary

Backports #890 (`ci(docker-publish): build :1.1-dev image on release/1.1.x pushes`) from `main` to `release/1.1.x`. One-file workflow change.

## Why this is needed on the branch itself

GitHub Actions executes workflow files from the branch that triggered them. PR #890 was merged to `main` only on 2026-04-26, so the trigger config that enables push-builds for `release/1.1.x` exists on `main` but not on `release/1.1.x`. As a result, the docker-publish workflow has not fired on any merge into `release/1.1.x` (#891, #892, #900, #960, #962, #964, #970, #971, #955 etc.) since the original change. The `:1.1-dev` image is stuck at the 2026-04-28 manual `workflow_dispatch` and does not yet contain the wasmtime 36 backport (#971), the S3 fail-fast (#970), or the download-ticket consumer (#955).

This PR adds the same trigger and tag rules to the file living on `release/1.1.x` so future merges auto-publish.

Cherry-picked from commit `d8be81a34de80f64987b91ea0cc8ed54eb7a9e07`. Auto-merged cleanly.

## Test Checklist

- [x] N/A — CI workflow change; verification is the next merge to `release/1.1.x` triggering this workflow and producing a fresh `:1.1-dev` image.

## API Changes

- [x] N/A - no API changes

## Related

- Original: #890
- Tracking: #886 v1.1.9 stability release (release-gate runs against `:1.1-dev`)
- Without this fix: any release-gate run against `:1.1-dev` is testing pre-2026-04-28 code, defeating the gate's purpose for v1.1.9