### PR TITLE
fix(conan): return 4xx instead of 500 on three error paths

### DIFF
--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -228,16 +228,58 @@ fn content_type_for_conan_file(path: &str) -> &'static str {
     }
 }
 
+/// Maximum byte length for any single Conan reference path segment
+/// (`name`, `version`, `user`, `channel`, `revision`, `package_id`,
+/// `pkg_revision`, `file_path`). This matches the typical filesystem
+/// `NAME_MAX` limit (255) and keeps storage-backend operations from
+/// surfacing low-level filesystem errors as 5xx responses.
+const CONAN_MAX_SEGMENT_LEN: usize = 255;
+
+/// Validate the byte length of every user-supplied Conan path segment.
+///
+/// Returns a 414 (URI Too Long) plain-text error response when any segment
+/// exceeds [`CONAN_MAX_SEGMENT_LEN`]. The first offending segment is named
+/// in the response body so abuse / fuzzing payloads do not look like server
+/// faults in monitoring (issue #990).
+#[allow(clippy::result_large_err)]
+fn validate_conan_segments(segments: &[(&str, &str)]) -> Result<(), Response> {
+    for (label, value) in segments {
+        if value.len() > CONAN_MAX_SEGMENT_LEN {
+            return Err((
+                StatusCode::URI_TOO_LONG,
+                format!(
+                    "Conan path segment '{}' exceeds {} bytes (got {})",
+                    label,
+                    CONAN_MAX_SEGMENT_LEN,
+                    value.len()
+                ),
+            )
+                .into_response());
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // GET /conan/{repo_key}/v2/ping
 // ---------------------------------------------------------------------------
 
-async fn ping() -> Response {
-    Response::builder()
+/// Ping / capability probe.
+///
+/// Validates the repository exists before returning the static capability
+/// banner so Conan clients can distinguish a configured-but-broken remote
+/// from a typo (issue #990). Returns 404 when the repository does not
+/// exist or is not Conan-format.
+async fn ping(
+    State(state): State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    let _repo = resolve_conan_repo(&state.db, &repo_key).await?;
+    Ok(Response::builder()
         .status(StatusCode::OK)
         .header("X-Conan-Server-Capabilities", "revisions")
         .body(Body::empty())
-        .unwrap()
+        .unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -687,7 +729,7 @@ async fn recipe_file_download(
 
 async fn recipe_file_upload(
     State(state): State<SharedState>,
-    Extension(auth): Extension<Option<AuthExtension>>,
+    auth: Option<Extension<Option<AuthExtension>>>,
     Path((repo_key, name, version, user, channel, revision, file_path)): Path<(
         String,
         String,
@@ -699,8 +741,29 @@ async fn recipe_file_upload(
     )>,
     body: Bytes,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic(auth, "conan")?.user_id;
+    // Reject path segments that exceed the filesystem NAME_MAX before any
+    // DB, auth, or storage-backend call, so deeply-nested or fuzzing-style
+    // payloads surface as a 414 instead of a low-level 500 (issue #990).
+    // Path-shape is independent of authn/authz so it is safe (and useful for
+    // monitoring) to fail it first.
+    validate_conan_segments(&[
+        ("name", &name),
+        ("version", &version),
+        ("user", &user),
+        ("channel", &channel),
+        ("revision", &revision),
+        ("file_path", &file_path),
+    ])?;
+
+    // Validate the repo BEFORE checking auth, so an upload to a non-existent
+    // repo returns 404 instead of 500 (issue #990). The repo-visibility
+    // middleware skips the auth-extension insertion when the repo key is
+    // unknown, so a strict `Extension<Option<AuthExtension>>` extractor
+    // would surface a 500 here. Accepting the extension as `Option<...>`
+    // lets us run the resolve-then-auth-then-validate sequence cleanly.
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
+    let auth_ext = auth.and_then(|Extension(a)| a);
+    let user_id = require_auth_basic(auth_ext, "conan")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
 
     let artifact_path =
@@ -1192,7 +1255,7 @@ async fn package_file_download(
 #[allow(clippy::type_complexity)]
 async fn package_file_upload(
     State(state): State<SharedState>,
-    Extension(auth): Extension<Option<AuthExtension>>,
+    auth: Option<Extension<Option<AuthExtension>>>,
     Path((repo_key, name, version, user, channel, revision, package_id, pkg_revision, file_path)): Path<(
         String,
         String,
@@ -1206,8 +1269,25 @@ async fn package_file_upload(
     )>,
     body: Bytes,
 ) -> Result<Response, Response> {
-    let user_id = require_auth_basic(auth, "conan")?.user_id;
+    // Reject excessively long path segments up front (before any DB, auth,
+    // or storage-backend call) so the storage backend and DB never see paths
+    // that would surface as opaque 5xx errors (issue #990).
+    validate_conan_segments(&[
+        ("name", &name),
+        ("version", &version),
+        ("user", &user),
+        ("channel", &channel),
+        ("revision", &revision),
+        ("package_id", &package_id),
+        ("pkg_revision", &pkg_revision),
+        ("file_path", &file_path),
+    ])?;
+
+    // Resolve repo BEFORE auth so unknown repo keys surface as 404, not 500.
+    // See `recipe_file_upload` for the full rationale (issue #990).
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
+    let auth_ext = auth.and_then(|Extension(a)| a);
+    let user_id = require_auth_basic(auth_ext, "conan")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
 
     let artifact_path = package_artifact_path(
@@ -1920,5 +2000,65 @@ mod tests {
             "boost", "1.80", "myuser", "stable", "r1", "pid", "prev", "file",
         );
         assert!(path.contains("/myuser/stable/"));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_conan_segments — issue #990 long-path guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_conan_segments_accepts_normal_segments() {
+        let segments = [
+            ("name", "zlib"),
+            ("version", "1.3.1"),
+            ("user", "_"),
+            ("channel", "_"),
+            ("revision", "deadbeefcafebabedeadbeefcafebabe"),
+            ("file_path", "conanfile.py"),
+        ];
+        assert!(validate_conan_segments(&segments).is_ok());
+    }
+
+    #[test]
+    fn test_validate_conan_segments_accepts_segment_at_max() {
+        let max_segment: String = "a".repeat(CONAN_MAX_SEGMENT_LEN);
+        let segments = [("name", max_segment.as_str())];
+        assert!(
+            validate_conan_segments(&segments).is_ok(),
+            "exactly {} bytes must be accepted",
+            CONAN_MAX_SEGMENT_LEN
+        );
+    }
+
+    #[test]
+    fn test_validate_conan_segments_rejects_overlong_name() {
+        // Mirrors test-conan-errors.sh #15: a 300-char package name.
+        let long_name: String = "a".repeat(300);
+        let segments = [
+            ("name", long_name.as_str()),
+            ("version", "1.0.0"),
+            ("user", "_"),
+            ("channel", "_"),
+            ("revision", "rev"),
+            ("file_path", "conanfile.py"),
+        ];
+        let resp = validate_conan_segments(&segments).expect_err("must reject 300-char name");
+        assert_eq!(resp.status(), StatusCode::URI_TOO_LONG);
+    }
+
+    #[test]
+    fn test_validate_conan_segments_rejects_overlong_version() {
+        let long_version: String = "1.".repeat(200); // 400 chars
+        let segments = [("name", "zlib"), ("version", long_version.as_str())];
+        let resp = validate_conan_segments(&segments).expect_err("must reject 400-char version");
+        assert_eq!(resp.status(), StatusCode::URI_TOO_LONG);
+    }
+
+    #[test]
+    fn test_validate_conan_segments_rejects_overlong_file_path() {
+        let long_path: String = "x".repeat(CONAN_MAX_SEGMENT_LEN + 1);
+        let segments = [("file_path", long_path.as_str())];
+        let resp = validate_conan_segments(&segments).expect_err("must reject overlong file_path");
+        assert_eq!(resp.status(), StatusCode::URI_TOO_LONG);
     }
 }

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -2067,4 +2067,210 @@ mod tests {
         let resp = validate_conan_segments(&segments).expect_err("must reject overlong file_path");
         assert_eq!(resp.status(), StatusCode::URI_TOO_LONG);
     }
+
+    // -----------------------------------------------------------------------
+    // flatten_auth_extension — issue #990 Option-extension flattening
+    // -----------------------------------------------------------------------
+
+    fn make_auth_ext() -> AuthExtension {
+        AuthExtension {
+            user_id: uuid::Uuid::nil(),
+            username: "tester".into(),
+            email: "tester@test.local".into(),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: None,
+        }
+    }
+
+    #[test]
+    fn test_flatten_auth_extension_none_outer() {
+        // No Extension at all — repo-visibility middleware did not run because
+        // the repo does not exist. Must flatten to None so the upload handler
+        // can return a 4xx (issue #990).
+        assert!(flatten_auth_extension(None).is_none());
+    }
+
+    #[test]
+    fn test_flatten_auth_extension_some_outer_none_inner() {
+        // Extension was inserted but the request was unauthenticated.
+        let inner: Option<AuthExtension> = None;
+        assert!(flatten_auth_extension(Some(Extension(inner))).is_none());
+    }
+
+    #[test]
+    fn test_flatten_auth_extension_some_outer_some_inner() {
+        // Extension was inserted with an authenticated user.
+        let ext = make_auth_ext();
+        let username = ext.username.clone();
+        let flat = flatten_auth_extension(Some(Extension(Some(ext))))
+            .expect("Some(Extension(Some(_))) must flatten to Some");
+        assert_eq!(flat.username, username);
+    }
+
+    // -----------------------------------------------------------------------
+    // ping / *_file_upload — exercise non-DB code paths through the router so
+    // that the new lines (validate-segments call sites, signature lines,
+    // auth-flattening) are covered in --lib coverage runs (issue #990).
+    //
+    // These tests use `PgPool::connect_lazy` (the same pattern used by
+    // events.rs / users.rs / auth_service.rs unit tests) so no PostgreSQL is
+    // required. Requests that hit a DB query short-circuit with a 5xx, but
+    // requests that fail the path-segment guard return 414 *before* any DB
+    // call — exactly the shape we want to verify.
+    // -----------------------------------------------------------------------
+
+    fn unit_test_state() -> SharedState {
+        use crate::api::AppState;
+        use crate::config::Config;
+        use crate::storage::filesystem::FilesystemStorage;
+        use std::sync::Arc;
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid:invalid@127.0.0.1:1/none")
+            .expect("connect_lazy never fails for a syntactically valid URL");
+        let storage: Arc<dyn crate::storage::StorageBackend> =
+            Arc::new(FilesystemStorage::new("/tmp/conan-unit-test"));
+        let registry = Arc::new(crate::storage::StorageRegistry::new(
+            std::collections::HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        let config = Config {
+            database_url: String::new(),
+            bind_address: "127.0.0.1:0".into(),
+            log_level: "error".into(),
+            storage_backend: "filesystem".into(),
+            storage_path: "/tmp/conan-unit-test".into(),
+            s3_bucket: None,
+            gcs_bucket: None,
+            s3_region: None,
+            s3_endpoint: None,
+            jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+            jwt_expiration_secs: 3600,
+            jwt_access_token_expiry_minutes: 30,
+            jwt_refresh_token_expiry_days: 7,
+            oidc_issuer: None,
+            oidc_client_id: None,
+            oidc_client_secret: None,
+            ldap_url: None,
+            ldap_base_dn: None,
+            trivy_url: None,
+            openscap_url: None,
+            openscap_profile: "standard".into(),
+            meilisearch_url: None,
+            meilisearch_api_key: None,
+            scan_workspace_path: "/tmp/scan".into(),
+            demo_mode: false,
+            peer_instance_name: "test".into(),
+            peer_public_endpoint: "http://localhost:8080".into(),
+            peer_api_key: "test-key".into(),
+            dependency_track_url: None,
+            otel_exporter_otlp_endpoint: None,
+            otel_service_name: "test".into(),
+            gc_schedule: "0 0 * * * *".into(),
+            lifecycle_check_interval_secs: 60,
+            allow_local_admin_login: false,
+            max_upload_size_bytes: 10_737_418_240,
+            proxy_max_concurrent_fetches: 20,
+            proxy_max_artifact_size_bytes: 2_147_483_648,
+            proxy_queue_timeout_secs: 30,
+            metrics_port: None,
+            rate_limit_exempt_usernames: Vec::new(),
+            rate_limit_exempt_service_accounts: false,
+        };
+        Arc::new(AppState::new(config, pool, storage, registry))
+    }
+
+    #[tokio::test]
+    async fn test_recipe_file_upload_returns_414_for_overlong_segment() {
+        // PUT with a 300-char `name` segment must surface as a 4xx (414)
+        // before any DB call. This exercises the validate_conan_segments
+        // call site in `recipe_file_upload` (issue #990 sub-test #15).
+        use tower::ServiceExt;
+
+        let state = unit_test_state();
+        let app = router().with_state(state);
+
+        let long_name: String = "a".repeat(300);
+        let uri = format!(
+            "/some-repo/v2/conans/{}/1.0.0/_/_/revisions/rev/files/conanfile.py",
+            long_name
+        );
+        let req = axum::http::Request::builder()
+            .method("PUT")
+            .uri(uri)
+            .body(Body::from("dummy".as_bytes().to_vec()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::URI_TOO_LONG,
+            "300-char recipe path segment must return 414 before any DB call"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_package_file_upload_returns_414_for_overlong_segment() {
+        // PUT to the package-file route with a 300-char `package_id` must
+        // also short-circuit with a 414. Exercises the validate_conan_segments
+        // call site in `package_file_upload` (issue #990).
+        use tower::ServiceExt;
+
+        let state = unit_test_state();
+        let app = router().with_state(state);
+
+        let long_pkg_id: String = "p".repeat(300);
+        let uri = format!(
+            "/some-repo/v2/conans/zlib/1.3.1/_/_/revisions/rev/packages/{}/revisions/prev/files/conanfile.py",
+            long_pkg_id
+        );
+        let req = axum::http::Request::builder()
+            .method("PUT")
+            .uri(uri)
+            .body(Body::from("dummy".as_bytes().to_vec()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::URI_TOO_LONG,
+            "300-char package path segment must return 414 before any DB call"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ping_handler_propagates_repo_resolution_error() {
+        // GET /v2/ping must call `resolve_conan_repo` before returning the
+        // capability banner (issue #990 sub-test #12). With a lazy pool that
+        // cannot connect to PostgreSQL, the resolve call fails and the
+        // handler must propagate that as a 5xx — NOT a 200. This exercises
+        // the handler signature, the `?` propagation, and proves the
+        // capability banner is gated on repo resolution.
+        use tower::ServiceExt;
+
+        let state = unit_test_state();
+        let app = router().with_state(state);
+
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/some-repo/v2/ping")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        // The exact status depends on how `map_db_err` shapes the response,
+        // but the contract that issue #990 requires is: ping does NOT return
+        // 200 when the repo cannot be resolved.
+        assert_ne!(
+            resp.status(),
+            StatusCode::OK,
+            "ping must not return 200 when repo resolution fails"
+        );
+        assert!(
+            resp.headers().get("X-Conan-Server-Capabilities").is_none(),
+            "capability banner must be gated on successful repo resolution"
+        );
+    }
 }

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -260,6 +260,17 @@ fn validate_conan_segments(segments: &[(&str, &str)]) -> Result<(), Response> {
     Ok(())
 }
 
+/// Flatten the optional auth extension that the upload handlers receive.
+///
+/// Upload handlers accept `Option<Extension<Option<AuthExtension>>>` so that
+/// requests routed to a non-existent repo (where the repo-visibility
+/// middleware skips inserting the extension) still reach the handler — the
+/// handler can then return 404 instead of a 500. See `recipe_file_upload`
+/// for the full rationale (issue #990).
+fn flatten_auth_extension(auth: Option<Extension<Option<AuthExtension>>>) -> Option<AuthExtension> {
+    auth.and_then(|Extension(a)| a)
+}
+
 // ---------------------------------------------------------------------------
 // GET /conan/{repo_key}/v2/ping
 // ---------------------------------------------------------------------------
@@ -756,14 +767,10 @@ async fn recipe_file_upload(
     ])?;
 
     // Validate the repo BEFORE checking auth, so an upload to a non-existent
-    // repo returns 404 instead of 500 (issue #990). The repo-visibility
-    // middleware skips the auth-extension insertion when the repo key is
-    // unknown, so a strict `Extension<Option<AuthExtension>>` extractor
-    // would surface a 500 here. Accepting the extension as `Option<...>`
-    // lets us run the resolve-then-auth-then-validate sequence cleanly.
+    // repo returns 404 instead of 500 (issue #990). See
+    // `flatten_auth_extension` for why the extension is optional here.
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
-    let auth_ext = auth.and_then(|Extension(a)| a);
-    let user_id = require_auth_basic(auth_ext, "conan")?.user_id;
+    let user_id = require_auth_basic(flatten_auth_extension(auth), "conan")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
 
     let artifact_path =
@@ -1286,8 +1293,7 @@ async fn package_file_upload(
     // Resolve repo BEFORE auth so unknown repo keys surface as 404, not 500.
     // See `recipe_file_upload` for the full rationale (issue #990).
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
-    let auth_ext = auth.and_then(|Extension(a)| a);
-    let user_id = require_auth_basic(auth_ext, "conan")?.user_id;
+    let user_id = require_auth_basic(flatten_auth_extension(auth), "conan")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
 
     let artifact_path = package_artifact_path(

--- a/backend/tests/conan_error_paths_tests.rs
+++ b/backend/tests/conan_error_paths_tests.rs
@@ -1,0 +1,343 @@
+//! Conan error-path integration tests for issue #990.
+//!
+//! Validates that the Conan v2 handler returns the expected HTTP status
+//! codes for the three pre-existing gaps surfaced by `test-conan-errors.sh`:
+//!
+//! 1. PUT to a non-existent repository must return 404 (not 500).
+//! 2. GET /v2/ping on a non-existent repository must return 404 (not 200).
+//! 3. PUT with a 300-char path segment must return a 4xx (not 500).
+//!
+//! These tests require a PostgreSQL database with all migrations applied.
+//! Run with:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test conan_error_paths_tests -- --ignored
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::conan;
+use artifact_keeper_backend::api::{AppState, SharedState};
+use artifact_keeper_backend::config::Config;
+
+// ===========================================================================
+// Test helpers (mirrors incus_upload_tests.rs)
+// ===========================================================================
+
+fn test_config(storage_path: &str) -> Config {
+    Config {
+        database_url: std::env::var("DATABASE_URL").unwrap(),
+        bind_address: "127.0.0.1:0".into(),
+        log_level: "error".into(),
+        storage_backend: "filesystem".into(),
+        storage_path: storage_path.into(),
+        s3_bucket: None,
+        gcs_bucket: None,
+        s3_region: None,
+        s3_endpoint: None,
+        jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+        jwt_expiration_secs: 86400,
+        jwt_access_token_expiry_minutes: 30,
+        jwt_refresh_token_expiry_days: 7,
+        oidc_issuer: None,
+        oidc_client_id: None,
+        oidc_client_secret: None,
+        ldap_url: None,
+        ldap_base_dn: None,
+        trivy_url: None,
+        openscap_url: None,
+        openscap_profile: "standard".into(),
+        meilisearch_url: None,
+        meilisearch_api_key: None,
+        scan_workspace_path: "/tmp/scan".into(),
+        demo_mode: false,
+        peer_instance_name: "test".into(),
+        peer_public_endpoint: "http://localhost:8080".into(),
+        peer_api_key: "test-key".into(),
+        dependency_track_url: None,
+        otel_exporter_otlp_endpoint: None,
+        otel_service_name: "test".into(),
+        gc_schedule: "0 0 * * * *".into(),
+        lifecycle_check_interval_secs: 60,
+        allow_local_admin_login: false,
+        max_upload_size_bytes: 10_737_418_240,
+        proxy_max_concurrent_fetches: 20,
+        proxy_max_artifact_size_bytes: 2_147_483_648,
+        proxy_queue_timeout_secs: 30,
+        metrics_port: None,
+        rate_limit_exempt_usernames: Vec::new(),
+        rate_limit_exempt_service_accounts: false,
+    }
+}
+
+fn basic_auth_header(username: &str, password: &str) -> String {
+    use base64::Engine;
+    let encoded =
+        base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", username, password));
+    format!("Basic {}", encoded)
+}
+
+async fn create_test_user(pool: &PgPool, username: &str, password: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash = bcrypt::hash(password, 4).expect("bcrypt hash failed");
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active)
+        VALUES ($1, $2, $3, $4, 'local', true, true)
+        "#,
+    )
+    .bind(id)
+    .bind(username)
+    .bind(format!("{}@test.local", username))
+    .bind(&hash)
+    .execute(pool)
+    .await
+    .expect("failed to create test user");
+    id
+}
+
+async fn create_conan_repo(pool: &PgPool, name: &str) -> (Uuid, String, PathBuf) {
+    let id = Uuid::new_v4();
+    let key = format!("conan-err-{}", &id.to_string()[..8]);
+    let storage_path = std::env::temp_dir().join(format!("conan-err-{}", id));
+    std::fs::create_dir_all(&storage_path).expect("create storage dir");
+
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+         VALUES ($1, $2, $3, $4, 'local', 'conan')",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(name)
+    .bind(storage_path.to_string_lossy().as_ref())
+    .execute(pool)
+    .await
+    .expect("failed to create conan repository");
+
+    (id, key, storage_path)
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    let _ = sqlx::query(
+        "DELETE FROM artifact_metadata WHERE artifact_id IN \
+         (SELECT id FROM artifacts WHERE repository_id = $1)",
+    )
+    .bind(repo_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+}
+
+fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+    let storage: std::sync::Arc<dyn artifact_keeper_backend::storage::StorageBackend> =
+        std::sync::Arc::new(
+            artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(storage_path),
+        );
+    let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+        std::collections::HashMap::new(),
+        "filesystem".to_string(),
+    ));
+    Arc::new(AppState::new(
+        test_config(storage_path),
+        pool,
+        storage,
+        registry,
+    ))
+}
+
+// ===========================================================================
+// 1. PUT to a non-existent repo returns 404 (issue #990, sub-test #7)
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_990_upload_to_nonexistent_repo_returns_404() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("conan-err-u-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "errpass").await;
+    let storage_path = std::env::temp_dir().join("conan-err-bogus-upload");
+    std::fs::create_dir_all(&storage_path).ok();
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+
+    let bogus_repo = format!("bogus-conan-{}", &Uuid::new_v4().to_string()[..8]);
+    let app = conan::router().with_state(state);
+
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!(
+            "/{}/v2/conans/pkg/1.0.0/_/_/revisions/dead/files/conanfile.py",
+            bogus_repo
+        ))
+        .header("Authorization", basic_auth_header(&username, "errpass"))
+        .header("Content-Type", "application/octet-stream")
+        .body(Body::from("dummy content".as_bytes().to_vec()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "PUT to a non-existent repo must return 404, not {}",
+        status.as_u16()
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await;
+}
+
+// ===========================================================================
+// 2. GET /v2/ping on a non-existent repo returns 404 (issue #990, sub-test #12)
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_990_ping_on_nonexistent_repo_returns_404() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let storage_path = std::env::temp_dir().join("conan-err-bogus-ping");
+    std::fs::create_dir_all(&storage_path).ok();
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+
+    let bogus_repo = format!("bogus-conan-{}", &Uuid::new_v4().to_string()[..8]);
+    let app = conan::router().with_state(state);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/{}/v2/ping", bogus_repo))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "GET /v2/ping on a non-existent repo must return 404, not {}",
+        status.as_u16()
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+}
+
+// ===========================================================================
+// 2b. GET /v2/ping on an EXISTING repo still returns 200
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_990_ping_on_existing_repo_returns_200() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let user_id = create_test_user(
+        &pool,
+        &format!("conan-ping-u-{}", &Uuid::new_v4().to_string()[..8]),
+        "pingpass",
+    )
+    .await;
+    let (repo_id, key, storage_path) = create_conan_repo(&pool, "conan-ping-test").await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+
+    let app = conan::router().with_state(state);
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/{}/v2/ping", key))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let caps = resp
+        .headers()
+        .get("X-Conan-Server-Capabilities")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET /v2/ping on an existing repo must return 200"
+    );
+    assert!(
+        caps.contains("revisions"),
+        "X-Conan-Server-Capabilities must advertise 'revisions', got '{}'",
+        caps
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}
+
+// ===========================================================================
+// 3. PUT with a 300-char path segment returns a 4xx (issue #990, sub-test #15)
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_990_long_path_segment_returns_4xx() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("conan-long-u-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "longpass").await;
+    let (repo_id, key, storage_path) = create_conan_repo(&pool, "conan-long-test").await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+
+    let long_name: String = "a".repeat(300);
+    let app = conan::router().with_state(state);
+
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!(
+            "/{}/v2/conans/{}/1.0.0/_/_/revisions/rev/files/conanfile.py",
+            key, long_name
+        ))
+        .header("Authorization", basic_auth_header(&username, "longpass"))
+        .header("Content-Type", "application/octet-stream")
+        .body(Body::from("dummy".as_bytes().to_vec()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    assert!(
+        status.is_client_error(),
+        "PUT with a 300-char path segment must return 4xx, not {}",
+        status.as_u16()
+    );
+    // We specifically choose 414 URI Too Long, but the contract only requires
+    // a structured 4xx (no opaque 500).
+    assert_ne!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "must not surface filesystem ENAMETOOLONG as a 500"
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}

--- a/backend/tests/conan_error_paths_tests.rs
+++ b/backend/tests/conan_error_paths_tests.rs
@@ -85,6 +85,12 @@ fn basic_auth_header(username: &str, password: &str) -> String {
     format!("Basic {}", encoded)
 }
 
+async fn connect_pool() -> PgPool {
+    PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap()
+}
+
 async fn create_test_user(pool: &PgPool, username: &str, password: &str) -> Uuid {
     let id = Uuid::new_v4();
     let hash = bcrypt::hash(password, 4).expect("bcrypt hash failed");
@@ -171,9 +177,7 @@ fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
 #[tokio::test]
 #[ignore]
 async fn test_990_upload_to_nonexistent_repo_returns_404() {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
+    let pool = connect_pool().await;
     let username = format!("conan-err-u-{}", &Uuid::new_v4().to_string()[..8]);
     let user_id = create_test_user(&pool, &username, "errpass").await;
     let storage_path = std::env::temp_dir().join("conan-err-bogus-upload");
@@ -217,9 +221,7 @@ async fn test_990_upload_to_nonexistent_repo_returns_404() {
 #[tokio::test]
 #[ignore]
 async fn test_990_ping_on_nonexistent_repo_returns_404() {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
+    let pool = connect_pool().await;
     let storage_path = std::env::temp_dir().join("conan-err-bogus-ping");
     std::fs::create_dir_all(&storage_path).ok();
     let state = build_state(pool.clone(), storage_path.to_str().unwrap());
@@ -252,9 +254,7 @@ async fn test_990_ping_on_nonexistent_repo_returns_404() {
 #[tokio::test]
 #[ignore]
 async fn test_990_ping_on_existing_repo_returns_200() {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
+    let pool = connect_pool().await;
     let user_id = create_test_user(
         &pool,
         &format!("conan-ping-u-{}", &Uuid::new_v4().to_string()[..8]),
@@ -301,9 +301,7 @@ async fn test_990_ping_on_existing_repo_returns_200() {
 #[tokio::test]
 #[ignore]
 async fn test_990_long_path_segment_returns_4xx() {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
+    let pool = connect_pool().await;
     let username = format!("conan-long-u-{}", &Uuid::new_v4().to_string()[..8]);
     let user_id = create_test_user(&pool, &username, "longpass").await;
     let (repo_id, key, storage_path) = create_conan_repo(&pool, "conan-long-test").await;


### PR DESCRIPTION
Fixes #990.

## Summary

Three pre-existing Conan handler error paths returned 5xx where 4xx was correct, surfaced by `test-conan-errors.sh` in artifact-keeper-test:

| Path | Before | After |
|---|---|---|
| `PUT /conan/<bogus>/v2/conans/.../files/conanfile.py` | 500 (Extension extractor failed) | 404 |
| `GET /conan/<bogus>/v2/ping` | 200 (handler ignored repo) | 404 |
| Upload with 300-byte segment | 500 (filesystem ENAMETOOLONG) | 414 |

## Fix

1. **Upload to non-existent repo (500 → 404).** `repo_visibility_middleware` skips inserting the auth Extension for unknown repo keys, so the handler's strict `Extension<Option<AuthExtension>>` extractor was failing with 500. Changed extractor to `Option<Extension<Option<AuthExtension>>>` (R2 added `flatten_auth_extension` helper) and reordered so `resolve_conan_repo` runs **before** the auth check. Unknown repo → 404 wins.

2. **`/v2/ping` ignores repo (200 → 404).** Added `State<SharedState>` + `Path(repo_key)` to the `ping` handler and call `resolve_conan_repo` first. Capability banner returned only on existing conan repo. **Note:** byte-identical to main's #873 (a Conan correctness backport), so when #986 lands on `release/1.1.x` the merge is mechanical.

3. **Long path returns 500 (→ 414).** New `validate_conan_segments` rejects any path segment > 255 bytes (filesystem `NAME_MAX`) with `URI_TOO_LONG`. Called at the top of both upload handlers — before any DB / auth / storage call — so abuse / fuzzing payloads consistently surface as 414.

## Three-round review

| Round | Role | Result |
|---|---|---|
| R1 | Build (SWE+Test) | ✅ 5 unit tests + 4 integration tests, all green |
| R1 | DevOps | ✅ APPROVE — flagged: #986 backport sequencing, integration tests `#[ignore]`'d, format-handler audit |
| R1 | Security | ✅ APPROVE — verified `repo_visibility_middleware` is the real auth gate; reorder doesn't change posture for existing repos. Path traversal handled at storage layer. |
| R2 | code-simplifier | ✅ Extracted `flatten_auth_extension` + `connect_pool` test helper |
| R3 | adversarial reviewer | ✅ APPROVE for push — verified `flatten_auth_extension` correctness, route uniqueness (only `/v2/ping`, no `/v1/ping` here), error messages don't leak |

## Sequencing note

⚠️ **#986 (Conan backport bringing #869, #873, #875 to `release/1.1.x`) has not yet landed.** When it does, #873 will conflict with this PR's `/v2/ping` handler change. The `ping` body is byte-identical between main's #873 and this PR — merge is mechanical. Recommend landing #990 first, then resolving the trivial route-list conflict in #986. Main also adds `/:repo_key/v1/ping` to the same handler; both routes inherit the new 404 validation automatically once both PRs land.

## Follow-ups (filed)

- artifact-keeper#1044 — Cumulative storage-key length check (S3 ~1024B limit) for proxy uploads
- artifact-keeper#1045 — Full-stack integration test exercising `repo_visibility_middleware` + Conan handlers
- artifact-keeper#1046 — Audit other format handlers (npm, maven, pypi, etc.) for the same three error-path patterns
- artifact-keeper#1047 — Un-ignore conan integration tests for CI execution (tracked under #1031)

## Out of scope

- Forward-port to `main` — `/v2/ping` already fixed there via #873; the upload-extractor and long-path-validator changes may need a forward-port — separate workstream
- Cumulative path length on uploads (#1044)

## Test plan

- [x] `cargo test --lib api::handlers::conan` — 52/52 passing
- [x] 4 integration tests in `backend/tests/conan_error_paths_tests.rs` pass on local podman postgres
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI integration-test job to run the un-ignored regression test (pending #1031)