### PR TITLE
fix(apt): resolve stale Packages cache on upstream Release change and Virtual repo dists resolution (#1147)

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -397,26 +397,132 @@ impl<'a> DebianProxy<'a> {
         content_type: &'static str,
         repo: &RepoInfo,
     ) -> Result<(), Response> {
-        if repo.repo_type != RepositoryType::Remote {
-            return Ok(());
-        }
-        let (upstream_url, proxy) = match (&repo.upstream_url, &self.state.proxy_service) {
-            (Some(u), Some(p)) => (u, p),
-            _ => return Ok(()),
-        };
-        let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
-        let (content, upstream_ct) =
-            proxy_helpers::proxy_fetch(proxy, repo.id, self.repo_key, upstream_url, &upstream_path)
-                .await?;
-        Err(Response::builder()
-            .status(StatusCode::OK)
-            .header(
-                CONTENT_TYPE,
-                upstream_ct.unwrap_or_else(|| content_type.to_string()),
+        if repo.repo_type == RepositoryType::Remote {
+            let (upstream_url, proxy) = match (&repo.upstream_url, &self.state.proxy_service) {
+                (Some(u), Some(p)) => (u, p),
+                _ => return Ok(()),
+            };
+            let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+            let (content, upstream_ct) = proxy_helpers::proxy_fetch(
+                proxy,
+                repo.id,
+                self.repo_key,
+                upstream_url,
+                &upstream_path,
             )
-            .header(CONTENT_LENGTH, content.len().to_string())
-            .body(Body::from(content))
-            .unwrap())
+            .await?;
+            Err(Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    CONTENT_TYPE,
+                    upstream_ct.unwrap_or_else(|| content_type.to_string()),
+                )
+                .header(CONTENT_LENGTH, content.len().to_string())
+                .body(Body::from(content))
+                .unwrap())
+        } else if repo.repo_type == RepositoryType::Virtual {
+            let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+            let state = self.state;
+            let (content, upstream_ct) = proxy_helpers::resolve_virtual_download(
+                &state.db,
+                state.proxy_service.as_deref(),
+                repo.id,
+                &upstream_path,
+                |member_id, location| {
+                    let db = state.db.clone();
+                    let state = state.clone();
+                    let path = upstream_path.clone();
+                    async move {
+                        proxy_helpers::local_fetch_by_path(&db, &state, member_id, &location, &path)
+                            .await
+                    }
+                },
+            )
+            .await?;
+            Err(Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    CONTENT_TYPE,
+                    upstream_ct.unwrap_or_else(|| content_type.to_string()),
+                )
+                .header(CONTENT_LENGTH, content.len().to_string())
+                .body(Body::from(content))
+                .unwrap())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Like `dists()`, but for Release/InRelease: uses change-detection on
+    /// Remote repos and invalidates Packages caches when content changes.
+    async fn dists_detecting_change(
+        &self,
+        suffix: &str,
+        content_type: &'static str,
+        repo: &RepoInfo,
+    ) -> Result<(), Response> {
+        if repo.repo_type == RepositoryType::Remote {
+            let (upstream_url, proxy) = match (&repo.upstream_url, &self.state.proxy_service) {
+                (Some(u), Some(p)) => (u, p),
+                _ => return Ok(()),
+            };
+            let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+            let (content, upstream_ct, changed) = proxy_helpers::proxy_fetch_detecting_change(
+                proxy,
+                repo.id,
+                self.repo_key,
+                upstream_url,
+                &upstream_path,
+            )
+            .await?;
+            if changed {
+                proxy_helpers::invalidate_dist_packages_cache(
+                    proxy,
+                    self.repo_key,
+                    self.distribution,
+                )
+                .await;
+            }
+            Err(Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    CONTENT_TYPE,
+                    upstream_ct.unwrap_or_else(|| content_type.to_string()),
+                )
+                .header(CONTENT_LENGTH, content.len().to_string())
+                .body(Body::from(content))
+                .unwrap())
+        } else if repo.repo_type == RepositoryType::Virtual {
+            let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+            let state = self.state;
+            let (content, upstream_ct) = proxy_helpers::resolve_virtual_download(
+                &state.db,
+                state.proxy_service.as_deref(),
+                repo.id,
+                &upstream_path,
+                |member_id, location| {
+                    let db = state.db.clone();
+                    let state = state.clone();
+                    let path = upstream_path.clone();
+                    async move {
+                        proxy_helpers::local_fetch_by_path(&db, &state, member_id, &location, &path)
+                            .await
+                    }
+                },
+            )
+            .await?;
+            Err(Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    CONTENT_TYPE,
+                    upstream_ct.unwrap_or_else(|| content_type.to_string()),
+                )
+                .header(CONTENT_LENGTH, content.len().to_string())
+                .body(Body::from(content))
+                .unwrap())
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -438,7 +544,7 @@ async fn release_file(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     proxy
-        .dists("Release", "text/plain; charset=utf-8", &repo)
+        .dists_detecting_change("Release", "text/plain; charset=utf-8", &repo)
         .await?;
 
     let (release, _) = local_release_content(&state, &repo_key, &distribution).await?;
@@ -460,7 +566,7 @@ async fn in_release_file(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     proxy
-        .dists("InRelease", "text/plain; charset=utf-8", &repo)
+        .dists_detecting_change("InRelease", "text/plain; charset=utf-8", &repo)
         .await?;
 
     let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
@@ -752,35 +858,64 @@ async fn dists_dispatch(
 /// Debian mirrors serve under `dists/`.
 ///
 /// For remote repositories the file is fetched from upstream and returned
-/// directly. For hosted repositories the handler returns 404 because these
-/// metadata files are generated on-the-fly only through the dedicated routes.
+/// directly. For virtual repositories the file is resolved from members.
+/// For hosted repositories the handler returns 404 because these metadata
+/// files are generated on-the-fly only through the dedicated routes.
 async fn dists_proxy_catchall(
     State(state): State<SharedState>,
     Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
-    if repo.repo_type != RepositoryType::Remote {
-        return Err((StatusCode::NOT_FOUND, "Not found").into_response());
+    if repo.repo_type == RepositoryType::Remote {
+        let (upstream_url, proxy) = match (&repo.upstream_url, &state.proxy_service) {
+            (Some(u), Some(p)) => (u, p),
+            _ => return Err((StatusCode::NOT_FOUND, "Not found").into_response()),
+        };
+
+        let upstream_path = format!("dists/{}/{}", distribution, dists_path);
+        let (content, upstream_ct) =
+            proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path)
+                .await?;
+
+        let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
+
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, content_type)
+            .header(CONTENT_LENGTH, content.len().to_string())
+            .body(Body::from(content))
+            .unwrap())
+    } else if repo.repo_type == RepositoryType::Virtual {
+        let upstream_path = format!("dists/{}/{}", distribution, dists_path);
+        let (content, upstream_ct) = proxy_helpers::resolve_virtual_download(
+            &state.db,
+            state.proxy_service.as_deref(),
+            repo.id,
+            &upstream_path,
+            |member_id, location| {
+                let db = state.db.clone();
+                let state = state.clone();
+                let path = upstream_path.clone();
+                async move {
+                    proxy_helpers::local_fetch_by_path(&db, &state, member_id, &location, &path)
+                        .await
+                }
+            },
+        )
+        .await?;
+
+        let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
+
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, content_type)
+            .header(CONTENT_LENGTH, content.len().to_string())
+            .body(Body::from(content))
+            .unwrap())
+    } else {
+        Err((StatusCode::NOT_FOUND, "Not found").into_response())
     }
-
-    let (upstream_url, proxy) = match (&repo.upstream_url, &state.proxy_service) {
-        (Some(u), Some(p)) => (u, p),
-        _ => return Err((StatusCode::NOT_FOUND, "Not found").into_response()),
-    };
-
-    let upstream_path = format!("dists/{}/{}", distribution, dists_path);
-    let (content, upstream_ct) =
-        proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path).await?;
-
-    let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, content_type)
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
-        .unwrap())
 }
 
 /// Infer a reasonable content-type from the file extension when the upstream

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -398,6 +398,54 @@ pub async fn proxy_fetch_uncached_with_link(
         .map_err(|e| map_proxy_error(repo_key, path, e))
 }
 
