### PR TITLE
fix(cache-ttl): backport unification of GET default to 86400 (#932)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -21,6 +21,7 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::artifact_service::ArtifactService;
+use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
 use crate::services::repository_service::{
     CreateRepositoryRequest as ServiceCreateRepoReq, RepositoryService,
     UpdateRepositoryRequest as ServiceUpdateRepoReq,
@@ -382,14 +383,24 @@ pub async fn get_cache_ttl(
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
 
-    let ttl = result
-        .and_then(|(v,)| v.parse::<i64>().ok())
-        .unwrap_or(3600); // default 1 hour
+    let ttl = resolve_cache_ttl(result.map(|(v,)| v));
 
     Ok(Json(CacheTtlResponse {
         repository_key: key,
         cache_ttl_seconds: ttl,
     }))
+}
+
+/// Resolve the effective cache TTL from a stored `repository_config` value.
+///
+/// Falls back to [`DEFAULT_CACHE_TTL_SECS`] when no value is stored or when the
+/// stored value cannot be parsed as `i64`. This matches the default applied by
+/// `proxy_service` so `GET /cache-ttl` always reports the value the proxy will
+/// actually use.
+fn resolve_cache_ttl(stored: Option<String>) -> i64 {
+    stored
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(DEFAULT_CACHE_TTL_SECS)
 }
 
 fn parse_format(s: &str) -> Result<RepositoryFormat> {
@@ -3194,14 +3205,95 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // resolve_cache_ttl (issue #911: GET /cache-ttl default must match proxy)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_cache_ttl_falls_back_to_proxy_default_when_unset() {
+        // When no row exists in repository_config, the GET endpoint must
+        // report the same default the proxy actually applies (24h, not 1h).
+        assert_eq!(resolve_cache_ttl(None), DEFAULT_CACHE_TTL_SECS);
+        assert_eq!(resolve_cache_ttl(None), 86400);
+    }
+
+    #[test]
+    fn test_resolve_cache_ttl_falls_back_when_value_unparseable() {
+        assert_eq!(
+            resolve_cache_ttl(Some("not-a-number".to_string())),
+            DEFAULT_CACHE_TTL_SECS,
+        );
+    }
+
+    #[test]
+    fn test_resolve_cache_ttl_returns_stored_value() {
+        assert_eq!(resolve_cache_ttl(Some("7200".to_string())), 7200);
+    }
+
+    #[test]
+    fn test_resolve_cache_ttl_returns_stored_zero() {
+        // resolve_cache_ttl is only responsible for parsing; range validation
+        // happens on the SET path via validate_cache_ttl.
+        assert_eq!(resolve_cache_ttl(Some("0".to_string())), 0);
+    }
+
+    /// Structural guard for issue #911. The unit tests above only cover the
+    /// `resolve_cache_ttl` helper. They will still pass if a future change
+    /// reverts the `get_cache_ttl` handler call site to a hardcoded literal
+    /// like the old 1-hour default, which is exactly the regression we are
+    /// trying to prevent. Asserting on the source text of this file at
+    /// compile time is ugly but pins the call site without requiring a
+    /// Postgres fixture.
+    ///
+    /// In-process handler tests in this crate would require a live PgPool
+    /// (no `#[sqlx::test]` pattern is used in this file), so we use a
+    /// source-grep test as the lightweight regression contract instead.
+    ///
+    /// The forbidden substrings are constructed at runtime so this test's
+    /// own body does not contain them and trip the check on itself.
+    #[test]
+    fn test_get_cache_ttl_handler_uses_resolve_helper_not_hardcoded_literal() {
+        let src = include_str!("repositories.rs");
+
+        // Build forbidden patterns at runtime so they do not appear as
+        // literal substrings in this source file.
+        let unwrap_prefix = ["unwrap", "_or"].concat(); // "unwrap_or"
+        let bad_old_default = format!("{}({})", unwrap_prefix, 3600);
+        let bad_inline_default = format!("{}({})", unwrap_prefix, 86400);
+
+        assert!(
+            !src.contains(&bad_old_default),
+            "regression of issue #911: the old 1-hour fallback literal must \
+             not reappear in this file; the get_cache_ttl handler must \
+             delegate to resolve_cache_ttl(...) so the default stays aligned \
+             with proxy_service::DEFAULT_CACHE_TTL_SECS",
+        );
+        assert!(
+            !src.contains(&bad_inline_default),
+            "do not hardcode the cache TTL default literal; call \
+             resolve_cache_ttl(...) which references DEFAULT_CACHE_TTL_SECS",
+        );
+
+        // Anchor: the handler body must actually call the helper.
+        // Spelled in three pieces so this assertion's own text does not
+        // satisfy the search.
+        let helper_call = format!("{}{}{}", "resolve_cache_ttl(result.map(", "|(v,)| v", "))",);
+        assert!(
+            src.contains(&helper_call),
+            "get_cache_ttl handler must call the resolve_cache_ttl helper to \
+             derive the effective TTL; do not inline the fallback in the \
+             handler",
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Cache TTL DTO serialization / deserialization
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_set_cache_ttl_request_deserialization() {
-        let json = r#"{"cache_ttl_seconds": 3600}"#;
+        let json = r#"{"cache_ttl_seconds": 86400}"#;
         let req: SetCacheTtlRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.cache_ttl_seconds, 3600);
+        assert_eq!(req.cache_ttl_seconds, 86400);
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -25,7 +25,7 @@ use crate::services::storage_service::StorageService;
 use crate::storage::{StorageBackend as RepoStorageBackend, StorageRegistry};
 
 /// Default cache TTL in seconds (24 hours)
-const DEFAULT_CACHE_TTL_SECS: i64 = 86400;
+pub const DEFAULT_CACHE_TTL_SECS: i64 = 86400;
 
 /// HTTP client timeout in seconds
 const HTTP_TIMEOUT_SECS: u64 = 60;


### PR DESCRIPTION
## Summary

Cherry-pick of [#932](https://github.com/artifact-keeper/artifact-keeper/pull/932) (`d12e722a`) from `main` to `release/1.1.x`.

`GET /api/v1/repositories/:key/cache-ttl` returns a hardcoded `3600` (1 hour) when no row exists in `repository_config`. The proxy applies `DEFAULT_CACHE_TTL_SECS = 86400` (24 hours). Operators reading the GET response have been misled by a 24x discrepancy.

This unifies the GET default with the proxy_service constant. Same fix as #932 on main; backported here so v1.1.9 ships with consistent behavior.

This was discovered as a release-gate failure in v1.1.9-rc.3: `repo-tests / test-cache-ttl-config.sh` expected 86400 (per artifact-keeper-test #134) but the v1.1.x backend returned 3600 because #932 was never backported. With this PR landed, the test passes against `:1.1-dev`.

## Conflict resolution

The cherry-pick of `d12e722a` brought in two new imports:

```rust
use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
```

`SYSTEM_SENTINEL_ID` and `SYSTEM_TARGET_TYPE` don't exist in `release/1.1.x` (they were added on `main` by a separate change not relevant here). Dropped that import; kept only `DEFAULT_CACHE_TTL_SECS` which is the import #932 actually needs.

## Test Checklist
- [x] Unit tests added/updated (cherry-picked from #932)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (\`cargo check --workspace --tests\` clean)
- [x] No regressions in existing tests

## API Changes
- [x] N/A — only the documented default value of an existing endpoint changed (3600 → 86400, which matches what the proxy already does)