### PR TITLE
fix(release): release-gate must test :1.1-dev image, not :dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,20 @@ jobs:
     name: Mesh Replication E2E (optional)
     uses: ./.github/workflows/mesh-e2e.yml
     with:
-      image_tag: dev
+      # Validate against the release/1.1.x dev tag built from THIS branch,
+      # not main's `:dev`. Without this the gate tested whatever was on
+      # main at the time of the tag run instead of the actual rc commit.
+      image_tag: 1.1-dev
     secrets: inherit
 
   release-gate:
     name: Release Gate (Full Suite)
     uses: artifact-keeper/artifact-keeper-test/.github/workflows/release-gate.yml@main
     with:
-      backend_tag: dev
+      # Same reasoning as mesh-e2e-gate above: test the release/1.1.x dev
+      # image, not main's. v1.1.9-rc.2's release-gate failed on a python
+      # regression that was actually in main (#1004), not on release/1.1.x.
+      backend_tag: 1.1-dev
       test_suite: all
     secrets: inherit
 


### PR DESCRIPTION
## Summary

`release.yml` on `release/1.1.x` invoked both `mesh-e2e-gate` and the full `release-gate.yml@main` reusable workflow with `image_tag: dev` / `backend_tag: dev`. Those tags resolve to whatever was last pushed to **main**, not the actual rc commit on this branch.

Net effect: every prior `v1.1.x-rc.N` release-gate run tested **the wrong image**.

This surfaced concretely on v1.1.9-rc.2 (release run #25348233406):

- `format-tests (python)` failed on `multipart upload failed: ` (empty error). Root cause was PR #1004 (LIKE-escape extension) on **main** touching `pypi.rs`. `release/1.1.x` has no such change.
- `Publish Docker Images` skipped because release-gate failed → rc.2 only published binaries, no docker tag.

## Change

Pass `1.1-dev` (the dev tag built by `docker-publish.yml` from this branch) to both gates instead of `dev`:

```yaml
mesh-e2e-gate:
  with:
    image_tag: 1.1-dev    # was: dev
release-gate:
  with:
    backend_tag: 1.1-dev  # was: dev
```

Comments on each call explain why and reference the rc.2 incident.

This is intentionally branch-specific: `main`'s `release.yml` stays at `:dev`. Future maintenance branches should follow the same pattern (`release/1.2.x` → `1.2-dev`, etc.).

## Test Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (verified the docker-publish.yml on this branch produces the `1.1-dev` tag — `type=raw,value=1.1-dev,enable=...release/1.1.x...` at lines 491, 507, 612, 628, 718, 736)
- [x] No regressions in existing tests (this is a CI workflow fix, not application code)

## API Changes

- [x] N/A - CI workflow only

## Related

- v1.1.9-rc.2 release run: artifact-keeper/artifact-keeper#25348233406
- Companion PR in artifact-keeper-test: cache-ttl test default 3600 → 86400
- The python regression on main (PR #1004 in `pypi.rs`) is a separate issue not blocking 1.1.x