### PR TITLE
fix(proxy): metadata-only cache probe before presigned redirect

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -265,6 +265,34 @@ fn proxy_cache_storage_key(repo_key: &str, path: &str) -> String {
     )
 }
 
+/// Try to short-circuit a proxy-cache hit into a presigned redirect, without
+/// downloading the cached content into memory.
+///
+/// Returns `Some(Response)` when *all* of:
+///   * `presigned_enabled` is true,
+///   * `cache_is_fresh` is true (caller has already done a metadata-only
+///     freshness check that does not download the object body), and
+///   * `try_presigned_redirect` succeeds in producing a signed URL.
+///
+/// Otherwise returns `None` so the caller falls through to the buffered
+/// fetch + cache + serve path.
+///
+/// Extracted from `proxy_fetch_or_redirect` so the redirect short-circuit can
+/// be exercised in unit tests with recording mock storage backends.
+#[allow(dead_code)] // wired into proxy_fetch_or_redirect in the follow-up fix commit
+pub(crate) async fn try_proxy_cache_redirect<S: crate::storage::StorageBackend + ?Sized>(
+    _storage: &S,
+    _cache_key: &str,
+    _presigned_enabled: bool,
+    _expiry: Duration,
+    _cache_is_fresh: bool,
+) -> Option<Response> {
+    // Stub: always returns None. The fix will implement the real short-circuit
+    // logic so a fresh proxy-cache hit can redirect via presigned URL without
+    // first downloading the entire cached body into memory (issue #1018).
+    None
+}
+
 /// Check whether an artifact is present in the proxy cache under `path`
 /// without contacting upstream. Returns `Ok(Some(...))` on cache hit,
 /// `Ok(None)` on miss or expired entry.
@@ -1710,6 +1738,173 @@ mod tests {
         let key = super::proxy_cache_storage_key("test-repo", "path/to/artifact");
         assert!(key.starts_with("proxy-cache/"));
         assert!(key.ends_with("/__content__"));
+    }
+
+    // ── try_proxy_cache_redirect tests ─────────────────────────────────
+    // Regression coverage for #1018: when the proxy cache is fresh and
+    // presigned downloads are enabled, the helper must return a presigned
+    // redirect *without* calling `storage.get(...)`. The previous
+    // implementation downloaded the full cached body before deciding to
+    // redirect, defeating the memory-pressure guarantee that presigned URLs
+    // are meant to provide.
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc as StdArc;
+
+    /// Recording mock storage backend that counts every method call so tests
+    /// can assert which I/O paths fired (in particular: was the full object
+    /// `get(...)` called).
+    struct RecordingStorage {
+        get_calls: StdArc<AtomicUsize>,
+        presigned_calls: StdArc<AtomicUsize>,
+        supports: bool,
+    }
+
+    impl RecordingStorage {
+        fn new(supports: bool) -> Self {
+            Self {
+                get_calls: StdArc::new(AtomicUsize::new(0)),
+                presigned_calls: StdArc::new(AtomicUsize::new(0)),
+                supports,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::storage::StorageBackend for RecordingStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Bytes::from_static(b"full-body"))
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        fn supports_redirect(&self) -> bool {
+            self.supports
+        }
+        async fn get_presigned_url(
+            &self,
+            key: &str,
+            expires_in: std::time::Duration,
+        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+            self.presigned_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(crate::storage::PresignedUrl {
+                url: format!("https://signed.example.com/{}", key),
+                expires_in,
+                source: crate::storage::PresignedUrlSource::S3,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_try_proxy_cache_redirect_skips_get_on_fresh_cache_hit() {
+        // Bug #1018: a fresh cache hit with presigned enabled must NOT
+        // download the full body. The helper should only invoke the
+        // presigned URL machinery.
+        let storage = RecordingStorage::new(true);
+        let result = super::try_proxy_cache_redirect(
+            &storage,
+            "proxy-cache/repo/pkg/__content__",
+            /* presigned_enabled = */ true,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ true,
+        )
+        .await;
+
+        assert!(
+            result.is_some(),
+            "fresh cache + presigned enabled must yield a redirect"
+        );
+        assert_eq!(
+            storage.get_calls.load(Ordering::SeqCst),
+            0,
+            "full body must NOT be downloaded when redirecting via presigned URL"
+        );
+        assert_eq!(
+            storage.presigned_calls.load(Ordering::SeqCst),
+            1,
+            "exactly one presigned URL request expected"
+        );
+
+        let resp = result.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::FOUND);
+        let location = resp
+            .headers()
+            .get("location")
+            .expect("location header")
+            .to_str()
+            .unwrap();
+        assert!(
+            location.contains("signed.example.com"),
+            "redirect should point at the signed URL, got {}",
+            location
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_proxy_cache_redirect_returns_none_when_presigned_disabled() {
+        let storage = RecordingStorage::new(true);
+        let result = super::try_proxy_cache_redirect(
+            &storage,
+            "proxy-cache/repo/pkg/__content__",
+            /* presigned_enabled = */ false,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ true,
+        )
+        .await;
+
+        assert!(result.is_none(), "disabled presigned must short-circuit");
+        assert_eq!(storage.get_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(storage.presigned_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_try_proxy_cache_redirect_returns_none_when_cache_not_fresh() {
+        // Cache miss / expired: caller must do the upstream fetch + populate
+        // cache path, so the helper should not produce a redirect.
+        let storage = RecordingStorage::new(true);
+        let result = super::try_proxy_cache_redirect(
+            &storage,
+            "proxy-cache/repo/pkg/__content__",
+            /* presigned_enabled = */ true,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ false,
+        )
+        .await;
+
+        assert!(
+            result.is_none(),
+            "stale/missing cache must fall through to the buffered fetch path"
+        );
+        assert_eq!(storage.get_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(storage.presigned_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_try_proxy_cache_redirect_returns_none_when_backend_no_redirect_support() {
+        // Filesystem / RBAC-locked backends: redirect is not possible, so
+        // the helper must yield None and let the caller stream content.
+        let storage = RecordingStorage::new(false);
+        let result = super::try_proxy_cache_redirect(
+            &storage,
+            "proxy-cache/repo/pkg/__content__",
+            /* presigned_enabled = */ true,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ true,
+        )
+        .await;
+
+        assert!(
+            result.is_none(),
+            "backend without redirect support must yield None"
+        );
+        assert_eq!(storage.get_calls.load(Ordering::SeqCst), 0);
     }
 
     // ── classify_remote_or_virtual tests ───────────────────────────────

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -225,16 +225,17 @@ pub async fn proxy_fetch_or_redirect(
     let cache_key = proxy_cache_storage_key(repo_key, path);
     let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
     let presigned_enabled = state.config.presigned_downloads_enabled;
+    let storage_location = StorageLocation {
+        backend: state.config.storage_backend.clone(),
+        path: state.config.storage_path.clone(),
+    };
 
     // Fast path (#1018): if presigned downloads are enabled and the proxy
     // cache is already fresh, redirect to the signed URL without ever
     // pulling the cached body into the backend's memory. The freshness
     // probe is metadata-only (HEAD-equivalent on cloud backends).
     if presigned_enabled && proxy_service.is_cache_fresh(repo_key, path).await {
-        if let Ok(storage) = state.storage_for_repo(&StorageLocation {
-            backend: state.config.storage_backend.clone(),
-            path: state.config.storage_path.clone(),
-        }) {
+        if let Ok(storage) = state.storage_for_repo(&storage_location) {
             if let Some(redirect) = try_proxy_cache_redirect(
                 storage.as_ref(),
                 &cache_key,
@@ -258,10 +259,7 @@ pub async fn proxy_fetch_or_redirect(
     // If presigned is configured, prefer redirecting to the just-populated
     // cache entry over streaming the buffered content back to the client.
     if presigned_enabled {
-        if let Ok(storage) = state.storage_for_repo(&StorageLocation {
-            backend: state.config.storage_backend.clone(),
-            path: state.config.storage_path.clone(),
-        }) {
+        if let Ok(storage) = state.storage_for_repo(&storage_location) {
             if let Some(redirect) =
                 try_presigned_redirect(storage.as_ref(), &cache_key, true, expiry).await
             {

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -222,16 +222,42 @@ pub async fn proxy_fetch_or_redirect(
     upstream_url: &str,
     path: &str,
 ) -> Result<Response, Response> {
+    let cache_key = proxy_cache_storage_key(repo_key, path);
+    let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
+    let presigned_enabled = state.config.presigned_downloads_enabled;
+
+    // Fast path (#1018): if presigned downloads are enabled and the proxy
+    // cache is already fresh, redirect to the signed URL without ever
+    // pulling the cached body into the backend's memory. The freshness
+    // probe is metadata-only (HEAD-equivalent on cloud backends).
+    if presigned_enabled && proxy_service.is_cache_fresh(repo_key, path).await {
+        if let Ok(storage) = state.storage_for_repo(&StorageLocation {
+            backend: state.config.storage_backend.clone(),
+            path: state.config.storage_path.clone(),
+        }) {
+            if let Some(redirect) = try_proxy_cache_redirect(
+                storage.as_ref(),
+                &cache_key,
+                presigned_enabled,
+                expiry,
+                /* cache_is_fresh = */ true,
+            )
+            .await
+            {
+                return Ok(redirect);
+            }
+        }
+    }
+
+    // Slow path: cache miss / expired / presigned disabled. The fetch
+    // populates the proxy cache so a subsequent presigned redirect on the
+    // *next* request can take the fast path above.
     let (content, content_type) =
         proxy_fetch(proxy_service, repo_id, repo_key, upstream_url, path).await?;
 
-    // If presigned downloads are enabled, try to redirect to the cached copy.
-    // The proxy cache stores content under a well-known key derived from
-    // the repo key and path.
-    if state.config.presigned_downloads_enabled {
-        let cache_key = proxy_cache_storage_key(repo_key, path);
-        let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
-
+    // If presigned is configured, prefer redirecting to the just-populated
+    // cache entry over streaming the buffered content back to the client.
+    if presigned_enabled {
         if let Ok(storage) = state.storage_for_repo(&StorageLocation {
             backend: state.config.storage_backend.clone(),
             path: state.config.storage_path.clone(),
@@ -279,18 +305,17 @@ fn proxy_cache_storage_key(repo_key: &str, path: &str) -> String {
 ///
 /// Extracted from `proxy_fetch_or_redirect` so the redirect short-circuit can
 /// be exercised in unit tests with recording mock storage backends.
-#[allow(dead_code)] // wired into proxy_fetch_or_redirect in the follow-up fix commit
 pub(crate) async fn try_proxy_cache_redirect<S: crate::storage::StorageBackend + ?Sized>(
-    _storage: &S,
-    _cache_key: &str,
-    _presigned_enabled: bool,
-    _expiry: Duration,
-    _cache_is_fresh: bool,
+    storage: &S,
+    cache_key: &str,
+    presigned_enabled: bool,
+    expiry: Duration,
+    cache_is_fresh: bool,
 ) -> Option<Response> {
-    // Stub: always returns None. The fix will implement the real short-circuit
-    // logic so a fresh proxy-cache hit can redirect via presigned URL without
-    // first downloading the entire cached body into memory (issue #1018).
-    None
+    if !presigned_enabled || !cache_is_fresh {
+        return None;
+    }
+    try_presigned_redirect(storage, cache_key, true, expiry).await
 }
 
 /// Check whether an artifact is present in the proxy cache under `path`

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -222,7 +222,7 @@ pub async fn proxy_fetch_or_redirect(
     upstream_url: &str,
     path: &str,
 ) -> Result<Response, Response> {
-    let cache_key = proxy_cache_storage_key(repo_key, path);
+    let cache_key = ProxyService::cache_storage_key(repo_key, path);
     let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
     let presigned_enabled = state.config.presigned_downloads_enabled;
     let storage_location = StorageLocation {
@@ -275,18 +275,6 @@ pub async fn proxy_fetch_or_redirect(
         .header("content-length", content.len().to_string())
         .body(axum::body::Body::from(content))
         .unwrap())
-}
-
-/// Derive the proxy cache storage key for a given repo key and artifact path.
-///
-/// Matches the key pattern used by `ProxyService::cache_storage_key`, so
-/// presigned redirects point to the correct cached object.
-fn proxy_cache_storage_key(repo_key: &str, path: &str) -> String {
-    format!(
-        "proxy-cache/{}/{}/__content__",
-        repo_key,
-        path.trim_start_matches('/').trim_end_matches('/')
-    )
 }
 
 /// Try to short-circuit a proxy-cache hit into a presigned redirect, without
@@ -1717,50 +1705,6 @@ mod tests {
     #[test]
     fn test_reject_write_virtual_rejected() {
         assert!(super::reject_write_if_not_hosted("virtual").is_err());
-    }
-
-    // ── proxy_cache_storage_key tests ──────────────────────────────────
-
-    #[test]
-    fn test_proxy_cache_storage_key_basic() {
-        let key = super::proxy_cache_storage_key("npm-remote", "lodash/-/lodash-4.17.21.tgz");
-        assert_eq!(
-            key,
-            "proxy-cache/npm-remote/lodash/-/lodash-4.17.21.tgz/__content__"
-        );
-    }
-
-    #[test]
-    fn test_proxy_cache_storage_key_strips_leading_slash() {
-        let key = super::proxy_cache_storage_key("maven-central", "/com/example/lib-1.0.jar");
-        assert_eq!(
-            key,
-            "proxy-cache/maven-central/com/example/lib-1.0.jar/__content__"
-        );
-    }
-
-    #[test]
-    fn test_proxy_cache_storage_key_strips_trailing_slash() {
-        let key = super::proxy_cache_storage_key("pypi-proxy", "packages/simple/requests/");
-        assert_eq!(
-            key,
-            "proxy-cache/pypi-proxy/packages/simple/requests/__content__"
-        );
-    }
-
-    #[test]
-    fn test_proxy_cache_storage_key_no_slashes() {
-        let key = super::proxy_cache_storage_key("npm-remote", "express");
-        assert_eq!(key, "proxy-cache/npm-remote/express/__content__");
-    }
-
-    #[test]
-    fn test_proxy_cache_storage_key_matches_proxy_service_format() {
-        // Verifies the key format matches ProxyService::cache_storage_key
-        // so presigned redirects point to the correct cached objects.
-        let key = super::proxy_cache_storage_key("test-repo", "path/to/artifact");
-        assert!(key.starts_with("proxy-cache/"));
-        assert!(key.ends_with("/__content__"));
     }
 
     // ── try_proxy_cache_redirect tests ─────────────────────────────────

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -119,6 +119,31 @@ impl ProxyService {
         self.get_cached_artifact(&cache_key, &metadata_key).await
     }
 
+    /// Metadata-only freshness check for a proxy-cached artifact.
+    ///
+    /// Loads only the cache metadata sidecar (small JSON) and verifies that
+    /// the underlying content object exists in the storage backend. Does
+    /// NOT download the cached body, which is the whole point of a
+    /// metadata-only probe before issuing a presigned redirect (#1018).
+    ///
+    /// Returns `true` only when both:
+    ///   * the metadata exists and has not expired, and
+    ///   * the content object exists in the backing storage.
+    pub async fn is_cache_fresh(&self, repo_key: &str, path: &str) -> bool {
+        let cache_key = Self::cache_storage_key(repo_key, path);
+        let metadata_key = Self::cache_metadata_key(repo_key, path);
+
+        let Ok(Some(metadata)) = self.load_cache_metadata(&metadata_key).await else {
+            return false;
+        };
+        if Utc::now() > metadata.expires_at {
+            return false;
+        }
+        // exists() is a HEAD-equivalent on cloud backends and does not pull
+        // the object body into memory.
+        matches!(self.storage.exists(&cache_key).await, Ok(true))
+    }
+
     /// Fetch artifact from upstream, but use `cache_path` instead of
     /// `fetch_path` when reading and writing the proxy cache.
     ///

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -129,6 +129,31 @@ impl ProxyService {
     /// Returns `true` only when both:
     ///   * the metadata exists and has not expired, and
     ///   * the content object exists in the backing storage.
+    ///
+    /// # Integrity / SHA-256 self-heal divergence (fast vs. slow path)
+    ///
+    /// The slow path (`get_cached_artifact`) recomputes the SHA-256 of the
+    /// cached body and, on mismatch, returns `None` so the caller re-fetches
+    /// from upstream and overwrites the cache entry — i.e. the cache
+    /// self-heals on the next read.
+    ///
+    /// The fast path that this probe gates (presigned redirect to the
+    /// cached object) does **not** download the body and therefore cannot
+    /// recompute the SHA-256. It trusts the storage backend's own
+    /// integrity guarantees (S3/GCS/Azure object checksums, ETags,
+    /// versioning, etc.). Concretely:
+    ///
+    ///   * a SHA-mismatched cache entry served via a presigned URL will
+    ///     **not** be detected or healed until either (a) the next slow-path
+    ///     access of the same key, or (b) the cache TTL expires and the
+    ///     entry is refreshed from upstream;
+    ///   * this matches existing presign+redirect semantics elsewhere in
+    ///     the codebase — presigned URLs have always trusted the storage
+    ///     backend, the proxy cache is no different.
+    ///
+    /// ETag-based revalidation on the fast path is a deliberate follow-up
+    /// (not implemented here) so the #1018 fix stays scoped to "do not
+    /// buffer the body".
     pub async fn is_cache_fresh(&self, repo_key: &str, path: &str) -> bool {
         let cache_key = Self::cache_storage_key(repo_key, path);
         let metadata_key = Self::cache_metadata_key(repo_key, path);
@@ -360,7 +385,14 @@ impl ProxyService {
     /// Uses a `__content__` leaf file to avoid file/directory collisions
     /// when one path is a prefix of another (e.g., npm metadata at `is-odd`
     /// vs tarball at `is-odd/-/is-odd-3.0.1.tgz`).
-    fn cache_storage_key(repo_key: &str, path: &str) -> String {
+    ///
+    /// Visible to the rest of the crate so that the proxy fast-path in
+    /// `api::handlers::proxy_helpers::proxy_fetch_or_redirect` can sign
+    /// presigned URLs against the *exact* same key the freshness probe
+    /// in `is_cache_fresh` checks. Keeping a single source of truth for
+    /// the key formula prevents the freshness check and the presign
+    /// target from drifting out of sync (#1018).
+    pub(crate) fn cache_storage_key(repo_key: &str, path: &str) -> String {
         format!(
             "proxy-cache/{}/{}/__content__",
             repo_key,
@@ -2040,5 +2072,193 @@ mod tests {
         assert_eq!(capped, 3600);
         let effective = capped.saturating_mul(9) / 10;
         assert_eq!(effective, 3240);
+    }
+
+    // =======================================================================
+    // is_cache_fresh tests (#1018 R3-2)
+    // =======================================================================
+    //
+    // Direct unit coverage for the metadata-only freshness probe used by the
+    // proxy fast path. The probe is the gate that decides whether the
+    // presigned-redirect short-circuit fires, so any silent regression here
+    // (e.g. the probe always returning true, or accidentally downloading the
+    // body) re-introduces the buffered-download bug behind a different code
+    // path. These tests fix the contract:
+    //   * missing metadata sidecar         -> false
+    //   * expired metadata                 -> false
+    //   * valid metadata, content missing  -> false
+    //   * valid metadata, content present  -> true
+    //
+    // and crucially never invoke `storage.get(...)` on the cached body.
+
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    /// Programmable storage backend for `is_cache_fresh` tests.
+    ///
+    /// Lets each test wire up just enough behavior:
+    ///   * `metadata` is the JSON bytes returned by `get(metadata_key)`,
+    ///     or `None` to simulate a missing sidecar (`AppError::NotFound`).
+    ///   * `content_exists` is what `exists(content_key)` returns.
+    ///   * `get_calls` records every `get(...)` call so tests can assert
+    ///     the body was never downloaded.
+    struct CacheFreshMock {
+        metadata: Option<Bytes>,
+        content_exists: bool,
+        get_calls: AtomicUsize,
+    }
+
+    impl CacheFreshMock {
+        fn new(metadata: Option<Bytes>, content_exists: bool) -> Self {
+            Self {
+                metadata,
+                content_exists,
+                get_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for CacheFreshMock {
+        async fn put(&self, _key: &str, _content: Bytes) -> Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            self.get_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            if key.ends_with("__cache_meta__.json") {
+                match &self.metadata {
+                    Some(b) => Ok(b.clone()),
+                    None => Err(AppError::NotFound(key.to_string())),
+                }
+            } else {
+                // Body access on the fast path is forbidden — return
+                // NotFound so accidental hits surface as test failures
+                // rather than fake successes.
+                Err(AppError::NotFound(key.to_string()))
+            }
+        }
+        async fn exists(&self, key: &str) -> Result<bool> {
+            if key.ends_with("__content__") {
+                Ok(self.content_exists)
+            } else {
+                // Metadata sidecar exists iff metadata bytes are present.
+                Ok(self.metadata.is_some())
+            }
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// Build a `ProxyService` whose storage is the supplied mock. The DB
+    /// pool is a lazy connection that is never dialed because
+    /// `is_cache_fresh` does not touch the database.
+    fn build_proxy_service_with_storage(
+        storage: Arc<dyn crate::services::storage_service::StorageBackend>,
+    ) -> ProxyService {
+        let pool = sqlx::PgPool::connect_lazy("postgres://fake:fake@localhost/fake")
+            .expect("connect_lazy should not fail");
+        ProxyService::new(pool, Arc::new(StorageService::new(storage)))
+    }
+
+    fn fresh_metadata_bytes() -> Bytes {
+        let metadata = CacheMetadata {
+            cached_at: Utc::now(),
+            upstream_etag: None,
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            content_type: Some("application/octet-stream".to_string()),
+            size_bytes: 42,
+            checksum_sha256: "a".repeat(64),
+        };
+        Bytes::from(serde_json::to_vec(&metadata).unwrap())
+    }
+
+    fn expired_metadata_bytes() -> Bytes {
+        let metadata = CacheMetadata {
+            cached_at: Utc::now() - chrono::Duration::hours(2),
+            upstream_etag: None,
+            expires_at: Utc::now() - chrono::Duration::seconds(1),
+            content_type: None,
+            size_bytes: 0,
+            checksum_sha256: String::new(),
+        };
+        Bytes::from(serde_json::to_vec(&metadata).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_metadata_sidecar_missing() {
+        let mock = Arc::new(CacheFreshMock::new(/* metadata = */ None, true));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "missing metadata sidecar must yield is_cache_fresh = false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_metadata_expired() {
+        let mock = Arc::new(CacheFreshMock::new(Some(expired_metadata_bytes()), true));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "expired metadata (expires_at < now) must yield is_cache_fresh = false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_content_missing() {
+        // Metadata is valid and unexpired, but the underlying content
+        // object has been evicted (e.g. lifecycle policy). The freshness
+        // probe must catch this so the fast path does not sign a URL
+        // pointing at a 404.
+        let mock = Arc::new(CacheFreshMock::new(
+            Some(fresh_metadata_bytes()),
+            /* content_exists = */ false,
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "valid metadata with missing content object must yield is_cache_fresh = false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_true_when_metadata_valid_and_content_exists() {
+        let mock = Arc::new(CacheFreshMock::new(
+            Some(fresh_metadata_bytes()),
+            /* content_exists = */ true,
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            fresh,
+            "valid metadata + existing content must yield is_cache_fresh = true"
+        );
+        // Belt-and-suspenders: the probe must never download the body.
+        // It is only allowed to call `get` on the metadata sidecar.
+        assert_eq!(
+            mock.get_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "is_cache_fresh must read metadata exactly once and never the body"
+        );
     }
 }


### PR DESCRIPTION
Fixes #1018.

## Summary

`proxy_fetch_or_redirect` was downloading the full cached artifact body via `storage.get(...)` BEFORE deciding to issue a presigned redirect — defeating the whole point of presigned URLs (avoiding memory pressure on the server). For a 5GB image this was 5GB of buffered RAM per request.

## Fix

Add a fast-path that uses `is_cache_fresh` (metadata-only probe) + `StorageBackend::exists` (HEAD-only check) before deciding to redirect:

```rust
// Fast path (#1018): metadata-only freshness probe + presigned redirect.
if presigned_enabled && proxy_service.is_cache_fresh(repo_key, path).await {
    if let Ok(storage) = state.storage_for_repo(...) {
        if let Some(redirect) = try_proxy_cache_redirect(
            storage.as_ref(), &cache_key, presigned_enabled, expiry, true).await
        { return Ok(redirect); }
    }
}
// Slow path (cache miss / disabled): unchanged, calls proxy_fetch.
```

`exists` is already on the `StorageBackend` trait and faithfully implemented across all 4 production backends (filesystem `path.exists()`, S3 `store.head()`, GCS metadata GET, Azure authorized HEAD — verified per backend by R1 DevOps).

The slow path (cache miss / pre-signed disabled / metadata stale) is byte-identical to before the fix.

## Three-round review

| Round | Role | Result |
|---|---|---|
| R1 | Build (SWE+Test) | ✅ Test asserts `storage.get_calls == 0` (no body download) AND `presigned_calls == 1`. 4 tests covering cache-fresh / disabled / stale / no-redirect-support paths. |
| R1 | DevOps | ✅ APPROVE — verified `exists` correctness across filesystem/S3/GCS/Azure. **Recommended milestone v1.1.10 → v1.2.0** (the function being fixed only exists on main; v1.1.10 cuts from release/1.1.x without it). Milestone moved. |
| R1 | Security | ✅ APPROVE — TOCTOU bounded by 5-min expiry; `exists` is HEAD-only no body GET; race handled correctly. Three follow-ups filed. |
| R2 | code-simplifier | ✅ Hoisted `StorageLocation` construction; 290 proxy tests pass. |
| R3 | adversarial reviewer (iter 1) | 🛑 BLOCK — found cache-key formula duplicated across `proxy_helpers::proxy_cache_storage_key` and `ProxyService::cache_storage_key`. Silent-desync bug class. Plus: SHA-256 self-heal divergence undocumented; `is_cache_fresh` had no direct tests. |
| R2 | iteration 1 | ✅ Promoted `cache_storage_key` to `pub(crate)`, deleted duplicate (single source of truth). Added explicit doc on SHA-256 self-heal divergence. Added 4 new tests for `is_cache_fresh` (missing/expired/missing-content/happy-path). |
| R3 | adversarial reviewer (iter 2) | ✅ APPROVE — verified zero remaining duplicate references, doc accurately describes slow-path self-heal mechanism, 4/4 tests pass and properly distinguish metadata-sidecar reads from content-body reads. |

## Important: SHA-256 self-heal divergence

Documented in `is_cache_fresh` doccomment. Slow path's `get_cached_artifact` recomputes SHA-256 against the body and returns `None` on mismatch (which forces upstream re-fetch and rewrites cache). The fast path skips this — a SHA-mismatched cache entry served via presigned URL will not be detected/healed until either the next slow-path access or TTL expiry. **This matches existing presign-redirect semantics** (presigned URLs always trusted backend integrity), but is a real semantic change worth knowing.

ETag-based mitigation tracked separately as #1051.

## Follow-up issues (filed)

- artifact-keeper#1051 — ETag-based integrity revalidation on fast path (mitigates SHA-256 skip)
- artifact-keeper#1052 — Path-traversal sanitization in `cache_storage_key` (pre-existing)
- artifact-keeper#1053 — Per-IP rate limit on presigned-URL minting (DoS amplification mitigation)
- artifact-keeper#1054 — Verify `ProxyService.storage` and `state.storage_for_repo` coincide for default location

## Out of scope

- ETag-vs-SHA cross-checking in this PR (#1051)
- Rate-limit reshape (#1053)
- Pre-existing path-traversal hardening (#1052)

## Test plan

- [x] `cargo test --lib -- proxy` — 289/289 passing (incl. 4 new `is_cache_fresh` tests)
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Test asserts `storage.get_calls == 1` (only metadata sidecar) and presigned URL minted exactly once on fast-path hit
- [ ] CI to re-run on push
- [ ] Manual: large-artifact pull through proxy → memory observability (post-merge in staging)