### PR TITLE
fix(release): portable sed + bash shell for cross-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,19 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Set version from tag
+        # Force bash on every runner. GitHub-hosted Windows runners ship
+        # git-bash; without this line PowerShell tries to parse bash
+        # parameter expansion and fails.
+        shell: bash
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo "Setting workspace version to ${VERSION}"
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          # Portable sed -i: BSD sed (macOS) requires an extension argument,
+          # GNU sed (Linux) accepts it. Using `.bak` then deleting the file
+          # works on both. Without this, macOS reports
+          # `sed: 1: "Cargo.toml": invalid command code C`.
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
           head -5 Cargo.toml
 
       - name: Build


### PR DESCRIPTION
## Summary

Every release pipeline run for `v1.1.x` tags has failed all three non-Linux build matrix entries (macOS x86_64, macOS arm64, Windows x86_64). Most recent example: the v1.1.9-rc.1 tag run (#25282354352) where Create Release and Publish Docker Images skipped because the build matrix was red.

Root cause is a single line in `.github/workflows/release.yml`'s "Set version from tag" step:

```bash
sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
```

That line works on Linux only:

- macOS: BSD sed treats the next non-flag arg as the in-place backup extension. `sed -i "s/...;...;" Cargo.toml` makes BSD sed think `Cargo.toml` is the extension, then it tries to parse the substitute expression as a file and dies with `sed: 1: "Cargo.toml": invalid command code C`.
- Windows: GitHub's Windows runner defaults to PowerShell. The whole script is parsed by `pwsh`, so `${GITHUB_REF_NAME#v}` is a syntax error before sed even runs.

The fix is two changes to that one step:

- Force `shell: bash`. GitHub-hosted Windows runners ship git-bash, so this works without runner changes.
- Use `sed -i.bak ... Cargo.toml` then remove the `.bak`. The `.bak` argument is the portable form: BSD sed treats it as the backup extension, GNU sed accepts it.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`sed -i.bak` runs cleanly under both BSD and GNU sed; `shell: bash` is documented for Windows runners)
- [x] No regressions in existing tests (this is a CI workflow fix, not application code)

## API Changes
- [x] N/A - CI workflow only

## Related

- v1.1.9-rc.1 release run #25282354352 — where the bug surfaced
- Companion PR against `main` for the same fix (#TBD)