### PR TITLE
test(auth): scope GC tests to per-test user_id to fix llvm-cov parallel race

### DIFF
--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -3092,6 +3092,13 @@ mod tests {
 
         // Insert one aged row (older than the refresh-token TTL) and one
         // fresh row. GC should remove only the aged row.
+        //
+        // NOTE: production GC (`DELETE FROM used_refresh_jtis WHERE used_at < $1`)
+        // is intentionally global, so when this suite runs in parallel against a
+        // shared Postgres (e.g. `cargo llvm-cov --workspace --lib`), other tests'
+        // rows are visible to our `removed` count. We therefore assert outcomes
+        // by inspecting only THIS test's specific jti rows rather than the
+        // global `removed` count. The production path is still exercised end-to-end.
         let aged = Uuid::new_v4();
         sqlx::query(
             "INSERT INTO used_refresh_jtis (jti, user_id, used_at) \
@@ -3111,8 +3118,7 @@ mod tests {
             .await
             .expect("insert fresh jti");
 
-        let removed = svc.gc_used_refresh_jtis().await.expect("gc");
-        assert!(removed >= 1, "gc must reap at least the aged row");
+        svc.gc_used_refresh_jtis().await.expect("gc");
 
         let aged_exists: (bool,) =
             sqlx::query_as("SELECT EXISTS(SELECT 1 FROM used_refresh_jtis WHERE jti = $1)")
@@ -3135,7 +3141,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_gc_used_refresh_jtis_returns_zero_when_nothing_old() {
-        // Boundary: when no aged rows exist, GC returns 0 without erroring.
+        // Boundary: when no aged rows exist for THIS test's user, GC must
+        // leave that user's fresh row intact and return Ok without erroring.
+        //
+        // NOTE: production GC is global, so we cannot assert `removed == 0`
+        // when other tests run concurrently against the same database. Instead
+        // we scope the post-condition to this test's user_id and verify that
+        // the fresh row we inserted survives. This still proves "fresh rows
+        // are not reaped" — the assertion this test was designed to make.
         let Some(pool) = try_connect_test_db().await else {
             eprintln!("skip: DATABASE_URL unset or schema missing");
             return;
@@ -3143,10 +3156,6 @@ mod tests {
         let user_id = insert_test_user(&pool).await;
         let cfg = make_test_config();
         let svc = AuthService::new(pool.clone(), cfg.clone());
-
-        // First, reap any aged rows from previous failed runs so we get a
-        // clean baseline for the assertion below.
-        let _ = svc.gc_used_refresh_jtis().await;
 
         // Insert only fresh rows.
         let jti = Uuid::new_v4();
@@ -3157,8 +3166,21 @@ mod tests {
             .await
             .expect("insert fresh jti");
 
-        let removed = svc.gc_used_refresh_jtis().await.expect("gc");
-        assert_eq!(removed, 0, "fresh rows must not be reaped");
+        svc.gc_used_refresh_jtis().await.expect("gc");
+
+        // The fresh row for THIS test's user must still be present after GC.
+        let fresh_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM used_refresh_jtis WHERE user_id = $1 AND jti = $2",
+        )
+        .bind(user_id)
+        .bind(jti)
+        .fetch_one(&pool)
+        .await
+        .expect("count fresh");
+        assert_eq!(
+            fresh_count.0, 1,
+            "fresh row for this user must not be reaped"
+        );
 
         // Cleanup the row we just inserted before deleting the user, since
         // the FK has no cascade configured for jti rows in older migrations.


### PR DESCRIPTION
## Summary

Fixes the two flaky `services::auth_service::tests::test_gc_used_refresh_jtis_*` tests that block PR #995's Code Coverage gate when running on `release/1.1.x`.

**The race:** both tests share the `used_refresh_jtis` table and assert on the global `removed` count returned by `AuthService::gc_used_refresh_jtis()`, whose production query is intentionally global:

```sql
DELETE FROM used_refresh_jtis WHERE used_at < $1
```

Under default `cargo llvm-cov --workspace --lib` thread count the two tests interleave:

- Test A inserts an aged row + fresh row, then test B's pre-clean GC reaps A's aged row before A asserts. A's `removed >= 1` then fails.
- Test B asserts `removed == 0`, but A's concurrently-inserted aged row makes B's GC return `>= 1`.

`--test-threads=1` masks both, but PR #995's CI runs default thread count.

**The fix (option A from the dispatch brief):** keep production GC global (it must be), but assert outcomes per-test by inspecting only rows owned by each test's freshly created `user_id`/`jti`. The production GC path is still exercised end-to-end; we just verify per-test-row outcomes instead of a global counter that races against sibling tests.

- ~30 LoC delta, tests only.
- No new dependencies.
- Production `gc_used_refresh_jtis` behavior unchanged.

Option B (`#[serial_test::serial]`) was rejected because the suite has 91 auth tests already passing in parallel; serializing two of them works but loses concurrency for no semantic gain over option A. Option C (refactoring production GC to accept an optional `user_id` filter) was rejected as too invasive for a test-only need.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (10/10 parallel runs of the two GC tests pass; 5/5 parallel runs of all 91 auth_service tests pass)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes