### PR TITLE
chore(migration): conflict-match nits and list_repositories context log

### DIFF
--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -195,7 +195,21 @@ impl MigrationWorker {
         //
         // `list_repositories` returns `ArtifactoryError`; the `?` converts via
         // `MigrationError::from(ArtifactoryError)` on the existing `#[from]` impl.
-        let source_repos = client.list_repositories().await?;
+        // NOTE: total_failed below is incremented per *repo* during
+        // provisioning (missing-from-source, unsupported config, conflict,
+        // create_repository failure). A skipped repo with N artifacts
+        // contributes 1 to failed, not N. determine_final_status only
+        // checks failed > 0 && completed == 0, so the final job status is
+        // still correct, but the operator-facing failed count understates
+        // impact. Per-artifact accounting would require listing the
+        // source repo's artifacts before deciding to skip — deferred.
+        let source_repos = client.list_repositories().await.map_err(|e| {
+            tracing::error!(
+                job_id = %job_id, error = %e,
+                "Failed to list source repositories; aborting provisioning pre-pass",
+            );
+            e
+        })?;
         let plan = resolve_repos_for_provisioning(&repos, &source_repos);
         for missing_key in &plan.missing {
             tracing::error!(
@@ -234,12 +248,25 @@ impl MigrationWorker {
                             "Destination repository already exists with matching type+format; reusing",
                         );
                     }
-                    _ => {
+                    Some(other) => {
                         tracing::error!(
                             job_id = %job_id, repo = %migration_config.target_key,
-                            conflict = ?conflict.conflict_type,
+                            conflict = ?other,
                             message = %conflict.message,
                             "Destination repository conflict; skipping artifact transfer for this repo",
+                        );
+                        total_failed += 1;
+                        continue;
+                    }
+                    None => {
+                        // has_conflict=true with conflict_type=None is a
+                        // contract violation in check_repository_conflict.
+                        // Treat it as a conflict (don't silently route
+                        // through the "other" arm) so the bug surfaces.
+                        tracing::error!(
+                            job_id = %job_id, repo = %migration_config.target_key,
+                            message = %conflict.message,
+                            "has_conflict=true but conflict_type=None; treating as conflict",
                         );
                         total_failed += 1;
                         continue;


### PR DESCRIPTION
## Summary

Three small follow-ups to #1017 in `process_job`'s repository-provisioning pre-pass:

- **Conflict match arms.** Split the `_ =>` arm into explicit `Some(other)` and `None`. Previously a contract drift in `check_repository_conflict` (i.e. `has_conflict=true` with `conflict_type=None`) would silently route through the "other conflict" path; now it logs a distinct error so the bug surfaces.
- **`list_repositories` error context.** Wrapped the `?` propagation with a `tracing::error!` that includes `job_id`, so an aborted pre-pass leaves a correlatable line.
- **`total_failed` granularity comment.** Documented that the counter is incremented per-repo during provisioning, not per-artifact (a skipped repo with N artifacts contributes 1, not N). Job status logic is unaffected; this is operator-facing accuracy.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` — 8738 pass)
- [x] No regressions in existing tests

No new tests added. The match-arm split preserves existing logic for `Some(non-SameKey)` (already exercised by the upstream `_ =>` path); the new `None` arm is for a contract violation that should not occur in practice — adding a test for it would require introducing a mock that actively violates the contract. Happy to add one if a reviewer wants the safety net.

## API Changes
- [x] N/A - no API changes