### PR TITLE
refactor(oci): extract TagsFetchCtx struct from tags-list helpers (closes #1066)

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2162,7 +2162,10 @@ async fn fetch_upstream_tags_page(
     })?;
 
     let parsed = serde_json::from_slice::<serde_json::Value>(&content).map_err(|e| {
-        warn!("Invalid upstream tags/list response for {}: {}", ctx.image, e);
+        warn!(
+            "Invalid upstream tags/list response for {}: {}",
+            ctx.image, e
+        );
         oci_error(
             StatusCode::BAD_GATEWAY,
             "UNKNOWN",

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2114,16 +2114,24 @@ struct UpstreamTagsPage {
     next_last: Option<String>,
 }
 
-async fn fetch_upstream_tags_page(
-    state: &SharedState,
+/// Inputs shared across `fetch_upstream_tags_page`, `collect_upstream_tags`,
+/// and `fetch_tags_from_remote_member`. Bundling them avoids passing the same
+/// five values through every call (state + repo_id + repo_key + upstream_url +
+/// image), which previously pushed each helper to seven positional arguments.
+struct TagsFetchCtx<'a> {
+    state: &'a SharedState,
     repo_id: Uuid,
-    repo_key: &str,
-    upstream_url: &str,
-    image: &str,
+    repo_key: &'a str,
+    upstream_url: &'a str,
+    image: &'a str,
+}
+
+async fn fetch_upstream_tags_page(
+    ctx: &TagsFetchCtx<'_>,
     n: usize,
     last: Option<&str>,
 ) -> Result<UpstreamTagsPage, Response> {
-    let proxy = state.proxy_service.as_ref().ok_or_else(|| {
+    let proxy = ctx.state.proxy_service.as_ref().ok_or_else(|| {
         oci_error(
             StatusCode::BAD_GATEWAY,
             "UNKNOWN",
@@ -2131,12 +2139,12 @@ async fn fetch_upstream_tags_page(
         )
     })?;
 
-    let upstream_path = format!("v2/{}/{}", image, build_remote_tags_list_path(n, last));
+    let upstream_path = format!("v2/{}/{}", ctx.image, build_remote_tags_list_path(n, last));
     let (content, _ct, link) = proxy_helpers::proxy_fetch_uncached_with_link(
         proxy,
-        repo_id,
-        repo_key,
-        upstream_url,
+        ctx.repo_id,
+        ctx.repo_key,
+        ctx.upstream_url,
         &upstream_path,
     )
     .await
@@ -2154,7 +2162,7 @@ async fn fetch_upstream_tags_page(
     })?;
 
     let parsed = serde_json::from_slice::<serde_json::Value>(&content).map_err(|e| {
-        warn!("Invalid upstream tags/list response for {}: {}", image, e);
+        warn!("Invalid upstream tags/list response for {}: {}", ctx.image, e);
         oci_error(
             StatusCode::BAD_GATEWAY,
             "UNKNOWN",
@@ -2164,7 +2172,7 @@ async fn fetch_upstream_tags_page(
     let tags = parsed["tags"].as_array().ok_or_else(|| {
         warn!(
             "Upstream tags/list response for {} is missing a tags array",
-            image
+            ctx.image
         );
         oci_error(
             StatusCode::BAD_GATEWAY,
@@ -2183,11 +2191,7 @@ async fn fetch_upstream_tags_page(
 }
 
 async fn collect_upstream_tags(
-    state: &SharedState,
-    repo_id: Uuid,
-    repo_key: &str,
-    upstream_url: &str,
-    image: &str,
+    ctx: &TagsFetchCtx<'_>,
     max_tags: usize,
     last: Option<&str>,
 ) -> Result<(Vec<String>, bool), Response> {
@@ -2205,22 +2209,13 @@ async fn collect_upstream_tags(
             return Ok((collected, false));
         }
 
-        let page = fetch_upstream_tags_page(
-            state,
-            repo_id,
-            repo_key,
-            upstream_url,
-            image,
-            remaining,
-            cursor.as_deref(),
-        )
-        .await?;
+        let page = fetch_upstream_tags_page(ctx, remaining, cursor.as_deref()).await?;
         pages_fetched += 1;
 
         if pages_fetched > 1024 {
             warn!(
                 "Stopping upstream tags pagination for {} after {} pages to avoid a loop",
-                image, pages_fetched
+                ctx.image, pages_fetched
             );
             return Ok((collected, true));
         }
@@ -2239,7 +2234,7 @@ async fn collect_upstream_tags(
                 if collected.len() == before_len || cursor.as_deref() == Some(next_last.as_str()) {
                     warn!(
                         "Upstream tags pagination for {} returned a non-advancing cursor, stopping early",
-                        image
+                        ctx.image
                     );
                     return Ok((collected, true));
                 }
@@ -2268,8 +2263,14 @@ async fn tags_list_remote(
         )
     })?;
     let image = normalize_docker_image(&repo.image, upstream_url);
-    let (tags, upstream_has_more) =
-        collect_upstream_tags(state, repo.id, &repo.key, upstream_url, &image, n + 1, last).await?;
+    let ctx = TagsFetchCtx {
+        state,
+        repo_id: repo.id,
+        repo_key: &repo.key,
+        upstream_url,
+        image: &image,
+    };
+    let (tags, upstream_has_more) = collect_upstream_tags(&ctx, n + 1, last).await?;
     Ok(split_remote_tags_page(tags, n, upstream_has_more))
 }
 
@@ -2339,23 +2340,22 @@ async fn fetch_tags_from_remote_member(
 ) -> Option<Vec<String>> {
     let upstream_url = upstream_url?;
     let image = normalize_docker_image(image_name, upstream_url);
-    let (tags, upstream_has_more) = collect_upstream_tags(
+    let ctx = TagsFetchCtx {
         state,
-        member_id,
-        member_key,
+        repo_id: member_id,
+        repo_key: member_key,
         upstream_url,
-        &image,
-        n_limit,
-        last,
-    )
-    .await
-    .map_err(|_| {
-        tracing::debug!(
-            "Virtual member '{}': upstream tags/list failed, skipping",
-            member_key
-        );
-    })
-    .ok()?;
+        image: &image,
+    };
+    let (tags, upstream_has_more) = collect_upstream_tags(&ctx, n_limit, last)
+        .await
+        .map_err(|_| {
+            tracing::debug!(
+                "Virtual member '{}': upstream tags/list failed, skipping",
+                member_key
+            );
+        })
+        .ok()?;
 
     tracing::debug!(
         "Virtual member '{}': fetched {} tags from upstream (has_more={})",


### PR DESCRIPTION
## Summary

`fetch_upstream_tags_page`, `collect_upstream_tags`, and (internally) `fetch_tags_from_remote_member` repeated the same five-arg cluster (`state`, `repo_id`, `repo_key`, `upstream_url`, `image`) before each helper's per-call parameters. Each helper sat at seven positional args: one below the clippy `too_many_arguments` threshold but pushing on it. Surfaced during #1016 R3 iter 2.

Bundle the five into `TagsFetchCtx<'a>`. The two inner helpers now take `(&TagsFetchCtx, n, last)` and `(&TagsFetchCtx, max_tags, last)` (3 args each). `fetch_tags_from_remote_member` builds the ctx and forwards. `tags_list_remote` builds the ctx once and calls `collect_upstream_tags` directly.

No behavior change. The change is local to oci_v2.rs (no new crates, no SQL, no public API).

Refs: artifact-keeper#1016 R3 iter 2.

## Test Checklist
- [x] Unit tests added/updated (no behavior change at unit-test level; 170 existing oci_v2 tests pass)
- [ ] Integration tests added/updated (covered by existing OCI tags-list integration tests)
- [ ] E2E tests added/updated (covered by existing native-tests OCI suites)
- [x] Manually tested locally (`cargo check`, `cargo clippy`, `cargo test --lib api::handlers::oci_v2`)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes