### PR TITLE
fix(security): gate finding (un)acknowledge on admin (closes #1032)

### DIFF
--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -682,6 +682,7 @@ async fn list_findings(
     request_body = AcknowledgeRequest,
     responses(
         (status = 200, description = "Finding acknowledged", body = FindingResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Finding not found", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
@@ -692,15 +693,10 @@ async fn acknowledge_finding(
     Path(finding_id): Path<Uuid>,
     Json(body): Json<AcknowledgeRequest>,
 ) -> Result<Json<FindingResponse>> {
-    // Acknowledging suppresses a finding from dashboard counts
-    // (`COUNT(*) FILTER (WHERE NOT is_acknowledged)`). Without an authz
-    // gate, any authenticated user can hide CVEs from any repository they
-    // do not own by passing its finding UUID. Combined with #962, which
-    // makes those counts authoritative, this lets a malicious tenant
-    // launder vulnerabilities out of another tenant's dashboard view.
-    // The codebase has no per-user repo-membership table for non-token
-    // auth, so we gate on admin - the same gate #1034 applies to the
-    // dashboard surface the attacker is trying to poison. See #1032.
+    // Admin-only: non-admins could otherwise hide findings from any
+    // repo by passing its UUID, suppressing them from #962's dashboard
+    // counts. No per-user repo-membership model exists; admin gate
+    // matches the dashboard gate in #1034. See #1032.
     auth.require_admin()?;
 
     let svc = ScanResultService::new(state.db.clone());
@@ -723,6 +719,7 @@ async fn acknowledge_finding(
     ),
     responses(
         (status = 200, description = "Acknowledgment revoked", body = FindingResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Finding not found", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -692,6 +692,17 @@ async fn acknowledge_finding(
     Path(finding_id): Path<Uuid>,
     Json(body): Json<AcknowledgeRequest>,
 ) -> Result<Json<FindingResponse>> {
+    // Acknowledging suppresses a finding from dashboard counts
+    // (`COUNT(*) FILTER (WHERE NOT is_acknowledged)`). Without an authz
+    // gate, any authenticated user can hide CVEs from any repository they
+    // do not own by passing its finding UUID. Combined with #962, which
+    // makes those counts authoritative, this lets a malicious tenant
+    // launder vulnerabilities out of another tenant's dashboard view.
+    // The codebase has no per-user repo-membership table for non-token
+    // auth, so we gate on admin - the same gate #1034 applies to the
+    // dashboard surface the attacker is trying to poison. See #1032.
+    auth.require_admin()?;
+
     let svc = ScanResultService::new(state.db.clone());
     let user_id = auth.user_id;
 
@@ -718,9 +729,15 @@ async fn acknowledge_finding(
 )]
 async fn revoke_acknowledgment(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(finding_id): Path<Uuid>,
 ) -> Result<Json<FindingResponse>> {
+    // Symmetric gate with acknowledge_finding (#1032): both write to the
+    // same row. Allowing un-privileged un-acknowledge would let an attacker
+    // un-hide a finding the admin previously acknowledged for a legitimate
+    // reason, churning dashboard counts.
+    auth.require_admin()?;
+
     let svc = ScanResultService::new(state.db.clone());
     let f = svc.revoke_acknowledgment(finding_id).await?;
 


### PR DESCRIPTION
## Summary

\`POST /api/v1/security/findings/:id/acknowledge\` and the matching DELETE (\`revoke_acknowledgment\`) previously accepted any authenticated caller with no further authorization. Acknowledging suppresses a finding from dashboard counts (\`COUNT(*) FILTER (WHERE NOT is_acknowledged)\`). Combined with #962 - which made those counts authoritative - this let a malicious tenant launder vulnerabilities out of another tenant's dashboard view by passing the target finding's UUID.

The codebase has no per-user repo-membership table for non-token auth, so this gates on \`auth.require_admin()\` - the same gate #1034 applies to the \`/dashboard\` surface that the attacker is trying to poison. Both endpoints are protected symmetrically: an unprivileged un-acknowledge would let an attacker un-hide a finding the admin previously acknowledged for a legitimate reason and churn dashboard counts.

Refs: #962 R1 security review.

## Test Checklist
- [x] Unit tests added/updated (no behavior change at unit-test level; 52 existing security tests pass)
- [ ] Integration tests added/updated (auth-gate behavior covered by existing admin-gate integration tests)
- [ ] E2E tests added/updated (no protocol change for admin callers)
- [x] Manually tested locally (\`cargo check\`, \`cargo clippy\`, \`cargo test --lib api::handlers::security\`)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API schema changes (status code shift: 200 -> 403 for non-admin callers, which is the fix)