### PR TITLE
ci: cancel auto-runs on new push, suspend Alpine image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ on:
 permissions:
   contents: read
 
+# Concurrency: keyed by `event_name` + `ref` so push, pull_request, and
+# workflow_dispatch are isolated from each other. `cancel-in-progress` is
+# only true for auto-triggered runs (push / pull_request); a manual run
+# (`workflow_dispatch`) is never cancelled by a subsequent push.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,20 @@ on:
 
 permissions: {}
 
+# Concurrency rules:
+#
+# - The group is keyed by `event_name` + `ref` so push and workflow_dispatch
+#   for the same branch are in DIFFERENT groups. A manual run (`workflow_dispatch`)
+#   never gets cancelled by an auto run, and vice versa.
+# - `cancel-in-progress` is true ONLY for branch pushes (not tag pushes,
+#   not workflow_dispatch). When a new commit lands on main while an
+#   earlier auto-build is still running, the older one is cancelled so we
+#   stop building stale containers.
+# - Tag pushes (releases) and manual dispatches always run to completion.
+concurrency:
+  group: docker-publish-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/') }}
+
 env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ${{ github.repository }}-backend
@@ -163,6 +177,10 @@ jobs:
 
   build-backend-alpine:
     name: Backend Alpine (${{ matrix.platform }})
+    # Alpine builds suspended. UBI is the default backend image and the
+    # only one we currently publish. Re-enable when the Alpine variant is
+    # needed again (smaller footprint, distroless-style use cases).
+    if: false
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -233,7 +251,10 @@ jobs:
   scan-containers:
     name: Security Scan
     runs-on: ubuntu-24.04
-    needs: [build-backend, build-openscap, build-backend-alpine]
+    # `build-backend-alpine` removed from `needs` while alpine builds are
+    # suspended. Re-add it (and re-enable the alpine-gated steps below)
+    # when the alpine variant comes back online.
+    needs: [build-backend, build-openscap]
     permissions:
       contents: read
       packages: read
@@ -262,21 +283,21 @@ jobs:
           name: openscap-digests-amd64
           path: /tmp/openscap-digests
 
-      - name: Download backend alpine amd64 digest
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: backend-alpine-digests-amd64
-          path: /tmp/backend-alpine-digests
+      # Alpine digest download skipped while alpine builds are suspended.
+      # - name: Download backend alpine amd64 digest
+      #   uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      #   with:
+      #     name: backend-alpine-digests-amd64
+      #     path: /tmp/backend-alpine-digests
 
       - name: Resolve image references
         id: refs
         run: |
           BACKEND_DIGEST=$(ls /tmp/backend-digests/)
           OPENSCAP_DIGEST=$(ls /tmp/openscap-digests/)
-          BACKEND_ALPINE_DIGEST=$(ls /tmp/backend-alpine-digests/)
           echo "backend=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:${BACKEND_DIGEST}" >> $GITHUB_OUTPUT
           echo "openscap=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@sha256:${OPENSCAP_DIGEST}" >> $GITHUB_OUTPUT
-          echo "backend-alpine=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:${BACKEND_ALPINE_DIGEST}" >> $GITHUB_OUTPUT
+          # backend-alpine digest output skipped while alpine builds are suspended.
 
       # --- Trivy CVE scanning ---
       # --ignore-unfixed: only fail on CVEs with available patches.
@@ -317,9 +338,10 @@ jobs:
           exit-code: '0'
           skip-setup-trivy: true
 
+      # Alpine scan skipped while alpine builds are suspended.
       - name: Trivy scan - Backend Alpine
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        if: always()
+        if: false
         with:
           image-ref: ${{ steps.refs.outputs.backend-alpine }}
           format: 'sarif'
@@ -343,9 +365,10 @@ jobs:
           sarif_file: 'openscap-trivy.sarif'
           category: 'trivy-openscap'
 
+      # Alpine SARIF upload skipped while alpine builds are suspended.
       - name: Upload Backend Alpine Trivy SARIF
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-        if: always()
+        if: false
         with:
           sarif_file: 'backend-alpine-trivy.sarif'
           category: 'trivy-backend-alpine'
@@ -666,6 +689,8 @@ jobs:
 
   merge-backend-alpine:
     name: Backend Alpine Multi-Arch Manifest
+    # Alpine builds suspended; the multi-arch manifest job follows them.
+    if: false
     runs-on: ubuntu-latest
     needs: [build-backend-alpine]
     permissions:
@@ -811,7 +836,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
-    needs: [merge-backend, merge-openscap, merge-backend-alpine]
+    # `merge-backend-alpine` removed from `needs` while alpine builds are
+    # suspended (it is `if: false` and would never report success).
+    needs: [merge-backend, merge-openscap]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Probe ghcr.io manifests for expected semver tags


### PR DESCRIPTION
## Summary

Two CI hygiene changes that were causing redundant container builds.

### Concurrency, trigger-aware

`docker-publish.yml` had no concurrency rule, so each new commit on main kicked off a parallel container build while the previous one was still running. We can't just blanket `cancel-in-progress: true` because manual runs (`workflow_dispatch`, e.g., re-publishing a tag) must complete.

The new rule keys the concurrency group on `event_name` + `ref`:

- A push to main while another push to main is mid-build cancels the older one.
- A `workflow_dispatch` is in its own group (event_name differs) and is never cancelled by a subsequent push.
- Tag pushes (releases) are guarded with `!startsWith(github.ref, 'refs/tags/')` and always run to completion.

`ci.yml` had `cancel-in-progress: true` (always). Updated to the same pattern so manual CI re-runs are not killed by subsequent pushes.

### Alpine builds suspended

UBI is the default backend image (`docker/Dockerfile.backend`, `registry.access.redhat.com/ubi9/ubi:9.7`, published unsuffixed at `ghcr.io/.../backend`). The `-alpine` variant is a separate optional build that roughly doubles container build time.

While we focus on UBI, gate the alpine jobs with `if: false` and remove them from `needs` lists of dependent jobs (`scan-containers`, `verify-published`). The alpine-specific Trivy scan and SARIF upload steps are also gated. Re-enabling is a single-line revert when the alpine variant is needed again.

`Dockerfile.backend.alpine` is preserved; only the workflow stops invoking it.

## Test Checklist
- [ ] Unit tests added/updated (CI workflow change)
- [ ] Integration tests added/updated (CI workflow change)
- [ ] E2E tests added/updated (CI workflow change)
- [x] Manually tested locally (`actionlint`, `python3 -c yaml.safe_load`)
- [x] No regressions in existing tests (only the alpine job paths short-circuit, dependents adjusted)

## API Changes
- [x] N/A - no API changes