### PR TITLE
fix(dtrack-init): create new API key via POST instead of reading masked metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,9 +185,10 @@ JWT_EXPIRATION_SECS=86400
 # -----------------------------------------------------------------------------
 # Dependency-Track integration (backend)
 # -----------------------------------------------------------------------------
-# DEPENDENCY_TRACK_URL=http://dependency-track:8080
+# DEPENDENCY_TRACK_URL=http://dependency-track-apiserver:8080
 # DEPENDENCY_TRACK_API_KEY=xxx
 # DEPENDENCY_TRACK_ENABLED=true
+# DEPENDENCY_TRACK_ADMIN_PASSWORD=ArtifactKeeper2026!
 
 # Dependency-Track proxy (required if DTrack is behind a corporate proxy)
 # Without this, NVD vulnerability mirroring will silently fail.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,9 @@ services:
         condition: service_healthy
       dependency-track-apiserver:
         condition: service_healthy
+    environment:
+      DEPENDENCY_TRACK_URL: ${DEPENDENCY_TRACK_URL:-http://dependency-track-apiserver:8080}
+      DEPENDENCY_TRACK_ADMIN_PASSWORD: ${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}
     volumes:
       - ./docker/init-dtrack.sh:/init-dtrack.sh:ro,z
       - shared_config:/shared

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -21,8 +21,19 @@ DT_URL="${DEPENDENCY_TRACK_URL:-http://dependency-track-apiserver:8080}"
 DT_ADMIN_USER="admin"
 DT_DEFAULT_PASS="admin"
 DT_NEW_PASS="${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}"
+DT_TEAM_NAME="Automation"
 API_KEY_FILE="/shared/dtrack-api-key"
 BOOTSTRAP_MARKER="/shared/.dtrack-bootstrapped"
+
+# Login against /api/v1/user/login. DT returns a bare JWT string body on
+# success and a body containing "FORCE_PASSWORD_CHANGE" when the default
+# password has not yet been rotated. The caller decides which response is
+# acceptable; we just echo the body.
+dt_login() {
+  curl -sf -X POST "$DT_URL/api/v1/user/login" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "username=${DT_ADMIN_USER}&password=$1" 2>/dev/null || true
+}
 
 echo "[dtrack-init] Waiting for Dependency-Track at $DT_URL ..."
 for i in $(seq 1 60); do
@@ -46,9 +57,7 @@ if [ -f "$API_KEY_FILE" ] && [ -s "$API_KEY_FILE" ]; then
 fi
 
 # Try login with the new password first (already changed in a previous partial run)
-TOKEN=$(curl -sf -X POST "$DT_URL/api/v1/user/login" \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=${DT_ADMIN_USER}&password=${DT_NEW_PASS}" 2>/dev/null || true)
+TOKEN=$(dt_login "$DT_NEW_PASS")
 
 if [ -z "$TOKEN" ] || echo "$TOKEN" | grep -qi "FORCE_PASSWORD_CHANGE"; then
   # First boot: change the default admin password
@@ -63,9 +72,7 @@ if [ -z "$TOKEN" ] || echo "$TOKEN" | grep -qi "FORCE_PASSWORD_CHANGE"; then
   fi
 
   # Login with new password
-  TOKEN=$(curl -sf -X POST "$DT_URL/api/v1/user/login" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${DT_ADMIN_USER}&password=${DT_NEW_PASS}" 2>/dev/null || true)
+  TOKEN=$(dt_login "$DT_NEW_PASS")
 fi
 
 if [ -z "$TOKEN" ]; then
@@ -85,24 +92,25 @@ if [ -z "$TEAM_JSON" ]; then
   exit 1
 fi
 
-TEAM_UUID=$(echo "$TEAM_JSON" | jq -r '.[] | select(.name == "Automation") | .uuid // empty')
+TEAM_UUID=$(echo "$TEAM_JSON" | jq -r --arg name "$DT_TEAM_NAME" \
+  '.[] | select(.name == $name) | .uuid // empty')
 
 if [ -z "$TEAM_UUID" ]; then
-  echo "[dtrack-init] ERROR: Could not find Automation team" >&2
+  echo "[dtrack-init] ERROR: Could not find $DT_TEAM_NAME team" >&2
   echo "[dtrack-init] Available teams:" >&2
-  echo "$TEAM_JSON" | jq -r '.[].name' >&2 2>/dev/null || true
+  echo "$TEAM_JSON" | jq -r '.[].name' 2>/dev/null >&2 || true
   exit 1
 fi
-echo "[dtrack-init] Found Automation team: $TEAM_UUID"
+echo "[dtrack-init] Found $DT_TEAM_NAME team: $TEAM_UUID"
 
 # Rotate: delete every pre-existing key on the Automation team. Each helm
 # upgrade that reaches this branch (i.e. shared volume is empty) starts
 # fresh, preventing key accumulation. DELETE returns 204 on success;
 # missing/already-gone keys are ignored.
-EXISTING_PUBLIC_IDS=$(echo "$TEAM_JSON" | \
-  jq -r '.[] | select(.name == "Automation") | .apiKeys[]?.publicId // empty')
+EXISTING_PUBLIC_IDS=$(echo "$TEAM_JSON" | jq -r --arg name "$DT_TEAM_NAME" \
+  '.[] | select(.name == $name) | .apiKeys[]?.publicId // empty')
 if [ -n "$EXISTING_PUBLIC_IDS" ]; then
-  echo "[dtrack-init] Rotating existing Automation API keys..."
+  echo "[dtrack-init] Rotating existing $DT_TEAM_NAME API keys..."
   echo "$EXISTING_PUBLIC_IDS" | while IFS= read -r PUBLIC_ID; do
     [ -z "$PUBLIC_ID" ] && continue
     DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -117,7 +125,7 @@ fi
 
 # Create a fresh API key. DT 4.x returns the unmasked secret in the
 # response body of this single call — there is no other way to retrieve it.
-echo "[dtrack-init] Generating new Automation API key..."
+echo "[dtrack-init] Generating new $DT_TEAM_NAME API key..."
 KEY_RESP=$(curl -sf -X POST "$DT_URL/api/v1/team/$TEAM_UUID/key" \
   -H "Authorization: Bearer $TOKEN" || true)
 

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -137,8 +137,13 @@ fi
 API_KEY=$(echo "$KEY_RESP" | jq -r '.key // empty')
 
 if [ -z "$API_KEY" ]; then
+  # Do NOT log $KEY_RESP — if the schema ever moves .key (e.g. to .data.key)
+  # the unmasked secret is in that body and would leak to log aggregation.
+  # Log only structural diagnostics.
   echo "[dtrack-init] ERROR: Could not extract .key from create-key response" >&2
-  echo "[dtrack-init] Response was: $KEY_RESP" >&2
+  echo "[dtrack-init] Response length: ${#KEY_RESP} bytes" >&2
+  RESP_KEYS=$(echo "$KEY_RESP" | jq -r 'keys // []' 2>/dev/null || echo '<not-json>')
+  echo "[dtrack-init] Response top-level keys: $RESP_KEYS" >&2
   exit 1
 fi
 

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
-# Bootstrap Dependency-Track: change default password and extract API key.
+# Bootstrap Dependency-Track: change default password and provision API key.
 # Runs as an init container, writes the API key to a shared volume.
 #
 # Requires: curl, jq (use alpine/curl + apk add jq, or similar)
 # Idempotent: safe to run multiple times.
+#
+# Bug #978: Dependency-Track 4.x no longer exposes existing key material on
+# `GET /api/v1/team` — only `maskedKey` is returned for previously-created
+# keys. The unmasked key is only ever returned in the response body of
+# `POST /api/v1/team/<uuid>/key`. We must therefore *create* a fresh key
+# and capture the response, rather than try to read an existing one.
+#
+# Idempotence strategy: on each run we delete every existing key on the
+# Automation team (using `publicId` from the GET listing) and then POST a
+# new one. This keeps the team to a single active key across reruns and
+# prevents accumulation across helm upgrades.
 set -e
 
 DT_URL="${DEPENDENCY_TRACK_URL:-http://dependency-track-apiserver:8080}"
@@ -26,7 +37,9 @@ for i in $(seq 1 60); do
 done
 echo "[dtrack-init] Dependency-Track is up"
 
-# If API key file already exists from a previous run, skip all provisioning
+# If API key file already exists from a previous run, skip all provisioning.
+# This is the fast path on helm upgrades — we don't rotate unless the shared
+# volume has been wiped.
 if [ -f "$API_KEY_FILE" ] && [ -s "$API_KEY_FILE" ]; then
   echo "[dtrack-init] API key already provisioned at $API_KEY_FILE — skipping"
   exit 0
@@ -62,21 +75,71 @@ fi
 
 echo "[dtrack-init] Authenticated successfully"
 
-# Extract the Automation team's API key using jq
-API_KEY=$(curl -sf "$DT_URL/api/v1/team" \
-  -H "Authorization: Bearer $TOKEN" | \
-  jq -r '.[] | select(.name == "Automation") | .apiKeys[0].key // empty')
-
-if [ -z "$API_KEY" ]; then
-  echo "[dtrack-init] ERROR: Could not find Automation team API key" >&2
-  echo "[dtrack-init] Available teams:"
-  curl -sf "$DT_URL/api/v1/team" \
-    -H "Authorization: Bearer $TOKEN" | jq -r '.[].name' 2>/dev/null || true
+# Look up the Automation team's UUID and existing key publicIds.
+# DT 4.x only returns `maskedKey` and `publicId` for existing keys, so we
+# can't extract the actual secret here — we use this only to identify the
+# team and to enumerate stale keys for rotation.
+TEAM_JSON=$(curl -sf "$DT_URL/api/v1/team" -H "Authorization: Bearer $TOKEN" || true)
+if [ -z "$TEAM_JSON" ]; then
+  echo "[dtrack-init] ERROR: Could not list teams" >&2
   exit 1
 fi
 
-echo "$API_KEY" > "$API_KEY_FILE"
-chmod 644 "$API_KEY_FILE"
+TEAM_UUID=$(echo "$TEAM_JSON" | jq -r '.[] | select(.name == "Automation") | .uuid // empty')
+
+if [ -z "$TEAM_UUID" ]; then
+  echo "[dtrack-init] ERROR: Could not find Automation team" >&2
+  echo "[dtrack-init] Available teams:" >&2
+  echo "$TEAM_JSON" | jq -r '.[].name' >&2 2>/dev/null || true
+  exit 1
+fi
+echo "[dtrack-init] Found Automation team: $TEAM_UUID"
+
+# Rotate: delete every pre-existing key on the Automation team. Each helm
+# upgrade that reaches this branch (i.e. shared volume is empty) starts
+# fresh, preventing key accumulation. DELETE returns 204 on success;
+# missing/already-gone keys are ignored.
+EXISTING_PUBLIC_IDS=$(echo "$TEAM_JSON" | \
+  jq -r '.[] | select(.name == "Automation") | .apiKeys[]?.publicId // empty')
+if [ -n "$EXISTING_PUBLIC_IDS" ]; then
+  echo "[dtrack-init] Rotating existing Automation API keys..."
+  echo "$EXISTING_PUBLIC_IDS" | while IFS= read -r PUBLIC_ID; do
+    [ -z "$PUBLIC_ID" ] && continue
+    DEL_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+      -X DELETE "$DT_URL/api/v1/team/$TEAM_UUID/key/$PUBLIC_ID" \
+      -H "Authorization: Bearer $TOKEN")
+    case "$DEL_CODE" in
+      204|404) ;;  # gone (success) or already gone — both fine
+      *) echo "[dtrack-init] WARNING: DELETE key $PUBLIC_ID returned HTTP $DEL_CODE" ;;
+    esac
+  done
+fi
+
+# Create a fresh API key. DT 4.x returns the unmasked secret in the
+# response body of this single call — there is no other way to retrieve it.
+echo "[dtrack-init] Generating new Automation API key..."
+KEY_RESP=$(curl -sf -X POST "$DT_URL/api/v1/team/$TEAM_UUID/key" \
+  -H "Authorization: Bearer $TOKEN" || true)
+
+if [ -z "$KEY_RESP" ]; then
+  echo "[dtrack-init] ERROR: POST /api/v1/team/$TEAM_UUID/key returned empty body" >&2
+  exit 1
+fi
+
+API_KEY=$(echo "$KEY_RESP" | jq -r '.key // empty')
+
+if [ -z "$API_KEY" ]; then
+  echo "[dtrack-init] ERROR: Could not extract .key from create-key response" >&2
+  echo "[dtrack-init] Response was: $KEY_RESP" >&2
+  exit 1
+fi
+
+# Write to a temp file in the same directory then rename, so consumers
+# never see a half-written key.
+TMP_KEY_FILE="$API_KEY_FILE.tmp"
+printf '%s' "$API_KEY" > "$TMP_KEY_FILE"
+chmod 644 "$TMP_KEY_FILE"
+mv "$TMP_KEY_FILE" "$API_KEY_FILE"
 echo "[dtrack-init] API key written to $API_KEY_FILE"
 
 # Enable NVD API 2.0 mirroring (NIST retired legacy feeds; DTrack 4.10.0+ supports API 2.0)
@@ -91,5 +154,8 @@ if [ "$NVD_RESULT" = "200" ]; then
 else
   echo "[dtrack-init] WARNING: NVD config returned HTTP $NVD_RESULT (may already be set or unsupported)"
 fi
+
+# Drop a marker so operators can tell at a glance that bootstrap completed.
+: > "$BOOTSTRAP_MARKER" 2>/dev/null || true
 
 echo "[dtrack-init] Done"

--- a/docker/test-init-dtrack.sh
+++ b/docker/test-init-dtrack.sh
@@ -58,7 +58,13 @@ EXISTING_PUBLIC_ID = "abc123"
 
 # Track which key public_ids currently exist on the team. Starts with the
 # pre-provisioned masked one; deletes remove it; create-key adds new ones.
-state = {"keys": [{"publicId": EXISTING_PUBLIC_ID, "maskedKey": MASKED_KEY}]}
+# post_key_count tracks how many times POST /key was hit so the test can
+# prove the rotation path actually fired across multiple init runs.
+state = {
+    "keys": [{"publicId": EXISTING_PUBLIC_ID, "maskedKey": MASKED_KEY}],
+    "post_key_count": 0,
+}
+KEY_LOG = os.environ["KEY_LOG"]
 
 class H(BaseHTTPRequestHandler):
     def log_message(self, *a, **k):
