### PR TITLE
chore(dependabot): pin RustCrypto digest cohort until ecosystem aligns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,21 @@ updates:
       - "cargo"
     commit-message:
       prefix: "chore"
+    # The RustCrypto digest 0.10 -> 0.11 ecosystem migration is mid-flight.
+    # Bumping any one of sha2 / hmac / md-5 / sha1 in isolation is not
+    # mergeable: the new versions require digest 0.11, which is not
+    # type-compatible with the digest 0.10 traits the rest of the workspace
+    # (and transitives like rsa, blake2, sqlx, object_store) still use.
+    # See artifact-keeper#844 / #848 for the closed dependabot PRs and the
+    # tracking analysis. Reassess once rsa publishes a sha2 0.11 release
+    # and blake2 reaches 0.11 stable; at that point a single coordinated
+    # bump PR can land sha2 + hmac + md-5 + sha1 together.
+    ignore:
+      - dependency-name: "sha2"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "hmac"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "md-5"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "sha1"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
## Summary

Adds an `ignore` block to the cargo updater in `.github/dependabot.yml` so dependabot stops reopening unmergeable PRs for the four RustCrypto crates that are mid-migration to digest 0.11:

- `sha2`
- `hmac`
- `md-5`
- `sha1`

Each released a new minor (sha2/md-5/sha1 0.11, hmac 0.13) that requires `digest 0.11`. The workspace and several transitive crypto deps (`rsa 0.9`, `blake2 0.10`) still build against `digest 0.10`. So a single-crate bump fails to compile because `hmac::Mac` and the new `Sha256`/`Sha1` hashers cannot satisfy the digest-0.10 trait bounds the rest of the codebase uses (`signing_service.rs`, `conda.rs` blake2 callsites, etc.).

Patch bumps for these crates still flow normally — only minor/major are pinned.

Replaces the recurring churn of #844 (hmac) and #848 (md-5), which I'm closing alongside this PR. When `rsa` publishes sha2 0.11 support and `blake2` reaches 0.11 stable, drop these ignores and land one coordinated bump PR that moves sha2 + hmac + md-5 + sha1 together (and the ~60 callsite edits that come with digest 0.11's `Array<u8, _>` `finalize()` return type — `format!("{:x}", finalize())` no longer satisfies `LowerHex`, has to become `hex::encode(finalize())`).

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (parsed YAML, confirmed schema)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes