### PR TITLE
fix(handlers): backport LIKE wildcard escape to 1.1.x (#984)

### DIFF
--- a/.sqlx/query-2236e1cc46653c82524cebe626b1cef84cf3458654455fba01b4467613c13b6a.json
+++ b/.sqlx/query-2236e1cc46653c82524cebe626b1cef84cf3458654455fba01b4467613c13b6a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT storage_key, content_type\n        FROM artifacts\n        WHERE repository_id = $1 AND path LIKE $2 || $3 AND is_deleted = false\n        LIMIT 1",
+  "query": "SELECT storage_key, content_type\n        FROM artifacts\n        WHERE repository_id = $1 AND path LIKE $2 || $3 ESCAPE '\\' AND is_deleted = false\n        LIMIT 1",
   "describe": {
     "columns": [
       {
@@ -26,5 +26,5 @@
       false
     ]
   },
-  "hash": "81c95ae7856779504cf8b4a63f56b60f8d7d2fff35e997895045cac317db7711"
+  "hash": "2236e1cc46653c82524cebe626b1cef84cf3458654455fba01b4467613c13b6a"
 }

--- a/.sqlx/query-584883b0d93314604fc2a261d5d22dd0ee5a9d3cf9eff3c30fabe4f1b4c4dbe7.json
+++ b/.sqlx/query-584883b0d93314604fc2a261d5d22dd0ee5a9d3cf9eff3c30fabe4f1b4c4dbe7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, path, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE '%/' || $2\n        LIMIT 1\n        ",
+  "query": "\n        SELECT id, path, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE '%/' || $2 ESCAPE '\\'\n        LIMIT 1\n        ",
   "describe": {
     "columns": [
       {
@@ -43,5 +43,5 @@
       false
     ]
   },
-  "hash": "605b301fd529b8d41b02c55c35688a94688fb608efbe91bffcf34d6ac6ecd153"
+  "hash": "584883b0d93314604fc2a261d5d22dd0ee5a9d3cf9eff3c30fabe4f1b4c4dbe7"
 }

--- a/.sqlx/query-5d97e8a01b88d8af16b2bd57317e2961550066eaae65d571b4d4f79afc86a386.json
+++ b/.sqlx/query-5d97e8a01b88d8af16b2bd57317e2961550066eaae65d571b4d4f79afc86a386.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE $2\n        LIMIT 1\n        ",
+  "query": "\n        SELECT id, path, name, version, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE '%/' || $2 ESCAPE '\\'\n        LIMIT 1\n        ",
   "describe": {
     "columns": [
       {
@@ -20,16 +20,21 @@
       },
       {
         "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
         "name": "size_bytes",
         "type_info": "Int8"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "checksum_sha256",
         "type_info": "Bpchar"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "storage_key",
         "type_info": "Varchar"
       }
@@ -44,10 +49,11 @@
       false,
       false,
       false,
+      true,
       false,
       false,
       false
     ]
   },
-  "hash": "94bf14be7e71718fd184a4d1ada7143e388b2ebb5a06b9440113adf2814227f4"
+  "hash": "5d97e8a01b88d8af16b2bd57317e2961550066eaae65d571b4d4f79afc86a386"
 }

--- a/.sqlx/query-7437aa5f83fa8ac03d71aa130b1aa77dc3d86978e72511f9812ba0b22f82ec94.json
+++ b/.sqlx/query-7437aa5f83fa8ac03d71aa130b1aa77dc3d86978e72511f9812ba0b22f82ec94.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE $2 ESCAPE '\\'\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7437aa5f83fa8ac03d71aa130b1aa77dc3d86978e72511f9812ba0b22f82ec94"
+}

--- a/.sqlx/query-dbce4f53f1bfeeab3230d00c8a400bb8fc7b7df69df6b6a416ef1d30fd663103.json
+++ b/.sqlx/query-dbce4f53f1bfeeab3230d00c8a400bb8fc7b7df69df6b6a416ef1d30fd663103.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE '%/' || $2\n        LIMIT 1\n        ",
+  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE '%/' || $2 ESCAPE '\\'\n        LIMIT 1\n        ",
   "describe": {
     "columns": [
       {
@@ -49,5 +49,5 @@
       false
     ]
   },
-  "hash": "5d9e64731c022c0acec9f8f66ee761f83b886bacb73fecacfa908fadaa04ebf2"
+  "hash": "dbce4f53f1bfeeab3230d00c8a400bb8fc7b7df69df6b6a416ef1d30fd663103"
 }

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -223,6 +223,9 @@ async fn download_chart(
     Path((repo_key, filename)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_helm_repo(&state.db, &repo_key).await?;
+    // Escape `%` and `_` so user-supplied filename is matched as a literal,
+    // not a LIKE wildcard. See `crate::api::handlers::escape_like_literal`.
+    let filename_escaped = super::escape_like_literal(&filename);
 
     // Find artifact by filename pattern
     let artifact = sqlx::query!(
@@ -231,11 +234,11 @@ async fn download_chart(
         FROM artifacts
         WHERE repository_id = $1
           AND is_deleted = false
-          AND path LIKE '%/' || $2
+          AND path LIKE '%/' || $2 ESCAPE '\'
         LIMIT 1
         "#,
         repo.id,
-        filename
+        filename_escaped
     )
     .fetch_optional(&state.db)
     .await

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -18,6 +18,27 @@ pub async fn cleanup_soft_deleted_artifact(
     .await;
 }
 
+/// Escape SQL `LIKE` wildcards (`%`, `_`) and the escape character (`\`) in
+/// user-supplied input that will be concatenated into a `LIKE` pattern.
+///
+/// Use together with an `ESCAPE '\'` clause on the SQL side. Without this
+/// helper, a user-supplied path component containing `%` or `_` would act
+/// as a wildcard rather than a literal — leaking other artifact paths inside
+/// the same repository (info disclosure / wrong-artifact serving).
+pub fn escape_like_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' | '%' | '_' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 pub mod error_helpers;
 
 pub mod admin;
@@ -97,3 +118,48 @@ pub mod users;
 pub mod vscode;
 pub mod wasm_proxy;
 pub mod webhooks;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // escape_like_literal — SQL LIKE wildcard escape for user-supplied input
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_escape_like_literal_passes_safe_chars_through() {
+        assert_eq!(escape_like_literal("foo-1.0.0.tgz"), "foo-1.0.0.tgz");
+        assert_eq!(escape_like_literal(""), "");
+        assert_eq!(escape_like_literal("@types/mdurl"), "@types/mdurl");
+    }
+
+    #[test]
+    fn test_escape_like_literal_escapes_percent() {
+        // SECURITY: a `%` from user input must not act as a LIKE wildcard.
+        assert_eq!(escape_like_literal("%"), r"\%");
+        assert_eq!(escape_like_literal("%.gem"), r"\%.gem");
+        assert_eq!(escape_like_literal("foo%bar%baz"), r"foo\%bar\%baz");
+    }
+
+    #[test]
+    fn test_escape_like_literal_escapes_underscore() {
+        // SECURITY: a `_` from user input must not act as a LIKE single-char wildcard.
+        assert_eq!(escape_like_literal("_"), r"\_");
+        assert_eq!(escape_like_literal("foo_bar"), r"foo\_bar");
+    }
+
+    #[test]
+    fn test_escape_like_literal_escapes_backslash() {
+        // SECURITY: a `\` must be escaped so it doesn't itself act as the LIKE
+        // escape character (we use `ESCAPE '\'` on the SQL side).
+        assert_eq!(escape_like_literal(r"\"), r"\\");
+        assert_eq!(escape_like_literal(r"foo\bar"), r"foo\\bar");
+    }
+
+    #[test]
+    fn test_escape_like_literal_combined_payload() {
+        // Adversarial filename mixing all special chars.
+        assert_eq!(escape_like_literal(r"%_\evil"), r"\%\_\\evil");
+    }
+}

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -741,15 +741,21 @@ async fn npm_local_fetch(
     // Fall back to a pattern that anchors the match on the decoded package
     // name, covering locally published artifacts whose path follows the
     // layout "{package_name}/{version}/{filename}".
-    let pkg_path_prefix = format!("{}/%/", package_name);
+    //
+    // Escape `%` and `_` from the user-supplied package_name and filename
+    // so they're treated as literals; the literal `/%/` separator below
+    // remains a wildcard. The ESCAPE '\' clause on the SQL side makes
+    // backslash the escape character. See `super::escape_like_literal`.
+    let pkg_path_prefix = format!("{}/%/", super::escape_like_literal(package_name));
+    let filename_escaped = super::escape_like_literal(filename);
     let artifact = sqlx::query!(
         r#"SELECT storage_key, content_type
         FROM artifacts
-        WHERE repository_id = $1 AND path LIKE $2 || $3 AND is_deleted = false
+        WHERE repository_id = $1 AND path LIKE $2 || $3 ESCAPE '\' AND is_deleted = false
         LIMIT 1"#,
         repo_id,
         pkg_path_prefix,
-        filename
+        filename_escaped
     )
     .fetch_optional(db)
     .await
@@ -836,14 +842,23 @@ async fn serve_tarball(
     // name in the path match to avoid returning a different package's tarball
     // when two packages share the same filename (e.g. @types/mdurl and mdurl
     // both produce mdurl-2.0.0.tgz).
-    let path_pattern = format!("{}/%/{}", package_name, filename);
+    //
+    // Escape `%` and `_` in the user-supplied package_name and filename so
+    // they're treated as literals; the literal `/%/` separator remains a
+    // wildcard. ESCAPE '\' on the SQL side selects backslash as the escape
+    // character. See `super::escape_like_literal`.
+    let path_pattern = format!(
+        "{}/%/{}",
+        super::escape_like_literal(package_name),
+        super::escape_like_literal(filename)
+    );
     let artifact = sqlx::query!(
         r#"
         SELECT id, path, name, size_bytes, checksum_sha256, storage_key
         FROM artifacts
         WHERE repository_id = $1
           AND is_deleted = false
-          AND path LIKE $2
+          AND path LIKE $2 ESCAPE '\'
         LIMIT 1
         "#,
         repo.id,

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -425,6 +425,9 @@ async fn download_package(
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
 
     let filename = pkg_path.rsplit('/').next().unwrap_or(&pkg_path);
+    // Escape `%` and `_` so user-supplied filename is matched as a literal,
+    // not a LIKE wildcard. See `crate::api::handlers::escape_like_literal`.
+    let filename_escaped = super::escape_like_literal(filename);
 
     let artifact = sqlx::query!(
         r#"
@@ -432,11 +435,11 @@ async fn download_package(
         FROM artifacts
         WHERE repository_id = $1
           AND is_deleted = false
-          AND path LIKE '%/' || $2
+          AND path LIKE '%/' || $2 ESCAPE '\'
         LIMIT 1
         "#,
         repo.id,
-        filename
+        filename_escaped
     )
     .fetch_optional(&state.db)
     .await

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -249,6 +249,10 @@ async fn download_gem(
     let repo = resolve_rubygems_repo(&state.db, &repo_key).await?;
 
     let filename = gem_file.trim_start_matches('/');
+    // Escape `%` and `_` in user-supplied filename so they're treated as
+    // literals in the LIKE pattern below, not wildcards. See
+    // `crate::api::handlers::escape_like_literal`.
+    let filename_escaped = super::escape_like_literal(filename);
 
     // Find artifact by matching the path ending
     let artifact = sqlx::query!(
@@ -257,11 +261,11 @@ async fn download_gem(
         FROM artifacts
         WHERE repository_id = $1
           AND is_deleted = false
-          AND path LIKE '%/' || $2
+          AND path LIKE '%/' || $2 ESCAPE '\'
         LIMIT 1
         "#,
         repo.id,
-        filename
+        filename_escaped
     )
     .fetch_optional(&state.db)
     .await


### PR DESCRIPTION
## Summary

Backport of #984 to `release/1.1.x`. Same bug class as the maven LIKE-wildcard
escape (#881): user-supplied path components were interpolated into a
parameterized LIKE clause without escaping `%` and `_`, allowing wildcard
injection within a single repository's namespace (info disclosure /
wrong-artifact serving).

Affected sites (paths/lines as in 1.1.x):
- `rubygems.rs` — `download_gem`
- `rpm.rs` — `download_package`
- `helm.rs` — `download_chart`
- `npm.rs` — `npm_local_fetch` (first LIKE)
- `npm.rs` — `serve_tarball` (second LIKE pattern built with `format!`)

Adds shared `escape_like_literal` helper to `api::handlers::mod.rs`
(alongside the existing `cleanup_soft_deleted_artifact`). Each site escapes
user-supplied fragments and adds `ESCAPE '\'` to the SQL.

Not SQL injection — sqlx parameterizes correctly. Wildcard-injection only.

## Backport Notes
- Cherry-pick from `fix/like-wildcard-escape-package-handlers` had conflicts in `npm.rs` (release/1.1.x's `npm_local_fetch` still uses `query!` with the older `(storage_key, content_type)` row shape — main introduced `proxy_helpers::LocalArtifactRow` with quarantine fields). Resolved by preserving the 1.1.x query shape and applying just the escape + `ESCAPE '\'` clause.
- `.sqlx/` cache restored from release/1.1.x baseline and regenerated against 1.1.x migrations (74 applied).

## Test Checklist
- [x] Unit tests added/updated (5 new in `api::handlers::tests` — safe input, percent, underscore, backslash, combined adversarial payload)
- [ ] Integration tests added/updated — N/A; bug is in pattern-builder, covered by unit tests
- [ ] E2E tests added/updated — N/A
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --all-targets -- -D warnings` clean
- [x] `cargo test --lib api::handlers` — 3091 passed; 0 failed
- [x] No regressions in existing tests

## API Changes
- [x] N/A — no API changes

## Notes

Behavior change: package filenames and names containing `%` or `_` are now
treated as literals rather than LIKE wildcards. No legitimate package
coordinate in the affected handlers contains these characters.

Regenerated `.sqlx/` query cache for the five `query!()` invocations that
gained the `ESCAPE '\'` clause.