### PR TITLE
fix(scanner): bound stdout capture in capture_cli_version (closes #1014)

### DIFF
--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -6,8 +6,11 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use tokio::io::AsyncReadExt;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -505,11 +508,16 @@ pub(crate) async fn capture_cli_version_with_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> Option<String> {
-    use std::process::Stdio;
-    use tokio::io::AsyncReadExt;
+    // Always kill+reap a child before returning so we never leave a
+    // zombie. `child.kill()` on Unix sends SIGKILL but does not reap;
+    // a subsequent `child.wait()` is required.
+    async fn kill_and_reap(child: &mut tokio::process::Child) {
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+    }
 
     // Spawn with stdout piped so we can bound the read. `Command::output`
-    // would buffer the entire stdout into memory unconditionally - a
+    // would buffer the entire stdout into memory unconditionally; a
     // hostile binary printing 1 GiB to stdout would OOM the backend.
     let mut child = match tokio::process::Command::new(binary)
         .args(args)
@@ -522,39 +530,40 @@ pub(crate) async fn capture_cli_version_with_timeout(
         Err(_) => return None, // spawn / IO error
     };
 
-    // Read at most CAP bytes of stdout; anything beyond is silently
-    // dropped (the child's pipe buffer fills, the child either keeps
-    // writing into a discarded buffer or blocks on SIGPIPE on close -
-    // either way we move on once we have our 64 KiB).
     let stdout = match child.stdout.take() {
         Some(s) => s,
         None => {
-            // Pipe wasn't set up - kill the child to avoid a leaked process
-            // and treat as a probe failure.
-            let _ = child.kill().await;
+            // Pipe wasn't set up; kill+reap and treat as a probe failure.
+            kill_and_reap(&mut child).await;
             return None;
         }
     };
     // `AsyncReadExt::take(N)` consumes the reader by value and returns a
-    // `Take<R>` that yields at most N bytes. This is the bound: any
-    // bytes the binary writes beyond N stay in the kernel pipe and are
-    // dropped when the child is killed / exits, never landing in `buf`.
+    // `Take<R>` that yields at most N bytes. Any bytes the binary writes
+    // beyond N stay in the kernel pipe and are dropped when the child is
+    // killed (or when its stdout pipe is closed on EOF), never landing in
+    // `buf`. This is the OOM bound from #1014.
     let mut limited = stdout.take(CAPTURE_CLI_VERSION_STDOUT_CAP_BYTES);
     let mut buf = Vec::with_capacity(1024);
     let read_result = tokio::time::timeout(timeout, limited.read_to_end(&mut buf)).await;
 
-    // Always reap the child to avoid zombies. Use a short remaining-budget
-    // wait; if it has already exited the wait is immediate.
-    let wait_status = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
-
+    // Handle the read outcome BEFORE waiting on the child. Issuing
+    // `child.wait()` concurrently with the read (the previous shape) was
+    // racy: a wait that lost the race against the read would return Err
+    // even when the child later exited cleanly, falsely producing
+    // `exit_ok = false` and a `None` return. See #1014 R1.
     match read_result {
         Ok(Ok(_)) => {}
-        Ok(Err(_)) => return None,
+        Ok(Err(_)) => {
+            // Read I/O error; kill+reap to be safe.
+            kill_and_reap(&mut child).await;
+            return None;
+        }
         Err(_) => {
-            // Timeout reading stdout: kill the child if it is still alive.
-            if !matches!(wait_status, Ok(Ok(_))) {
-                let _ = child.kill().await;
-            }
+            // Read budget exhausted. Kill+reap (the child is still running
+            // - it filled the pipe but we did not drain it fast enough,
+            // or it is stuck before stdout EOF).
+            kill_and_reap(&mut child).await;
             warn!(
                 binary = binary,
                 timeout_ms = timeout.as_millis() as u64,
@@ -564,9 +573,33 @@ pub(crate) async fn capture_cli_version_with_timeout(
         }
     }
 
-    // Did the binary exit successfully?
+    // Detect cap-hit truncation. read_to_end returning at least
+    // CAP bytes means the binary may have more output we did not read,
+    // and the buffer can be a midway split through a non-version line.
+    // A legitimate `--version` invocation never reaches 64 KiB. Treat
+    // this as a probe failure rather than risk parsing garbage. Issue
+    // a debug log so operators can correlate this with a misbehaving
+    // binary on PATH.
+    if buf.len() as u64 >= CAPTURE_CLI_VERSION_STDOUT_CAP_BYTES {
+        tracing::debug!(
+            binary = binary,
+            cap_bytes = CAPTURE_CLI_VERSION_STDOUT_CAP_BYTES,
+            "scanner --version stdout reached cap; treating probe as failure"
+        );
+        kill_and_reap(&mut child).await;
+        return None;
+    }
+
+    // Read drained successfully; now wait for the child to exit. With
+    // stdout already EOF'd this is essentially instantaneous, but bound
+    // it on a small wall-clock budget to defend against a child that
+    // closes stdout but lingers (e.g., stuck on stderr that we redirected
+    // to /dev/null, or on signal handling).
+    let wait_status = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
     let exit_ok = matches!(wait_status, Ok(Ok(s)) if s.success());
     if !exit_ok {
+        // Child did not exit cleanly; kill+reap before returning.
+        kill_and_reap(&mut child).await;
         return None;
     }
 
@@ -2556,6 +2589,30 @@ mod tests {
         )
         .await;
         assert_eq!(result, None);
+    }
+
+    /// #1014 acceptance test: a binary that emits more than the
+    /// `CAPTURE_CLI_VERSION_STDOUT_CAP_BYTES` cap MUST NOT OOM the
+    /// backend. The implementation bounds the read to 64 KiB via
+    /// `AsyncReadExt::take`, kills the child after the cap is hit, and
+    /// returns `None` (because parsing a midway-truncated buffer would
+    /// risk recording garbage as the scanner_version). The test must
+    /// complete quickly without consuming gigabytes of memory.
+    #[tokio::test]
+    async fn test_capture_cli_version_capped_stdout_returns_none() {
+        if !std::path::Path::new("/bin/sh").exists() {
+            eprintln!("skipping: /bin/sh not present on this host");
+            return;
+        }
+        // `yes` emits "y\n" forever (POSIX). Piping it to `head -c
+        // <large>` would still eventually hit the disk - we want to
+        // hit the in-memory cap. Using `dd if=/dev/zero bs=1024
+        // count=128` gives us 128 KiB of NULs - well past the 64 KiB
+        // cap and produces in milliseconds.
+        let cmd = "dd if=/dev/zero bs=1024 count=128 2>/dev/null";
+        let result =
+            capture_cli_version_with_timeout("/bin/sh", &["-c", cmd], Duration::from_secs(5)).await;
+        assert_eq!(result, None, "binary blowing past the cap must yield None");
     }
 
     /// `capture_cli_version` (the non-timeout-parameterized wrapper) must

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -487,6 +487,16 @@ pub(crate) async fn capture_cli_version(binary: &str, args: &[&str]) -> Option<S
     capture_cli_version_with_timeout(binary, args, CAPTURE_CLI_VERSION_TIMEOUT).await
 }
 
+/// Maximum bytes of stdout we read from a `--version` invocation.
+///
+/// Legitimate `--version` output is well under 1 KiB across every scanner
+/// we shell out to (Trivy, Grype, OpenSCAP, etc.). 64 KiB is a generous
+/// ceiling that protects against a malicious / compromised binary on
+/// PATH emitting unbounded output and OOM'ing the backend (see #1014).
+/// Bytes beyond the cap are dropped; the version token always lives in
+/// the first line, so a sane binary is unaffected.
+const CAPTURE_CLI_VERSION_STDOUT_CAP_BYTES: u64 = 64 * 1024;
+
 /// Inner implementation of [`capture_cli_version`] parameterized on the
 /// timeout so tests can exercise the elapsed-timeout branch in milliseconds
 /// rather than the full production five-second wait.
@@ -495,11 +505,56 @@ pub(crate) async fn capture_cli_version_with_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> Option<String> {
-    let fut = tokio::process::Command::new(binary).args(args).output();
-    let output = match tokio::time::timeout(timeout, fut).await {
-        Ok(Ok(output)) => output,
-        Ok(Err(_)) => return None, // spawn / IO error
+    use std::process::Stdio;
+    use tokio::io::AsyncReadExt;
+
+    // Spawn with stdout piped so we can bound the read. `Command::output`
+    // would buffer the entire stdout into memory unconditionally - a
+    // hostile binary printing 1 GiB to stdout would OOM the backend.
+    let mut child = match tokio::process::Command::new(binary)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return None, // spawn / IO error
+    };
+
+    // Read at most CAP bytes of stdout; anything beyond is silently
+    // dropped (the child's pipe buffer fills, the child either keeps
+    // writing into a discarded buffer or blocks on SIGPIPE on close -
+    // either way we move on once we have our 64 KiB).
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            // Pipe wasn't set up - kill the child to avoid a leaked process
+            // and treat as a probe failure.
+            let _ = child.kill().await;
+            return None;
+        }
+    };
+    // `AsyncReadExt::take(N)` consumes the reader by value and returns a
+    // `Take<R>` that yields at most N bytes. This is the bound: any
+    // bytes the binary writes beyond N stay in the kernel pipe and are
+    // dropped when the child is killed / exits, never landing in `buf`.
+    let mut limited = stdout.take(CAPTURE_CLI_VERSION_STDOUT_CAP_BYTES);
+    let mut buf = Vec::with_capacity(1024);
+    let read_result = tokio::time::timeout(timeout, limited.read_to_end(&mut buf)).await;
+
+    // Always reap the child to avoid zombies. Use a short remaining-budget
+    // wait; if it has already exited the wait is immediate.
+    let wait_status = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
+
+    match read_result {
+        Ok(Ok(_)) => {}
+        Ok(Err(_)) => return None,
         Err(_) => {
+            // Timeout reading stdout: kill the child if it is still alive.
+            if !matches!(wait_status, Ok(Ok(_))) {
+                let _ = child.kill().await;
+            }
             warn!(
                 binary = binary,
                 timeout_ms = timeout.as_millis() as u64,
@@ -507,12 +562,16 @@ pub(crate) async fn capture_cli_version_with_timeout(
             );
             return None;
         }
-    };
-    if !output.status.success() {
+    }
+
+    // Did the binary exit successfully?
+    let exit_ok = matches!(wait_status, Ok(Ok(s)) if s.success());
+    if !exit_ok {
         return None;
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let line = stdout.lines().next()?.trim();
+
+    let stdout_str = String::from_utf8_lossy(&buf);
+    let line = stdout_str.lines().next()?.trim();
     if line.is_empty() {
         None
     } else {


### PR DESCRIPTION
## Summary

`scanner_service::capture_cli_version_with_timeout` previously called `tokio::process::Command::output().await`, which buffers the entire stdout of the spawned binary into memory with no upper bound. A malicious or compromised binary on PATH (substituted \`trivy\`, \`grype\`, \`oscap\`, etc.) could OOM the backend by emitting 1 GiB of output.

Switch to manual \`Stdio::piped()\` + \`AsyncReadExt::take(64 KiB).read_to_end\`. Bytes beyond the cap stay in the kernel pipe and are dropped when the child is killed or exits, never landing in the in-memory buffer. The version token always lives in the first line so a sane binary is unaffected (legitimate `--version` output across Trivy, Grype, OpenSCAP is well under 1 KiB).

### Defenses preserved

- The existing `CAPTURE_CLI_VERSION_TIMEOUT` budget (5s production, short ms in tests) still bounds wall time.
- The child is reaped via `child.wait()` with a 1s budget after the read; if the read times out we kill the child to avoid a leaked process.
- stderr is `Stdio::null()` and stdin is `Stdio::null()` so the binary cannot block on a missing input or fill stderr.

Exploitation requires write access to a PATH directory, which is itself a higher-severity primitive — this is filed as low-severity hardening rather than a security fix.

## Test Checklist
- [x] Unit tests added/updated (existing 306 lib tests pass; the existing `test_capture_cli_version_hung_binary_times_out` exercises the timeout branch)
- [ ] Integration tests added/updated (no behavior change for legitimate binaries)
- [ ] E2E tests added/updated (no protocol-visible change)
- [x] Manually tested locally (`cargo check`, `cargo clippy`, `cargo test --lib services::scanner_service`)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes