### PR TITLE
ci(docker): authenticate to Docker Hub before buildx (#1117 follow-up)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Authenticate to Docker Hub before buildx so transitive `FROM`
+      # statements that pull from docker.io (e.g., the alpine:3.23 stage
+      # used to pre-seed the Grype CVE DB inside Dockerfile.backend) are
+      # not subject to the 100-pull/6h anonymous rate limit.
+      - name: Log in to Docker Hub (for transitive base-image pulls)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
@@ -140,6 +150,14 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Authenticate to Docker Hub for transitive base-image pulls; see
+      # the matching step in build-backend for rationale.
+      - name: Log in to Docker Hub (for transitive base-image pulls)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Summary

The Backend (linux/amd64) build on the merged #1117 commit failed with `buildx failed with: toomanyrequests: You have reached your unauthenticated pull rate limit`.

The UBI runtime is unaffected (pulled from `registry.access.redhat.com`), but `docker/Dockerfile.backend` line 134 has:

\`\`\`
FROM alpine:3.23 AS grype-db-seed
\`\`\`

a tiny intermediate stage that pulls from `docker.io` to populate the Grype CVE DB at build time (#1001). Anonymous Docker Hub pulls are capped at 100 per 6h per egress IP, and the parallel runs from our self-hosted runners + dependabot bumps + cancelled stale runs blew through the cap.

`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` already exist in repo secrets (used by the docker.io publish step in `merge-backend` / `merge-openscap`). Add a `docker/login-action` step right after the ghcr.io login in both `build-backend` and `build-openscap`, before the buildx Build step. Authenticated pulls move us well above the trigger point.

### Why is the backend image pulling alpine?

The runtime is **100% UBI** (`ubi9/ubi-micro:9.7`). Alpine appears once as a throwaway intermediate stage to run `grype db update` (which needs network + ca-certs + a writable FS that the bare grype-bin stage doesn't provide). The seeded `/grype-db` is then copied into UBI and alpine is discarded.

Follow-up (separate PR): swap the alpine grype-db-seed stage to `ubi9-micro` so the build is "100% UBI end-to-end" and we no longer rely on docker.io pulls at all.

## Test Checklist
- [ ] Unit tests added/updated (CI workflow only)
- [ ] Integration tests added/updated (CI workflow only)
- [ ] E2E tests added/updated (CI workflow only)
- [x] Manually tested locally (`actionlint`, `python3 -c yaml.safe_load`)
- [x] No regressions in existing tests (additive: one extra login step per build job, no other behavior change)

## API Changes
- [x] N/A - no API changes