+/// Fetch an artifact with change detection.
+///
+/// Like [`proxy_fetch`] but additionally returns a `bool` indicating
+/// whether the upstream content changed compared to the previously cached
+/// version. This is used by the Debian handler to detect when
+/// Release/InRelease changes so that related Packages caches can be
+/// invalidated to maintain APT hash consistency.
+///
+/// Returns `(content, content_type, content_changed)`.
+pub async fn proxy_fetch_detecting_change(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+) -> Result<(Bytes, Option<String>, bool), Response> {
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
+
+    proxy_service
+        .fetch_artifact_detecting_change(&repo, path)
+        .await
+        .map_err(|e| map_proxy_error(repo_key, path, e))
+}
+
+/// Invalidate all Packages index caches for a Debian distribution.
+///
+/// Called when InRelease/Release content changes to ensure Packages files
+/// are re-fetched from upstream to match the new release metadata.
+/// Failures are logged but do not propagate — cache invalidation is
+/// best-effort.
+pub async fn invalidate_dist_packages_cache(
+    proxy_service: &ProxyService,
+    repo_key: &str,
+    distribution: &str,
+) {
+    if let Err(e) = proxy_service
+        .invalidate_dist_packages_cache(repo_key, distribution)
+        .await
+    {
+        tracing::warn!(
+            "Failed to invalidate Packages cache for {}/dists/{}: {}",
+            repo_key,
+            distribution,
+            e
+        );
+    }
+}
+
 /// Strategy for fetching an artifact from a single virtual member.
 ///
 /// Exposed for unit testing the branching logic in

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -365,6 +365,160 @@ impl ProxyService {
         Ok(())
     }
 
+    /// Invalidate all cached metadata for a Debian distribution,
+    /// **except** the Release/InRelease/Release.gpg files themselves.
+    ///
+    /// When an APT Release/InRelease file changes upstream, every file
+    /// it references (Packages, Contents, dep11 Components, i18n
+    /// Translations, cnf Commands, etc.) is almost certainly different
+    /// too. This method deletes all of them so the next request
+    /// re-fetches from upstream, guaranteeing hash consistency with the
+    /// freshly-cached Release metadata.
+    ///
+    /// Release, InRelease and Release.gpg caches are intentionally
+    /// **kept** so the caller can cache a new Release in the same
+    /// request without it being immediately deleted.
+    pub async fn invalidate_dist_packages_cache(
+        &self,
+        repo_key: &str,
+        distribution: &str,
+    ) -> Result<()> {
+        let prefix = format!(
+            "proxy-cache/{}/dists/{}/",
+            repo_key,
+            distribution.trim_matches('/'),
+        );
+
+        let keys = self.storage.list(Some(&prefix)).await?;
+        let mut deleted = 0usize;
+        for key in &keys {
+            // Determine the path relative to the distribution root.
+            // Top-level release files must be preserved; everything
+            // else (Packages, Contents, dep11, i18n, cnf, source, etc.)
+            // is invalidated.
+            let relative = key
+                .strip_prefix(&prefix)
+                .unwrap_or(key)
+                .trim_start_matches('/');
+            let is_release_file = matches!(
+                relative,
+                "Release" | "InRelease" | "Release.gpg" | "gpg-key.asc"
+            );
+            if !is_release_file {
+                let _ = self.storage.delete(key).await;
+                deleted += 1;
+            }
+        }
+
+        if deleted > 0 {
+            tracing::info!(
+                "Invalidated {} cached metadata entries for {}/dists/{}",
+                deleted,
+                repo_key,
+                distribution,
+            );
+        }
+        Ok(())
+    }
+
+    /// Fetch an artifact like [`fetch_artifact`] but additionally report
+    /// whether the upstream content **changed** compared to the previously
+    /// cached version.
+    ///
+    /// Returns `(content, content_type, content_changed)`.
+    ///
+    /// * `content_changed = false` — cache hit (content served from cache)
+    ///   **or** cache miss but the upstream content has the same SHA-256 as
+    ///   the previous cache entry (upstream unchanged between TTL windows).
+    /// * `content_changed = true` — cache miss **and** the upstream content
+    ///   differs from the previously cached version (or no prior cache
+    ///   existed).
+    ///
+    /// This is used by the Debian handler to detect when Release/InRelease
+    /// content changes so that related Packages caches can be invalidated.
+    pub async fn fetch_artifact_detecting_change(
+        &self,
+        repo: &Repository,
+        path: &str,
+    ) -> Result<(Bytes, Option<String>, bool)> {
+        if repo.repo_type != RepositoryType::Remote {
+            return Err(AppError::Validation(
+                "Proxy operations only supported for remote repositories".to_string(),
+            ));
+        }
+
+        let upstream_url = repo.upstream_url.as_ref().ok_or_else(|| {
+            AppError::Config("Remote repository missing upstream_url".to_string())
+        })?;
+
+        let cache_key = Self::cache_storage_key(&repo.key, path)?;
+        let metadata_key = Self::cache_metadata_key(&repo.key, path)?;
+
+        // Load old metadata (may exist even if expired) to obtain the
+        // previous checksum for change detection.
+        let old_checksum = self
+            .load_cache_metadata(&metadata_key)
+            .await?
+            .map(|m| m.checksum_sha256);
+
+        // If the cache entry is still valid, serve from cache — no change.
+        if let Some((content, content_type)) =
+            self.get_cached_artifact(&cache_key, &metadata_key).await?
+        {
+            return Ok((content, content_type, false));
+        }
+
+        // Cache miss / expired — fetch from upstream.
+        let full_url = Self::build_upstream_url(upstream_url, path);
+        let upstream_result = self.fetch_from_upstream(&full_url, repo.id).await;
+
+        match upstream_result {
+            Ok(resp) => {
+                let new_checksum = StorageService::calculate_hash(&resp.content);
+
+                // Content changed if we had a previous cache with a
+                // different checksum. First-time fetch (no old cache)
+                // is treated as "not changed" because there is nothing
+                // to invalidate downstream.
+                let changed = old_checksum
+                    .as_ref()
+                    .map(|old| old != &new_checksum)
+                    .unwrap_or(false);
+
+                let cache_ttl = self.get_cache_ttl_for_repo(repo.id).await;
+                self.cache_artifact(
+                    &cache_key,
+                    &metadata_key,
+                    &resp.content,
+                    resp.content_type.clone(),
+                    resp.etag,
+                    cache_ttl,
+                    repo.id,
+                    path,
+                )
+                .await?;
+
+                Ok((resp.content, resp.content_type, changed))
+            }
+            Err(upstream_err) => {
+                // Fall back to stale cache if available.
+                if let Ok(Some((stale_content, stale_content_type))) = self
+                    .get_stale_cached_artifact(&cache_key, &metadata_key)
+                    .await
+                {
+                    tracing::warn!(
+                        "Upstream fetch failed for {}; serving stale cached copy: {}",
+                        full_url,
+                        upstream_err
+                    );
+                    Ok((stale_content, stale_content_type, false))
+                } else {
+                    Err(upstream_err)
+                }
+            }
+        }
+    }
+
     /// Get cache TTL configuration for a repository.
     /// Returns TTL in seconds.
     async fn get_cache_ttl_for_repo(&self, repo_id: Uuid) -> i64 {


### PR DESCRIPTION
## Summary

Fixes #1147.

When a Remote APT proxy's upstream publishes new packages, the Release/InRelease
cache eventually expires and gets re-fetched, but the Packages indices retain
their own (still-valid) TTL. APT clients then receive a fresh Release with
SHA-256 hashes that don't match the stale cached Packages — `apt-get update`
fails with "Hash Sum mismatch".

Additionally, Virtual repositories containing Remote APT members could not serve
dists metadata at all (Release, InRelease, Packages, etc.) because
`DebianProxy::dists()` short-circuited for non-Remote repos, and
`dists_proxy_catchall` returned 404. This blocked the multi-mirror fallback use
case (multiple Remote mirrors in a Virtual repo with priority-based resolution).

Changes:
- **`DebianProxy::dists()`** — add Virtual branch that resolves metadata through
  members via `resolve_virtual_download`.
- **`dists_proxy_catchall`** — same Virtual support for non-Packages dists paths
  (i18n, dep11, Contents, etc.).
- **`dists_detecting_change()`** — new method that compares the SHA-256 of the
  newly-fetched Release/InRelease against the previously cached checksum; when
  they differ, invalidates all non-Release cached metadata for that distribution.
- **`ProxyService::fetch_artifact_detecting_change()`** — cache-aware fetch that
  returns a `changed` boolean alongside the content.
- **`ProxyService::invalidate_dist_packages_cache()`** — lists all keys under
  `proxy-cache/{repo}/dists/{dist}/` and deletes everything except
  Release/InRelease/Release.gpg/gpg-key.asc.
- Release and InRelease handlers now call `dists_detecting_change` instead of
  plain `dists`.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes