### PR TITLE
chore(scanners): backport Grype 0.111.1 + DB pre-seed to 1.1.x

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -89,7 +89,7 @@ impl GrypeScanner {
                 return Err(AppError::Internal("Grype binary not available".to_string()));
             }
             return Err(AppError::Internal(format!(
-                "Grype scan failed (exit {}): {}",
+                "Grype scan failed ({}): {}",
                 output.status, stderr
             )));
         }

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -125,7 +125,7 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
-FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
+FROM ghcr.io/anchore/grype:v0.111.1 AS grype-bin
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.7

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -125,7 +125,7 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
-FROM ghcr.io/anchore/grype:v0.110.0 AS grype-bin
+FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.7

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -127,6 +127,16 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
 FROM ghcr.io/anchore/grype:v0.111.1 AS grype-bin
 
+# ---------- Stage 5b: Pre-seed the Grype vulnerability DB ----------
+# Populates the Grype DB at build time so the image works on egress-restricted
+# networks (e.g. ARC runner pods) without a first-scan network fetch from
+# grype.anchore.io. See artifact-keeper#1001.
+FROM alpine:3.23 AS grype-db-seed
+RUN apk add --no-cache ca-certificates
+COPY --from=grype-bin /grype /usr/local/bin/grype
+ENV GRYPE_DB_CACHE_DIR=/grype-db
+RUN mkdir -p /grype-db && grype db update && grype db status
+
 # ---------- Stage 6: UBI 9 Micro runtime ----------
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.7
 
@@ -136,6 +146,9 @@ COPY --from=rootfs-builder /mnt/rootfs /
 # Copy scanner CLIs from official images
 COPY --from=trivy-bin /usr/local/bin/trivy /usr/local/bin/
 COPY --from=grype-bin /grype /usr/local/bin/
+
+# Pre-seeded Grype vulnerability DB (avoids first-scan network fetch)
+COPY --from=grype-db-seed --chown=1001:0 /grype-db /home/artifact/.cache/grype
 
 # Copy application binary
 COPY --from=builder /app/target/release/artifact-keeper /usr/local/bin/
@@ -147,6 +160,7 @@ ENV RUST_LOG=info \
     DATABASE_URL=set-database-url-at-runtime \
     STORAGE_PATH=/data/storage \
     BACKUP_PATH=/data/backups \
+    GRYPE_DB_CACHE_DIR=/home/artifact/.cache/grype \
     HOST=0.0.0.0 \
     PORT=8080
 

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -44,6 +44,16 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
 FROM ghcr.io/anchore/grype:v0.111.1 AS grype-bin
 
+# ---------- Stage 4b: Pre-seed the Grype vulnerability DB ----------
+# Populates the Grype DB at build time so the image works on egress-restricted
+# networks (e.g. ARC runner pods) without a first-scan network fetch from
+# grype.anchore.io. See artifact-keeper#1001.
+FROM alpine:3.23 AS grype-db-seed
+RUN apk add --no-cache ca-certificates
+COPY --from=grype-bin /grype /usr/local/bin/grype
+ENV GRYPE_DB_CACHE_DIR=/grype-db
+RUN mkdir -p /grype-db && grype db update && grype db status
+
 # ---------- Stage 5: Alpine runtime ----------
 FROM alpine:3.23
 
@@ -87,6 +97,9 @@ RUN rm -rf /var/cache/apk/* /tmp/*
 COPY --from=trivy-bin /usr/local/bin/trivy /usr/local/bin/
 COPY --from=grype-bin /grype /usr/local/bin/
 
+# Pre-seeded Grype vulnerability DB (avoids first-scan network fetch)
+COPY --from=grype-db-seed --chown=1001:1001 /grype-db /home/artifact/.cache/grype
+
 # Copy application binary
 COPY --from=builder /app/target/release/artifact-keeper /usr/local/bin/
 
@@ -97,6 +110,7 @@ ENV RUST_LOG=info \
     DATABASE_URL=set-database-url-at-runtime \
     STORAGE_PATH=/data/storage \
     BACKUP_PATH=/data/backups \
+    GRYPE_DB_CACHE_DIR=/home/artifact/.cache/grype \
     HOST=0.0.0.0 \
     PORT=8080
 

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -42,7 +42,7 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
-FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
+FROM ghcr.io/anchore/grype:v0.111.1 AS grype-bin
 
 # ---------- Stage 5: Alpine runtime ----------
 FROM alpine:3.23

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -42,7 +42,7 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
 FROM ghcr.io/aquasecurity/trivy:0.69.3 AS trivy-bin
-FROM ghcr.io/anchore/grype:v0.110.0 AS grype-bin
+FROM ghcr.io/anchore/grype:v0.111.0 AS grype-bin
 
 # ---------- Stage 5: Alpine runtime ----------
 FROM alpine:3.23


### PR DESCRIPTION
## Summary

Three-commit backport bringing the Grype scanner toolchain on \`release/1.1.x\` in line with \`main\`:

- [#748](https://github.com/artifact-keeper/artifact-keeper/pull/748): bump grype 0.110.0 → 0.111.0 (cherry-picked clean)
- [#845](https://github.com/artifact-keeper/artifact-keeper/pull/845): bump grype 0.111.0 → 0.111.1 (applied manually as a one-line version edit; the original commit conflicted on adjacent rev-bumps that landed differently here)
- [#1002](https://github.com/artifact-keeper/artifact-keeper/pull/1002): pre-seed Grype vulnerability DB at image build time, plus a one-character fix to the error format string ("exit exit status:" → "exit status:")

## Why

v1.1.9-rc.3's release-gate failed `security-tests` on the lodash-vuln-fixture scan:

```
FAIL: scan reported terminal status 'failed' (error_message:
      Internal error: Grype scan failed for lodash-vuln-fixture:
      Internal error: Grype scan failed (exit exit status: 1): )
FAIL: scan ... on known-vulnerable fixture (lodash 4.17.4 / CVE-2019-10744)
      reports findings_count=0; scanner did not inspect the bytes
```

`v0.110.0` cannot read the modern grype-db format, so every scan fails with a bare \`exit status: 1\` and zero findings. Bumping to v0.111.1 plus the DB pre-seed (which lays down a known-good DB cache at image build time, side-stepping live grype.anchore.io fetches in CI) fixes the scan path.

Note the "exit exit status" duplication mentioned in the rc.3 failure log is exactly the error-format glitch #1002 also fixes.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (\`cargo check --workspace\` clean against this branch state; image build path preserved)
- [x] No regressions in existing tests

## API Changes
- [x] N/A — Dockerfile + scanner internals only

## Related

- v1.1.9-rc.3 release run: artifact-keeper/artifact-keeper#25377051214
- Closes the v1.1.9-rc.3 \`security-tests\` blocker