### PR TITLE
fix: provision Dependency-Track API key when masked

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,9 +248,10 @@ JWT_EXPIRATION_SECS=86400
 # -----------------------------------------------------------------------------
 # Dependency-Track integration (backend)
 # -----------------------------------------------------------------------------
-# DEPENDENCY_TRACK_URL=http://dependency-track:8080
+# DEPENDENCY_TRACK_URL=http://dependency-track-apiserver:8080
 # DEPENDENCY_TRACK_API_KEY=xxx
 # DEPENDENCY_TRACK_ENABLED=true
+# DEPENDENCY_TRACK_ADMIN_PASSWORD=ArtifactKeeper2026!
 
 # Dependency-Track proxy (required if DTrack is behind a corporate proxy)
 # Without this, NVD vulnerability mirroring will silently fail.

--- a/backend/tests/docker_init_tests.rs
+++ b/backend/tests/docker_init_tests.rs
@@ -1,0 +1,126 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+#[test]
+fn init_dtrack_creates_key_when_existing_team_key_is_masked() {
+    let temp = tempfile::tempdir().unwrap();
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir(&bin_dir).unwrap();
+
+    let curl_log = temp.path().join("curl.log");
+    let api_key_file = temp.path().join("dtrack-api-key");
+
+    let fake_curl = format!(
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+
+case "$*" in
+  *"/api/version"*)
+    echo '{{"version":"4.14.1"}}'
+    ;;
+  *"/api/v1/user/login"*)
+    echo "test-token"
+    ;;
+  *"/api/v1/team/automation-team/key"*)
+    echo '{{"key":"odt_full_secret"}}'
+    ;;
+  *"/api/v1/team"*)
+    echo '[{{"name":"Automation","uuid":"automation-team","apiKeys":[{{"maskedKey":"odt_****abcd"}}]}}]'
+    ;;
+  *"/api/v1/configProperty"*)
+    echo "200"
+    ;;
+  *)
+    echo "unexpected curl call: $*" >&2
+    exit 1
+    ;;
+esac
+"#,
+        curl_log.display()
+    );
+    write_executable(&bin_dir.join("curl"), &fake_curl);
+
+    let fake_jq = r#"#!/bin/sh
+filter="$2"
+input="$(cat)"
+
+case "$filter" in
+  '.[] | select(.name == "Automation") | .apiKeys[0].key // empty')
+    case "$input" in
+      *'"key":"'*)
+        printf '%s\n' "$input" | sed 's/.*"key":"\([^"]*\)".*/\1/'
+        ;;
+    esac
+    ;;
+  '.[] | select(.name == "Automation") | .uuid // empty')
+    echo "automation-team"
+    ;;
+  '.key // empty')
+    echo "odt_full_secret"
+    ;;
+  '.[].name')
+    echo "Automation"
+    ;;
+  *)
+    echo "unexpected jq filter: $filter" >&2
+    exit 1
+    ;;
+esac
+"#;
+    write_executable(&bin_dir.join("jq"), fake_jq);
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let output = Command::new("/bin/sh")
+        .arg(repo_root().join("docker/init-dtrack.sh"))
+        .env("PATH", path)
+        .env("DEPENDENCY_TRACK_URL", "http://dtrack.test")
+        .env("DEPENDENCY_TRACK_ADMIN_PASSWORD", "ArtifactKeeper2026!")
+        .env("DTRACK_API_KEY_FILE", &api_key_file)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "script failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&api_key_file).unwrap(),
+        "odt_full_secret\n"
+    );
+
+    let curl_calls = fs::read_to_string(curl_log).unwrap();
+    assert!(
+        curl_calls.contains("-X PUT http://dtrack.test/api/v1/team/automation-team/key"),
+        "expected PUT key creation call, got:\n{curl_calls}"
+    );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,9 @@ services:
         condition: service_healthy
       dependency-track-apiserver:
         condition: service_healthy
+    environment:
+      DEPENDENCY_TRACK_URL: ${DEPENDENCY_TRACK_URL:-http://dependency-track-apiserver:8080}
+      DEPENDENCY_TRACK_ADMIN_PASSWORD: ${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}
     volumes:
       - ./docker/init-dtrack.sh:/init-dtrack.sh:ro,z
       - shared_config:/shared

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -10,7 +10,7 @@ DT_URL="${DEPENDENCY_TRACK_URL:-http://dependency-track-apiserver:8080}"
 DT_ADMIN_USER="admin"
 DT_DEFAULT_PASS="admin"
 DT_NEW_PASS="${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}"
-API_KEY_FILE="/shared/dtrack-api-key"
+API_KEY_FILE="${DTRACK_API_KEY_FILE:-/shared/dtrack-api-key}"
 BOOTSTRAP_MARKER="/shared/.dtrack-bootstrapped"
 
 echo "[dtrack-init] Waiting for Dependency-Track at $DT_URL ..."

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -62,16 +62,35 @@ fi
 
 echo "[dtrack-init] Authenticated successfully"
 
-# Extract the Automation team's API key using jq
-API_KEY=$(curl -sf "$DT_URL/api/v1/team" \
-  -H "Authorization: Bearer $TOKEN" | \
+# Get or create an Automation team API key. Newer Dependency-Track versions do
+# not always expose existing key material, so create one when none is visible.
+TEAMS_JSON=$(curl -sf "$DT_URL/api/v1/team" \
+  -H "Authorization: Bearer $TOKEN")
+
+API_KEY=$(echo "$TEAMS_JSON" | \
   jq -r '.[] | select(.name == "Automation") | .apiKeys[0].key // empty')
 
 if [ -z "$API_KEY" ]; then
-  echo "[dtrack-init] ERROR: Could not find Automation team API key" >&2
+  AUTOMATION_TEAM_UUID=$(echo "$TEAMS_JSON" | \
+    jq -r '.[] | select(.name == "Automation") | .uuid // empty')
+
+  if [ -z "$AUTOMATION_TEAM_UUID" ]; then
+    echo "[dtrack-init] ERROR: Could not find Automation team" >&2
+    echo "[dtrack-init] Available teams:"
+    echo "$TEAMS_JSON" | jq -r '.[].name' 2>/dev/null || true
+    exit 1
+  fi
+
+  echo "[dtrack-init] Creating Automation team API key..."
+  API_KEY=$(curl -sf -X PUT "$DT_URL/api/v1/team/$AUTOMATION_TEAM_UUID/key" \
+    -H "Authorization: Bearer $TOKEN" | \
+    jq -r '.key // empty')
+fi
+
+if [ -z "$API_KEY" ]; then
+  echo "[dtrack-init] ERROR: Could not provision Automation team API key" >&2
   echo "[dtrack-init] Available teams:"
-  curl -sf "$DT_URL/api/v1/team" \
-    -H "Authorization: Bearer $TOKEN" | jq -r '.[].name' 2>/dev/null || true
+  echo "$TEAMS_JSON" | jq -r '.[].name' 2>/dev/null || true
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Fixes `dtrack-init` so it can provision a usable Dependency-Track Automation team API key when existing team API keys are returned only as masked metadata.

The init script now:
- reuses a visible key when Dependency-Track returns one
- falls back to resolving the Automation team UUID
- creates a fresh API key with `PUT /api/v1/team/{uuid}/key`
- writes the returned full key to `/shared/dtrack-api-key`

Also wires the Dependency-Track init settings through Docker Compose so `.env` / `.env.example` values are applied consistently.

Closes #978

## Regression test (required for `fix/*` PRs)
<!--
Hardening Core (https://github.com/orgs/artifact-keeper/projects/2) requires
every bug-fix PR to land with a regression test that fails on `main` and
passes on this PR. Choose one that fits the bug:
  - unit test (closest to the buggy logic)
  - integration test (requires DB/storage/etc.)
  - end-to-end test in artifact-keeper-test (exercises the user flow)

For non-fix PRs (feat/, chore/, docs/, ci/, refactor/) check N/A.
Reviewers should not approve fix/* PRs without a checked box.
-->
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
