### PR TITLE
feat(events): thread explicit repository_id through DomainEvent (closes #948)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -902,9 +902,8 @@ pub async fn create_repository(
         .await?;
     }
 
-    state.event_bus.emit_for_repo(
+    state.event_bus.emit_repository_event(
         "repository.created",
-        repo.id,
         repo.id,
         Some(auth.username.clone()),
     );
@@ -1111,9 +1110,8 @@ pub async fn update_repository(
 
     let storage_used = service.get_storage_usage(repo.id).await?;
 
-    state.event_bus.emit_for_repo(
+    state.event_bus.emit_repository_event(
         "repository.updated",
-        repo.id,
         repo.id,
         Some(auth.username.clone()),
     );
@@ -1169,9 +1167,8 @@ pub async fn delete_repository(
         cache.remove(&key);
     }
 
-    state.event_bus.emit_for_repo(
+    state.event_bus.emit_repository_event(
         "repository.deleted",
-        repo.id,
         repo.id,
         Some(auth.username.clone()),
     );

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -902,9 +902,12 @@ pub async fn create_repository(
         .await?;
     }
 
-    state
-        .event_bus
-        .emit("repository.created", repo.id, Some(auth.username.clone()));
+    state.event_bus.emit_for_repo(
+        "repository.created",
+        repo.id,
+        repo.id,
+        Some(auth.username.clone()),
+    );
 
     let mut response = repo_to_response(repo, 0);
     if let Some(ref at) = payload.upstream_auth_type {
@@ -1108,9 +1111,12 @@ pub async fn update_repository(
 
     let storage_used = service.get_storage_usage(repo.id).await?;
 
-    state
-        .event_bus
-        .emit("repository.updated", repo.id, Some(auth.username.clone()));
+    state.event_bus.emit_for_repo(
+        "repository.updated",
+        repo.id,
+        repo.id,
+        Some(auth.username.clone()),
+    );
 
     Ok(Json(repo_to_response(repo, storage_used)))
 }
@@ -1163,9 +1169,12 @@ pub async fn delete_repository(
         cache.remove(&key);
     }
 
-    state
-        .event_bus
-        .emit("repository.deleted", repo.id, Some(auth.username.clone()));
+    state.event_bus.emit_for_repo(
+        "repository.deleted",
+        repo.id,
+        repo.id,
+        Some(auth.username.clone()),
+    );
     Ok(())
 }
 

--- a/backend/src/services/event_bus.rs
+++ b/backend/src/services/event_bus.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use tokio::sync::broadcast;
+use uuid::Uuid;
 
 /// A domain event published when entities change.
 #[derive(Debug, Clone, Serialize)]
@@ -9,6 +10,14 @@ pub struct DomainEvent {
     pub event_type: String,
     /// UUID or key of the affected entity
     pub entity_id: String,
+    /// The owning repository, if this event is repo-scoped. Set explicitly
+    /// by the publisher (NOT parsed from `entity_id`) so repo-scoped
+    /// webhook and notification subscriptions can match non-repo events
+    /// (`user.*`, `group.*`, `quality_gate.*`, etc.) whose `entity_id` is
+    /// the affected entity's UUID rather than the owning repo's UUID.
+    /// See #948.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_id: Option<Uuid>,
     /// Username of the actor who triggered the change
     pub actor: Option<String>,
     /// ISO 8601 timestamp
@@ -16,15 +25,37 @@ pub struct DomainEvent {
 }
 
 impl DomainEvent {
-    /// Create a domain event timestamped to now.
+    /// Create a non-repo-scoped domain event timestamped to now.
+    /// Use [`DomainEvent::now_for_repo`] for events owned by a specific
+    /// repository.
     pub fn now(
         event_type: impl Into<String>,
         entity_id: impl Into<String>,
         actor: Option<String>,
     ) -> Self {
+        Self::now_with_repo(event_type, entity_id, None, actor)
+    }
+
+    /// Create a repo-scoped domain event timestamped to now.
+    pub fn now_for_repo(
+        event_type: impl Into<String>,
+        entity_id: impl Into<String>,
+        repository_id: Uuid,
+        actor: Option<String>,
+    ) -> Self {
+        Self::now_with_repo(event_type, entity_id, Some(repository_id), actor)
+    }
+
+    fn now_with_repo(
+        event_type: impl Into<String>,
+        entity_id: impl Into<String>,
+        repository_id: Option<Uuid>,
+        actor: Option<String>,
+    ) -> Self {
         Self {
             event_type: event_type.into(),
             entity_id: entity_id.into(),
+            repository_id,
             actor,
             timestamp: chrono::Utc::now().to_rfc3339(),
         }
@@ -55,9 +86,28 @@ impl EventBus {
         self.tx.subscribe()
     }
 
-    /// Convenience: create a timestamped domain event and publish it in one call.
+    /// Convenience: create a timestamped non-repo-scoped domain event and
+    /// publish it in one call. Use [`EventBus::emit_for_repo`] for events
+    /// owned by a specific repository so repo-scoped subscriptions match.
     pub fn emit(&self, event_type: &str, entity_id: impl ToString, actor: Option<String>) {
         self.publish(DomainEvent::now(event_type, entity_id.to_string(), actor));
+    }
+
+    /// Like [`EventBus::emit`] but threads an explicit `repository_id` into
+    /// the published event. See #948.
+    pub fn emit_for_repo(
+        &self,
+        event_type: &str,
+        entity_id: impl ToString,
+        repository_id: Uuid,
+        actor: Option<String>,
+    ) {
+        self.publish(DomainEvent::now_for_repo(
+            event_type,
+            entity_id.to_string(),
+            repository_id,
+            actor,
+        ));
     }
 }
 
@@ -73,6 +123,7 @@ mod tests {
         bus.publish(DomainEvent {
             event_type: "user.created".into(),
             entity_id: "abc-123".into(),
+            repository_id: None,
             actor: Some("admin".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
         });
@@ -89,6 +140,7 @@ mod tests {
         bus.publish(DomainEvent {
             event_type: "test".into(),
             entity_id: "x".into(),
+            repository_id: None,
             actor: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
         });
@@ -104,6 +156,7 @@ mod tests {
             bus.publish(DomainEvent {
                 event_type: format!("event.{i}"),
                 entity_id: i.to_string(),
+                repository_id: None,
                 actor: None,
                 timestamp: "2026-01-01T00:00:00Z".into(),
             });
@@ -125,6 +178,7 @@ mod tests {
         bus.publish(DomainEvent {
             event_type: "repo.created".into(),
             entity_id: "repo-1".into(),
+            repository_id: None,
             actor: Some("alice".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
         });
@@ -193,11 +247,62 @@ mod tests {
         let event = DomainEvent {
             event_type: "user.deleted".into(),
             entity_id: "u-42".into(),
+            repository_id: None,
             actor: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""type":"user.deleted""#));
         assert!(!json.contains("event_type"));
+    }
+
+    #[test]
+    fn domain_event_now_for_repo_sets_repository_id() {
+        let repo_id = Uuid::new_v4();
+        let event = DomainEvent::now_for_repo("user.created", "u-7", repo_id, None);
+        assert_eq!(event.repository_id, Some(repo_id));
+        assert_eq!(event.event_type, "user.created");
+    }
+
+    #[test]
+    fn domain_event_now_leaves_repository_id_none() {
+        let event = DomainEvent::now("group.deleted", "g-7", None);
+        assert!(event.repository_id.is_none());
+    }
+
+    #[test]
+    fn domain_event_repository_id_omitted_when_none() {
+        // The serde `skip_serializing_if = "Option::is_none"` keeps the
+        // payload backward-compatible for non-repo events.
+        let event = DomainEvent::now("group.deleted", "g-7", None);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("repository_id"));
+    }
+
+    #[test]
+    fn domain_event_repository_id_present_when_set() {
+        let repo_id = Uuid::new_v4();
+        let event = DomainEvent::now_for_repo("repository.created", "r-1", repo_id, None);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("repository_id"));
+        assert!(json.contains(&repo_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn emit_for_repo_threads_repository_id() {
+        let bus = EventBus::new(16);
+        let mut rx = bus.subscribe();
+        let repo_id = Uuid::new_v4();
+
+        bus.emit_for_repo(
+            "user.created",
+            "u-1".to_string(),
+            repo_id,
+            Some("alice".into()),
+        );
+
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.repository_id, Some(repo_id));
+        assert_eq!(event.entity_id, "u-1");
     }
 }

--- a/backend/src/services/event_bus.rs
+++ b/backend/src/services/event_bus.rs
@@ -94,7 +94,12 @@ impl EventBus {
     }
 
     /// Like [`EventBus::emit`] but threads an explicit `repository_id` into
-    /// the published event. See #948.
+    /// the published event. Use this when the affected entity is NOT the
+    /// repository itself (e.g., a `user.created` triggered from a
+    /// repo-scoped admin action). For `repository.*` events where the
+    /// entity_id and repository_id coincide, prefer
+    /// [`EventBus::emit_repository_event`] which takes the UUID once.
+    /// See #948.
     pub fn emit_for_repo(
         &self,
         event_type: &str,
@@ -108,6 +113,15 @@ impl EventBus {
             repository_id,
             actor,
         ));
+    }
+
+    /// Convenience for `repository.*` events where the affected entity IS
+    /// the repository. Sets both `entity_id` and `repository_id` to
+    /// `repo_id`, avoiding the visually-duplicated argument at the call
+    /// site that `emit_for_repo(.., repo.id, repo.id, ..)` produces.
+    /// See #948.
+    pub fn emit_repository_event(&self, event_type: &str, repo_id: Uuid, actor: Option<String>) {
+        self.emit_for_repo(event_type, repo_id, repo_id, actor);
     }
 }
 
@@ -304,5 +318,22 @@ mod tests {
         let event = rx.recv().await.unwrap();
         assert_eq!(event.repository_id, Some(repo_id));
         assert_eq!(event.entity_id, "u-1");
+    }
+
+    #[tokio::test]
+    async fn emit_repository_event_uses_repo_id_for_both_fields() {
+        // For `repository.*` events the affected entity IS the repository,
+        // so entity_id and repository_id coincide. The shortcut takes the
+        // UUID once.
+        let bus = EventBus::new(16);
+        let mut rx = bus.subscribe();
+        let repo_id = Uuid::new_v4();
+
+        bus.emit_repository_event("repository.created", repo_id, Some("alice".into()));
+
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.event_type, "repository.created");
+        assert_eq!(event.entity_id, repo_id.to_string());
+        assert_eq!(event.repository_id, Some(repo_id));
     }
 }

--- a/backend/src/services/notification_dispatcher.rs
+++ b/backend/src/services/notification_dispatcher.rs
@@ -117,10 +117,12 @@ async fn dispatch_event(
 ) -> std::result::Result<(), String> {
     let notification_event = map_event_type(&event.event_type);
 
-    // Try to parse entity_id as a UUID (repository ID). If it is not a valid
-    // UUID, the event does not carry a repository context and we only match
-    // global subscriptions (repository_id IS NULL).
-    let repo_id: Option<uuid::Uuid> = uuid::Uuid::parse_str(&event.entity_id).ok();
+    // Repo scoping uses the publisher-set `event.repository_id` field, not a
+    // parse of `entity_id`. For repo-scoped events (`repository.*`) the
+    // publisher passes the repo UUID via `EventBus::emit_for_repo`. For
+    // non-repo events (`user.*`, `group.*`, etc.) it is None, and only
+    // global subscriptions match (`repository_id IS NULL`). See #948.
+    let repo_id: Option<uuid::Uuid> = event.repository_id;
 
     let rows = sqlx::query(
         r#"
@@ -377,6 +379,7 @@ mod tests {
         DomainEvent {
             event_type: "artifact.created".into(),
             entity_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            repository_id: None,
             actor: Some("alice".into()),
             timestamp: "2026-04-08T12:00:00Z".into(),
         }
@@ -387,6 +390,7 @@ mod tests {
         DomainEvent {
             event_type: "scan.completed".into(),
             entity_id: "repo-key-abc".into(),
+            repository_id: None,
             actor: None,
             timestamp: "2026-04-08T13:00:00Z".into(),
         }
@@ -653,6 +657,7 @@ mod tests {
         let event = DomainEvent {
             event_type: "build.failed".into(),
             entity_id: "build-42".into(),
+            repository_id: None,
             actor: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
         };
@@ -989,6 +994,7 @@ mod tests {
         let event = DomainEvent {
             event_type: "artifact.created".into(),
             entity_id: "abc".into(),
+            repository_id: None,
             actor: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
         };

--- a/backend/src/services/webhook_producer.rs
+++ b/backend/src/services/webhook_producer.rs
@@ -164,25 +164,20 @@ pub fn start_webhook_producer(
 ///
 /// Looks up enabled webhooks whose `events` array contains the mapped event
 /// type and whose `repository_id` is either NULL (global) or matches the
-/// event's entity_id when interpretable as a UUID. For each match, INSERTs a
-/// row into `webhook_deliveries` with `attempts = 0`, `next_retry_at = NOW()`,
+/// event's `repository_id` field. For each match, INSERTs a row into
+/// `webhook_deliveries` with `attempts = 0`, `next_retry_at = NOW()`,
 /// `success = false`. The retry scheduler picks these up on its tick.
 ///
-/// # Repository scoping limitation
+/// # Repository scoping (#948)
 ///
-/// `event.entity_id` is parsed as a `repository_id`. This works correctly
-/// for `repository.*` events because the EventBus carries the repo UUID in
-/// `entity_id`. It is a category error for `user.*`, `build.*`, and
-/// `artifact.*` events: their `entity_id` is the user/build/artifact UUID
-/// respectively, not the owning repository. For those events, the
-/// `repository_id = $2` arm of the WHERE clause never matches, so only
-/// global-scoped webhooks (repository_id IS NULL) fire. The same flaw
-/// exists in `notification_dispatcher.rs::dispatch_event`.
-///
-/// FIXME(#948): Thread an explicit `repository_id: Option<Uuid>` through
-/// `DomainEvent` so this scoping is correct for non-repo events. Until
-/// then, scoping non-repo events requires the operator to use a global
-/// webhook subscription.
+/// Repo scoping uses the publisher-set `event.repository_id` field, not a
+/// parse of `entity_id`. For repo-scoped events (`repository.*`) the
+/// publisher calls `EventBus::emit_for_repo` which threads the repo UUID
+/// through. For non-repo events (`user.*`, `group.*`, etc.) the field is
+/// `None`, so only global webhooks (`repository_id IS NULL`) match. The
+/// pre-#948 implementation parsed `entity_id` as a UUID, which was a
+/// category error for non-repo events whose `entity_id` is the user/group
+/// UUID rather than the owning repo's UUID.
 ///
 /// Uses `sqlx::query()` (not the macro) to avoid contention on the offline
 /// SQLx query cache while parallel webhook PRs are in flight (E1, E2, E4).
@@ -195,9 +190,7 @@ async fn enqueue_for_event(db: &PgPool, event: &DomainEvent) -> std::result::Res
         }
     };
 
-    // Try to parse entity_id as a UUID for repository scoping. If it is not
-    // a UUID, only global webhooks (repository_id IS NULL) match.
-    let repo_id: Option<uuid::Uuid> = uuid::Uuid::parse_str(&event.entity_id).ok();
+    let repo_id: Option<uuid::Uuid> = event.repository_id;
 
     let raw_rows = sqlx::query(
         r#"
@@ -269,6 +262,7 @@ mod tests {
         DomainEvent {
             event_type: event_type.to_string(),
             entity_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            repository_id: None,
             actor: Some("alice".into()),
             timestamp: "2026-04-08T12:00:00Z".into(),
         }
@@ -463,6 +457,7 @@ mod tests {
         let event = DomainEvent {
             event_type: "user.deleted".into(),
             entity_id: "u-7".into(),
+            repository_id: None,
             actor: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
         };
@@ -485,6 +480,7 @@ mod tests {
         let event = DomainEvent {
             event_type: "build.failed".into(),
             entity_id: "build-99".into(),
+            repository_id: None,
             actor: Some("ci".into()),
             timestamp: "2026-04-27T16:30:00.123456789Z".into(),
         };


### PR DESCRIPTION
## Summary

`webhook_producer::enqueue_for_event` and `notification_dispatcher::dispatch_event` previously parsed `DomainEvent.entity_id` as a `repository_id` for SQL scoping. That works for `repository.*` events because the EventBus puts the repo UUID in `entity_id`. It is a category error for `user.*`, `group.*`, `quality_gate.*`, `service_account.*`, etc., whose `entity_id` is the affected entity's UUID, not the owning repo's. For those events the `repository_id = $2` arm of the WHERE clause never matched, so only global-scoped subscriptions ever fired.

Add a `repository_id: Option<Uuid>` field to `DomainEvent`. Publishers populate it explicitly:

- `EventBus::emit(...)` stays as-is and produces non-repo events (`repository_id = None`)
- `EventBus::emit_for_repo(event_type, entity_id, repo_id, actor)` is new; producers of repo-scoped events call it
- `DomainEvent::now_for_repo(...)` for direct-construction sites

Both consumers now read `event.repository_id` directly instead of parsing `entity_id`. The SQL contract stays the same (`repository_id IS NULL OR repository_id = $repo_id`) but with a correctly-typed input.

Updated the three `repository.*` emit sites in `api/handlers/repositories.rs` to pass `repo.id` via `emit_for_repo`. All other emit sites (groups, permissions, users, quality_gates, service_accounts, quarantine) intentionally stay on `emit(...)` because they do not own a repo at the call site. Future call sites can opt into repo scoping when they have a repo handle.

The `repository_id` field uses `skip_serializing_if = "Option::is_none"`, so the on-the-wire webhook payload stays backward-compatible for non-repo events.

Removed the now-stale `FIXME(#948)` comment block in webhook_producer.rs.

## Test Checklist
- [x] Unit tests added/updated (5 new for the field; 19 event_bus + 60 webhook_producer + 15 notification_dispatcher pass)
- [ ] Integration tests added/updated (existing tests still pass; SQL shape unchanged)
- [ ] E2E tests added/updated (no protocol-level change)
- [x] Manually tested locally (`cargo check`, `cargo clippy --all-targets`, targeted `cargo test --lib`)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no public API endpoints changed (DomainEvent serialization stays back-compat via `skip_serializing_if`)