@@ -99,11 +105,18 @@ class H(BaseHTTPRequestHandler):
                               ctype="text/plain")
         if self.path == f"/api/v1/team/{TEAM_UUID}/key":
             # DT 4.x: POST returns the unmasked key once.
-            new = {"publicId": "newpub42",
-                   "maskedKey": "odt_********KEY42",
-                   "key": EXPECTED_KEY}
+            # Each POST mints a unique key so the test can verify rotation
+            # actually produced a different value on subsequent runs.
+            state["post_key_count"] += 1
+            n = state["post_key_count"]
+            unmasked = f"{EXPECTED_KEY}_run{n}"
+            new = {"publicId": f"newpub{n}",
+                   "maskedKey": f"odt_********KEY{n}",
+                   "key": unmasked}
             state["keys"].append({"publicId": new["publicId"],
                                   "maskedKey": new["maskedKey"]})
+            with open(KEY_LOG, "a") as f:
+                f.write(unmasked + "\n")
             return self._send(201, json.dumps(new).encode())
         if self.path == "/api/v1/configProperty":
             return self._send(200)
@@ -122,7 +135,9 @@ port = int(sys.argv[1])
 HTTPServer(("127.0.0.1", port), H).serve_forever()
 PYEOF
 
-EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" \
+KEY_LOG="$WORK_DIR/keys.log"
+: > "$KEY_LOG"
+EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" KEY_LOG="$KEY_LOG" \
   python3 "$WORK_DIR/mock_dtrack.py" "$MOCK_PORT" >"$WORK_DIR/mock.log" 2>&1 &
 MOCK_PID=$!
 
@@ -165,19 +180,41 @@ fail() {
 # Assertion 2: API key file exists and is non-empty
 [ -s "$KEY_FILE" ] || fail "$KEY_FILE missing or empty"
 
-# Assertion 3: contents are the unmasked key (not the masked one).
-GOT="$(tr -d '\n' < "$KEY_FILE")"
-[ "$GOT" = "$EXPECTED_KEY" ] || \
-  fail "API key file contents '$GOT' != expected '$EXPECTED_KEY'"
+# Assertion 3: contents are the unmasked key from the first POST /key call
+# (not the masked one). The mock mints "<EXPECTED_KEY>_run<N>" per POST.
+FIRST_KEY="$(tr -d '\n' < "$KEY_FILE")"
+EXPECTED_FIRST="${EXPECTED_KEY}_run1"
+[ "$FIRST_KEY" = "$EXPECTED_FIRST" ] || \
+  fail "API key file contents '$FIRST_KEY' != expected '$EXPECTED_FIRST'"
 
-# Assertion 4: Idempotence — re-running the script must not error and must
-# leave a usable key file in place. (Existing-file short-circuit is fine.)
+# Assertion 4a: Idempotence (warm start) — re-running with the marker
+# present must short-circuit cleanly without re-hitting POST /key.
 set +e
 DEPENDENCY_TRACK_URL="$MOCK_URL" \
   "$SANDBOXED" > "$WORK_DIR/init2.out" 2> "$WORK_DIR/init2.err"
 INIT_RC2=$?
 set -e
-[ "$INIT_RC2" -eq 0 ] || fail "second run exited $INIT_RC2 (expected 0)"
-[ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after second run"
+[ "$INIT_RC2" -eq 0 ] || fail "warm second run exited $INIT_RC2 (expected 0)"
+[ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after warm second run"
+
+# Assertion 4b: Cold-start rotation — wipe the marker and re-run. This is
+# the path the bug fix actually targets: DELETE old key + POST new key.
+# The new file must be non-empty AND differ from the first key, proving
+# rotation fired. Also assert the mock saw POST /key at least twice.
+rm -f "$KEY_FILE"
+set +e
+DEPENDENCY_TRACK_URL="$MOCK_URL" \
+  "$SANDBOXED" > "$WORK_DIR/init3.out" 2> "$WORK_DIR/init3.err"
+INIT_RC3=$?
+set -e
+[ "$INIT_RC3" -eq 0 ] || fail "cold-start rerun exited $INIT_RC3 (expected 0)"
+[ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after cold-start rerun"
+SECOND_KEY="$(tr -d '\n' < "$KEY_FILE")"
+[ "$SECOND_KEY" != "$FIRST_KEY" ] || \
+  fail "rotation did not fire: second key '$SECOND_KEY' equals first '$FIRST_KEY'"
+POST_COUNT=$(wc -l < "$KEY_LOG" | tr -d ' ')
+[ "$POST_COUNT" -ge 2 ] || \
+  fail "expected POST /key >=2 across runs, mock saw $POST_COUNT"
+echo "[test] rotation path fired: ${FIRST_KEY} -> ${SECOND_KEY} (POST /key count=${POST_COUNT})"
 
 echo "PASS: init-dtrack.sh writes unmasked Automation API key from POST /key"

--- a/docker/test-init-dtrack.sh
+++ b/docker/test-init-dtrack.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Regression test for docker/init-dtrack.sh (Bug #978).
+#
+# Spins up a tiny Python mock of Dependency-Track 4.x that mimics the
+# documented behavior:
+#   - GET  /api/version                      -> {version}
+#   - POST /api/v1/user/forceChangePassword  -> 200
+#   - POST /api/v1/user/login                -> Bearer JWT (string body)
+#   - GET  /api/v1/team                      -> existing teams; the Automation
+#                                               team's apiKeys ONLY expose
+#                                               .maskedKey (NOT .key)  <-- the bug
+#   - DELETE /api/v1/team/<uuid>/key/<pubid> -> 204 (idempotent rotation)
+#   - POST /api/v1/team/<uuid>/key           -> {"key":"<unmasked>","publicId":"..."}
+#   - POST /api/v1/configProperty            -> 200
+#
+# The test then runs init-dtrack.sh against the mock and asserts that:
+#   1. The script exits with status 0.
+#   2. /shared/dtrack-api-key (redirected via env) is non-empty.
+#   3. The contents match the unmasked key returned by POST /key
+#      (NOT the maskedKey returned by GET /team).
+#
+# This test deliberately uses no test framework other than bash + python3 +
+# curl, all of which are already required by the docker image.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INIT_SCRIPT="$SCRIPT_DIR/init-dtrack.sh"
+
+if [ ! -x "$INIT_SCRIPT" ]; then
+  echo "FAIL: $INIT_SCRIPT not found or not executable" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"; [ -n "${MOCK_PID:-}" ] && kill "$MOCK_PID" 2>/dev/null || true' EXIT
+
+SHARED_DIR="$WORK_DIR/shared"
+mkdir -p "$SHARED_DIR"
+
+# Pick an ephemeral port for the mock server.
+MOCK_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')"
+MOCK_URL="http://127.0.0.1:$MOCK_PORT"
+
+# The unmasked key the mock will return from POST /api/v1/team/<uuid>/key.
+# A passing test must end up with this exact value at the API key file path.
+EXPECTED_KEY="odt_NEWLY_CREATED_AUTOMATION_KEY_XYZ"
+MASKED_KEY="odt_********ECRET"  # what GET /team would expose (the broken path)
+
+cat > "$WORK_DIR/mock_dtrack.py" <<PYEOF
+import json, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+EXPECTED_KEY = os.environ["EXPECTED_KEY"]
+MASKED_KEY   = os.environ["MASKED_KEY"]
+TEAM_UUID    = "11111111-2222-3333-4444-555555555555"
+EXISTING_PUBLIC_ID = "abc123"
+
+# Track which key public_ids currently exist on the team. Starts with the
+# pre-provisioned masked one; deletes remove it; create-key adds new ones.
+state = {"keys": [{"publicId": EXISTING_PUBLIC_ID, "maskedKey": MASKED_KEY}]}
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **k):
+        pass  # quiet
+
+    def _send(self, code, body=b"", ctype="application/json"):
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        return self.rfile.read(n) if n else b""
+
+    def do_GET(self):
+        if self.path == "/api/version":
+            return self._send(200, b'{"version":"4.11.0"}')
+        if self.path == "/api/v1/team":
+            teams = [{
+                "uuid": TEAM_UUID,
+                "name": "Automation",
+                # DT 4.x: existing keys only expose maskedKey, not key
+                "apiKeys": [{"publicId": k["publicId"],
+                             "maskedKey": k["maskedKey"]} for k in state["keys"]],
+            }]
+            return self._send(200, json.dumps(teams).encode())
+        return self._send(404)
+
+    def do_POST(self):
+        body = self._read_body()
+        if self.path == "/api/v1/user/forceChangePassword":
+            return self._send(200)
+        if self.path == "/api/v1/user/login":
+            # DT login returns a bare JWT string, not JSON.
+            return self._send(200, b"eyJhbGciOiJIUzI1NiJ9.mockjwt.signature",
+                              ctype="text/plain")
+        if self.path == f"/api/v1/team/{TEAM_UUID}/key":
+            # DT 4.x: POST returns the unmasked key once.
+            new = {"publicId": "newpub42",
+                   "maskedKey": "odt_********KEY42",
+                   "key": EXPECTED_KEY}
+            state["keys"].append({"publicId": new["publicId"],
+                                  "maskedKey": new["maskedKey"]})
+            return self._send(201, json.dumps(new).encode())
+        if self.path == "/api/v1/configProperty":
+            return self._send(200)
+        return self._send(404)
+
+    def do_DELETE(self):
+        # DELETE /api/v1/team/<uuid>/key/<publicId>  -> 204
+        prefix = f"/api/v1/team/{TEAM_UUID}/key/"
+        if self.path.startswith(prefix):
+            pid = self.path[len(prefix):]
+            state["keys"] = [k for k in state["keys"] if k["publicId"] != pid]
+            return self._send(204)
+        return self._send(404)
+
+port = int(sys.argv[1])
+HTTPServer(("127.0.0.1", port), H).serve_forever()
+PYEOF
+
+EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" \
+  python3 "$WORK_DIR/mock_dtrack.py" "$MOCK_PORT" >"$WORK_DIR/mock.log" 2>&1 &
+MOCK_PID=$!
+
+# Wait for mock to be ready.
+for i in $(seq 1 50); do
+  if curl -sf "$MOCK_URL/api/version" >/dev/null 2>&1; then break; fi
+  sleep 0.1
+  if [ "$i" -eq 50 ]; then
+    echo "FAIL: mock DT did not become ready" >&2
+    cat "$WORK_DIR/mock.log" >&2
+    exit 1
+  fi
+done
+
+# Run the init script against the mock. We rewrite the hard-coded
+# /shared/dtrack-api-key path on the fly so the test doesn't need root.
+SANDBOXED="$WORK_DIR/init-dtrack.sh"
+sed "s|/shared/|$SHARED_DIR/|g" "$INIT_SCRIPT" > "$SANDBOXED"
+chmod +x "$SANDBOXED"
+
+set +e
+DEPENDENCY_TRACK_URL="$MOCK_URL" \
+  "$SANDBOXED" > "$WORK_DIR/init.out" 2> "$WORK_DIR/init.err"
+INIT_RC=$?
+set -e
+
+KEY_FILE="$SHARED_DIR/dtrack-api-key"
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "--- init stdout ---" >&2; cat "$WORK_DIR/init.out" >&2 || true
+  echo "--- init stderr ---" >&2; cat "$WORK_DIR/init.err" >&2 || true
+  echo "--- mock log ---"   >&2; cat "$WORK_DIR/mock.log" >&2 || true
+  exit 1
+}
+
+# Assertion 1: exit 0
+[ "$INIT_RC" -eq 0 ] || fail "init-dtrack.sh exited $INIT_RC (expected 0)"
+
+# Assertion 2: API key file exists and is non-empty
+[ -s "$KEY_FILE" ] || fail "$KEY_FILE missing or empty"
+
+# Assertion 3: contents are the unmasked key (not the masked one).
+GOT="$(tr -d '\n' < "$KEY_FILE")"
+[ "$GOT" = "$EXPECTED_KEY" ] || \
+  fail "API key file contents '$GOT' != expected '$EXPECTED_KEY'"
+
+# Assertion 4: Idempotence — re-running the script must not error and must
+# leave a usable key file in place. (Existing-file short-circuit is fine.)
+set +e
+DEPENDENCY_TRACK_URL="$MOCK_URL" \
+  "$SANDBOXED" > "$WORK_DIR/init2.out" 2> "$WORK_DIR/init2.err"
+INIT_RC2=$?
+set -e
+[ "$INIT_RC2" -eq 0 ] || fail "second run exited $INIT_RC2 (expected 0)"
+[ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after second run"
+
+echo "PASS: init-dtrack.sh writes unmasked Automation API key from POST /key"


### PR DESCRIPTION
Fixes #978.

## Summary

`docker/init-dtrack.sh` read the Dependency-Track Automation team API key from `.apiKeys[0].key`, but DT 4.x only exposes existing keys as `maskedKey` metadata — `.key` is undefined. The init container exited 1 before writing `/shared/dtrack-api-key`, leaving the backend without DT credentials.

## Fix

Replace masked-key read with a key-rotation flow:
1. List teams → find Automation team UUID + every existing key's `publicId`.
2. `DELETE /api/v1/team/<uuid>/key/<publicId>` for each (idempotent — 204+404 both treated as success).
3. `POST /api/v1/team/<uuid>/key` → response includes the unmasked `.key` once.
4. Atomic write: `printf '%s' > $API_KEY_FILE.tmp && mv` (no torn read), `chmod 644` (pre-existing — see follow-up #1038 for tightening).

The pre-existing `[ -f "$API_KEY_FILE" ] && [ -s "$API_KEY_FILE" ] && exit 0` short-circuit is preserved — steady-state helm upgrades skip the API entirely. Rotation only fires when the shared volume is empty (new PVC, ops wipe).

Self-contained regression test (`docker/test-init-dtrack.sh`) using bash + python3 http.server mock that exercises the maskedKey-vs-key distinction AND the cold-start rotation path (after R3 caught a coverage gap in the original test).

## Compose env wiring (cherry-picked from #980)

`docker-compose.yml` now passes `DEPENDENCY_TRACK_URL` and `DEPENDENCY_TRACK_ADMIN_PASSWORD` through to the `dtrack-init` service, and `.env.example` is updated to match (hostname corrected from `dependency-track` → `dependency-track-apiserver`, new admin-password placeholder added). Without this, `.env` overrides never reached the init container — operators had to edit `init-dtrack.sh` directly.

Credit to @junsung-cho who diagnosed the same DT-4.x masked-key issue independently in #980 and contributed the compose plumbing folded in here.

## Three-round review

| Round | Role | Result |
|---|---|---|
| R1 | Build (SWE+Test) | ✅ Fix + regression test, atomic write, idempotent |
| R1 | DevOps | ✅ Bind-mount only (no image rebuild), curl/jq present in alpine + glibc images, env-var contract preserved |
| R1 | Security | ✅ APPROVE WITH NITS — no command injection, atomic write correct, no `set -x` traces, mock test binds 127.0.0.1 only |
| R2 | code-simplifier | ✅ Extracted `dt_login()` helper, promoted `DT_TEAM_NAME` constant, fixed redirect-ordering bug |
| R3 | adversarial reviewer (iter 1) | 🛑 BLOCK — "Assertion 4: Idempotence" only exercised the short-circuit path, not the rotation logic |
| R2 | iteration 1 | ✅ Added cold-start rotation test (`rm $KEY_FILE; re-run; assert FIRST_KEY != SECOND_KEY; POST_COUNT >= 2`); redacted `KEY_RESP` from jq-failure stderr (length + top-level keys, never values) |
| R3 | adversarial reviewer (iter 2) | ✅ APPROVE for push — rotation path genuinely exercised, no key-leak surface remains |

## Follow-up issues (filed)

- artifact-keeper#1037 — Forward-port to `main` (main has buggy version)
- artifact-keeper#1038 — Tighten file mode `chmod 644 → 600` on the secret file (pre-existing)
- artifact-keeper#1039 — 1.1.x release notes must warn operators about Automation team key rotation
- artifact-keeper#1040 — Wire `docker/test-init-dtrack.sh` into CI (test exists but no workflow runs it)
- artifact-keeper#1041 — Pin mock response codes to actual DT 4.x values; tighten assertion 4a

## Out of scope

- Operator key-rotation race during k8s rollouts (R3 noted, self-heals on next cold start, covered by release notes follow-up)
- `dt_login()` swallows non-network failures via `2>/dev/null || true` (pre-existing pattern)

## Test plan

- [x] `bash docker/test-init-dtrack.sh` — PASS (rotation path fires `_run1 -> _run2`, POST count = 2)
- [x] `bash -n` clean on both scripts
- [x] Atomic write + `printf '%s'` no-newline contract preserved
- [x] `python3 -c 'import yaml; yaml.safe_load(open("docker-compose.yml"))'` — clean after env-block addition
- [ ] CI to run the same test (pending #1040)
- [ ] Manual: helm install on clean cluster against DT 4.x (post-merge in staging)
