### PR TITLE
ci: run #[ignore]'d integration tests in the integration job (closes #1031)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,14 +346,18 @@ jobs:
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
           SQLX_OFFLINE: true
-        # Pass `-- --ignored` so DB-backed integration tests gated by
-        # `#[ignore = "requires running DB / HTTP server"]` actually
-        # execute now that this job provisions postgres. Without this,
-        # 12+ integration test files (lifecycle_policy_tests,
-        # refresh_token_rotation_tests, meili_reindex_tests,
-        # api_token_cache_flush_tests, grpc_sbom_tests, integration_tests,
-        # etc.) were silently skipped. See #1031.
-        run: cargo test --workspace --test '*' --verbose -- --ignored
+        # Pass `-- --include-ignored` so the integration job runs BOTH
+        # ordinary tests AND tests gated by `#[ignore = "requires
+        # running DB / HTTP server"]`, now that this job provisions
+        # postgres. Without `--include-ignored`, the 12+ integration
+        # test files (lifecycle_policy_tests, refresh_token_rotation_tests,
+        # meili_reindex_tests, api_token_cache_flush_tests, grpc_sbom_tests,
+        # integration_tests, etc.) were silently skipped.
+        #
+        # `-- --ignored` (without `include-`) is a footgun: it would do
+        # the opposite, running ONLY ignored tests and skipping the rest.
+        # See #1031.
+        run: cargo test --workspace --test '*' --verbose -- --include-ignored
 
   # ════════════════════════════════════════════════════════════════════════════
   # SMOKE E2E (Every Push/PR) — self-contained via Docker-in-Docker on ARC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,14 @@ jobs:
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
           SQLX_OFFLINE: true
-        run: cargo test --workspace --test '*' --verbose
+        # Pass `-- --ignored` so DB-backed integration tests gated by
+        # `#[ignore = "requires running DB / HTTP server"]` actually
+        # execute now that this job provisions postgres. Without this,
+        # 12+ integration test files (lifecycle_policy_tests,
+        # refresh_token_rotation_tests, meili_reindex_tests,
+        # api_token_cache_flush_tests, grpc_sbom_tests, integration_tests,
+        # etc.) were silently skipped. See #1031.
+        run: cargo test --workspace --test '*' --verbose -- --ignored
 
   # ════════════════════════════════════════════════════════════════════════════
   # SMOKE E2E (Every Push/PR) — self-contained via Docker-in-Docker on ARC


### PR DESCRIPTION
## Summary

The \`test-backend-integration\` step in \`ci.yml\` provisions postgres and runs \`cargo test --workspace --test '*'\` without \`--ignored\`. The 12+ integration test files in \`backend/tests/\` (lifecycle_policy_tests, refresh_token_rotation_tests, meili_reindex_tests, api_token_cache_flush_tests, grpc_sbom_tests, integration_tests, azure_rbac_live_test, incus_upload_tests, azure_shared_key_live_test, replication_integration, s3_integration, storage_backend_tests) all carry \`#[ignore = "requires running DB / HTTP server"]\` because they cannot run on the unit-test job (no DB). They are exactly what the integration job was provisioned to run, but \`--ignored\` was missing so they were silently skipped.

Pass \`-- --ignored\` so the existing #[ignore] convention stands and the tests actually execute. This expands what CI verifies on every push to main / release/* without changing any test code.

Surfaced during #962 R1 DevOps + #[ignore] fix-up.

## Test Checklist
- [x] CI workflow change validated (`actionlint`, `yaml.safe_load`)
- [ ] Unit tests added/updated (CI-only change)
- [ ] Integration tests added/updated (this PR makes existing ones run)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes