### PR TITLE
ci(docker-publish): self-verify ghcr.io semver tags, drop redundant release dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -789,6 +789,85 @@ jobs:
           done
         continue-on-error: true
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # VERIFY-PUBLISHED: fail fast if a tag-triggered run did not actually
+  # publish the expected semver tags on ghcr.io.
+  #
+  # Background: issue #905 was filed because operators believed semver tags
+  # (1.1.7, 1.1.8) were missing on ghcr.io. The reproduction used
+  # `gh api .../packages/.../versions` without `--paginate`; that endpoint
+  # returns at most 30 versions per page sorted by recency, and the page is
+  # dominated by sha-prefixed dev/branch tags, so semver tags get pushed off
+  # the visible window. The tags were in fact present.
+  #
+  # To make the publish contract self-evident, this job probes the registry
+  # the same way consumers do (a HEAD on the manifest endpoint) and fails
+  # the workflow if any expected semver tag is missing for the current ref.
+  # That way we catch the real failure mode (a push that silently no-op'd)
+  # in the publish workflow itself, not days later via a broken helm install.
+  # ════════════════════════════════════════════════════════════════════════════
+  verify-published:
+    name: Verify Published Tags
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    needs: [merge-backend, merge-openscap, merge-backend-alpine]
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Probe ghcr.io manifests for expected semver tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          OPENSCAP_IMAGE: ${{ env.OPENSCAP_IMAGE }}
+        run: |
+          set -u
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Verifying ghcr.io semver tags for version: ${VERSION}"
+
+          MANIFEST_ACCEPT='-H Accept:application/vnd.oci.image.index.v1+json -H Accept:application/vnd.docker.distribution.manifest.list.v2+json -H Accept:application/vnd.docker.distribution.manifest.v2+json'
+
+          probe_ghcr() {
+            local name="$1"; local tag="$2"
+            local token
+            token=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${name}:pull" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              | jq -r '.token // empty')
+            [ -n "${token}" ] || return 1
+            # shellcheck disable=SC2086
+            curl -sfL --proto =https -o /dev/null \
+              -H "Authorization: Bearer ${token}" \
+              ${MANIFEST_ACCEPT} \
+              "https://ghcr.io/v2/${name}/manifests/${tag}"
+          }
+
+          # Tags this workflow promises to publish on a tag push. Mirror the
+          # metadata-action `tags:` blocks above. Alpine variant gets the
+          # `-alpine` suffix from the metadata-action `flavor` setting.
+          EXPECTED=(
+            "${BACKEND_IMAGE}:${VERSION}"
+            "${BACKEND_IMAGE}:${VERSION}-alpine"
+            "${OPENSCAP_IMAGE}:${VERSION}"
+          )
+
+          missing=()
+          for entry in "${EXPECTED[@]}"; do
+            name="${entry%:*}"
+            tag="${entry#*:}"
+            if probe_ghcr "${name}" "${tag}"; then
+              echo "  ok  ghcr.io/${name}:${tag}"
+            else
+              echo "::error::ghcr.io/${name}:${tag} is missing"
+              missing+=("ghcr.io/${name}:${tag}")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Tag-triggered publish completed but some expected semver tags are not present on ghcr.io. Inspect the merge-* jobs for silent imagetools failures."
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "All expected ghcr.io semver tags present for ${VERSION}."
+
   summary:
     name: Publish Summary
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,23 +363,14 @@ jobs:
           client-payload: '{"version": "${{ steps.version.outputs.version }}", "tag": "${{ steps.version.outputs.tag }}"}'
 
   # ════════════════════════════════════════════════════════════════════════════
-  # PUBLISH DOCKER IMAGES (only when gates pass, release is not draft)
+  # NOTE: Docker images are published by .github/workflows/docker-publish.yml,
+  # which already triggers on `tags: ['v*']`. We previously had a redundant
+  # `docker-release` job here that re-dispatched docker-publish via
+  # workflow_dispatch after the release was created. That second run
+  # (a) duplicated ~30 minutes of multi-arch build work, and (b) could only
+  # produce inferior tags because workflow_dispatch loses the tag context
+  # required by docker/metadata-action's `type=semver` patterns. Removing it
+  # leaves a single, deterministic publish path: tag push triggers
+  # docker-publish.yml, which now self-verifies the published semver tags
+  # before the run can succeed (see issue #905).
   # ════════════════════════════════════════════════════════════════════════════
-
-  docker-release:
-    name: Publish Docker Images
-    runs-on: ubuntu-latest
-    needs: [release, release-gate, mesh-e2e-gate]
-    if: |
-      always() &&
-      needs.release.result == 'success' &&
-      needs.release-gate.result == 'success'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Trigger Docker publish
-        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
-        with:
-          workflow: docker-publish.yml
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #905.

The issue reported that backend (and possibly OpenSCAP) semver tags were missing on `ghcr.io` after a release tag push. Investigation showed the tags **were** in fact published correctly:

```
$ for tag in 1.1.0 1.1.6 1.1.7 1.1.8; do
    curl -sf -H "Authorization: Bearer $TOKEN" \
      "https://ghcr.io/v2/artifact-keeper/artifact-keeper-backend/manifests/${tag}" \
      -o /dev/null && echo "${tag}: 200" || echo "${tag}: 404"
  done
1.1.0: 200
1.1.6: 200
1.1.7: 200
1.1.8: 200
```

Same outcome for `artifact-keeper-openscap`. The reproduction in the issue used `gh api .../packages/.../versions` without `--paginate`; that endpoint returns at most 30 versions per page sorted by recency, and the page is dominated by sha-prefixed dev/branch tags (every push to `release/1.1.x` adds a fresh sha tag), so the older semver tags are pushed off the visible window. They are still there.

This PR closes the visibility gap two ways:

1. **`docker-publish.yml`**: adds a `verify-published` job that runs after the multi-arch merge jobs on tag pushes. It probes `ghcr.io` directly for every semver tag this workflow promises to publish (`backend:VERSION`, `backend:VERSION-alpine`, `openscap:VERSION`) and fails the run if any are missing. Future regressions are caught in-band, in the workflow that introduced them, instead of surfacing days later via a broken `helm install`.

2. **`release.yml`**: removes the `docker-release` job that re-dispatched `docker-publish.yml` via `workflow_dispatch` after the release was created. That second run (a) duplicated ~30 minutes of multi-arch build work, and (b) produced inferior tags because `workflow_dispatch` loses the tag context that `docker/metadata-action`'s `type=semver` patterns rely on, so the rerun only generated branch/sha/dev tags. `docker-publish.yml` already triggers on tag push directly; the dispatch added cost and race-condition surface without adding value.

Note: `artifact-keeper-web` does have a real semver-tag gap on ghcr.io (`web:1.1.6/7/8` return 404). That is tracked separately in artifact-keeper-web#320 and needs a fix in that repo's workflow.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The new `verify-published` job is itself the regression test: it would fail any future tag-triggered run that silently fails to publish one of the expected semver tags on `ghcr.io`. The probe uses the same `https://ghcr.io/v2/<name>/manifests/<tag>` endpoint that consumers (`docker pull`, `helm install`) hit, so a green run proves the contract end-to-end.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification:

- Validated `python3 -c "import yaml; yaml.safe_load(...)"` on both modified workflow files.
- Confirmed via direct `ghcr.io` manifest probes that the verify step's expected tags are present for every `1.1.x` release shipped to date (so the new gate would not have falsely failed any historic release).
- Confirmed via `gh run view --log` on run `24751199244` (v1.1.8 push) that the merge-* jobs do successfully push semver tags to ghcr.io; the verify step exercises the same artefacts.
- The verify step itself cannot be exercised end-to-end without a tag push; will be implicitly validated on the first `v1.1.10*` tag.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes