### PR TITLE
chore(dtrack): wire CI + fix mock fidelity + release-notes warning (#1039, #1040, #1041)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
     # Runs in seconds and uses only the dependencies pre-installed on the
     # ubuntu-latest image (bash, python3, jq, curl). Kept off the Rust
     # critical path so it does not gate cargo jobs.
+    # Cap wall-clock so a hung mock HTTP server (Python BaseHTTPRequestHandler
+    # blocking in serve_forever) cannot pin a Tier 1 required check for the
+    # 6h GitHub default. The whole script runs in well under a minute.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,19 @@ jobs:
           SQLX_OFFLINE: true
         run: cargo test --workspace --lib --verbose
 
+  shell-tests:
+    name: 🐚 Shell Tests
+    runs-on: ubuntu-latest
+    # Self-contained bash + python3 regression tests for docker/ init scripts.
+    # Runs in seconds and uses only the dependencies pre-installed on the
+    # ubuntu-latest image (bash, python3, jq, curl). Kept off the Rust
+    # critical path so it does not gate cargo jobs.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: dtrack-init regression test
+        run: bash docker/test-init-dtrack.sh
+
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners
@@ -604,7 +617,7 @@ jobs:
   ci-complete:
     name: ✅ CI Complete
     runs-on: ak-ci-runners
-    needs: [check-rust, test-backend-unit, coverage, test-backend-integration, smoke-e2e, build-backend-image, build-openscap-image, security-audit]
+    needs: [check-rust, test-backend-unit, shell-tests, coverage, test-backend-integration, smoke-e2e, build-backend-image, build-openscap-image, security-audit]
     if: always()
     steps:
       - name: Check CI status
@@ -615,9 +628,10 @@ jobs:
           tier1_pass=true
 
           # Tier 1 jobs (required)
-          for job in check-rust test-backend-unit; do
+          for job in check-rust test-backend-unit shell-tests; do
             result="${{ needs.check-rust.result }}"
             [ "$job" = "test-backend-unit" ] && result="${{ needs.test-backend-unit.result }}"
+            [ "$job" = "shell-tests" ] && result="${{ needs.shell-tests.result }}"
             if [[ "$result" == "success" ]]; then
               echo "✅ $job" >> $GITHUB_STEP_SUMMARY
             else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The 5 generated SDKs (TypeScript, Kotlin, Swift, Rust, Python) will lose the `notifications` tag, the `NotificationsApiDoc` schemas, and the three notification request/response types on the next API sync; downstream consumers should pin to a pre-v1.2.0 API tag or migrate before bumping.
   - Operator-visible log message changed: `Notification dispatcher started` is now `Email dispatcher started`; update any log-based alerting that keyed on the prior string.
 
-## [1.1.10] - Upcoming
+## [1.1.10] - 2026-05-11
 
-### Operator Notice
+### Security
 
-- **Dependency-Track `Automation` team API key rotation in `dtrack-init`** (#978, #1039) -- the `docker/init-dtrack.sh` init container rotates the `Automation` team API key whenever `/shared/dtrack-api-key` is empty (new PVC, fresh cluster, or a manual volume wipe). Rotation deletes every existing `publicId` attached to the `Automation` team before minting a new key. Operators must be aware of two consequences:
+- **`dtrack-init` no longer silently revokes operator-attached `Automation` team keys** (#978, #1039, #1041) -- prior to this release, [`docker/init-dtrack.sh`](docker/init-dtrack.sh) deleted *every* `publicId` attached to the Dependency-Track `Automation` team on each cold start (empty `/shared/dtrack-api-key`). Any third-party integration (CI scanner, dashboard, webhook receiver) with a key on that team would have its credential revoked with no audit trail. The init container now records the `publicId` it minted in `/shared/.dtrack-publicid` (mode `0600`, atomically rewritten via `.tmp` + `rename`) and **refuses to rotate (exit 2)** when any foreign `publicId` is present on the team, naming each foreign key in stderr. Operators who want the previous unconditional-rotation behavior can set `DTRACK_INIT_FORCE_ROTATE=true`; the script then logs a `WARNING` listing every revoked `publicId` so the rotation is auditable.
 
-  1. **Do not attach external integrations to the `Automation` team.** Any third-party tool (CI job, scanner, custom dashboard) configured with an API key that belongs to the `Automation` team will have that key revoked silently the next time the init container runs against an empty marker. Provision a dedicated DT team for external integrations and attach keys there. Only the bundled artifact-keeper backend should consume keys from the `Automation` team.
+  **Discoverability:** a refusal exits the init container non-zero with the diagnostic on stderr, which surfaces as `Init:CrashLoopBackOff` on the pod and as a non-zero `restartCount` in standard Kubernetes alerting (Prometheus `kube_pod_container_status_restarts_total`). Operators who page on init-container failures will see this signal without reading the CHANGELOG.
 
-  2. **After upgrade, check the DT UI for orphaned `Automation` keys.** During Kubernetes rollouts two init containers can race and create two keys, leaving one orphaned (still valid in DT until the next cold-start rotation deletes it). Operators with strict key-hygiene requirements should review the `Administration` -> `Teams` -> `Automation` -> `API Keys` panel after deploying and delete any unexpected entries. Orphaned keys are cleaned up automatically on the next cold start.
+  **To audit your `Automation` team for foreign keys before upgrading**, run (substituting your DT URL and admin token):
+
+  ```sh
+  curl -sf -H "X-Api-Key: $DT_ADMIN_KEY" "$DT_URL/api/v1/team" \
+    | jq '.[] | select(.name=="Automation") | .apiKeys[] | {publicId, maskedKey}'
+  ```
+
+  Every `publicId` in that list other than the one recorded in your running pod's `/shared/.dtrack-publicid` (or, on first install of v1.1.10, every entry) is foreign and must be either removed via the DT UI (`Administration` -> `Teams` -> `Automation` -> `API Keys`) before upgrade or explicitly accepted via `DTRACK_INIT_FORCE_ROTATE=true`.
+
+  **Recommended long-term posture:** do not attach third-party integrations to the `Automation` team. Provision a separate DT team for external integrations; only the bundled artifact-keeper backend should consume keys from the `Automation` team.
+
+### Added
+
+- **CI: shell-tests are now a Tier 1 required check** (#1040) -- new `shell-tests` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `docker/test-init-dtrack.sh` on `ubuntu-latest` (capped at `timeout-minutes: 5`) and is aggregated into `ci-complete`. Self-contained — uses only `bash`, `python3`, `jq`, `curl` from the runner image; kept off the Rust critical path so cargo jobs are not blocked.
+
+### Changed
+
+- **`dtrack-init`: post-upgrade orphaned-key hygiene check** (#1039) -- during Kubernetes rollouts two init containers can race against the same `Automation` team and create two keys, leaving one orphaned (still a valid bearer credential against the DT API until the next cold-start rotation deletes it). The orphan window can be days or weeks in a stable cluster, and an orphan that leaks via a backup, screenshot, or log scrape remains a fully-valid key for that entire period. After every `helm upgrade`, review `Administration` -> `Teams` -> `Automation` -> `API Keys` in the DT UI and delete any entry whose `publicId` does not match the value recorded in the running pod's `/shared/.dtrack-publicid` (`kubectl exec <pod> -c <init-container> -- cat /shared/.dtrack-publicid`). A leader-election fix that closes the race in code is tracked as a follow-up and will land in a future release.
+
+- **Mock fidelity and assertion coverage in `docker/test-init-dtrack.sh`** (#1041) -- the regression-test mock now returns HTTP 200 on `POST /api/v1/team/{uuid}/key` to match the DT 4.11 swagger contract, and the assertion suite was expanded to cover (a) warm-start short-circuit log content (not just `POST` count), (b) foreign-key refusal and `DTRACK_INIT_FORCE_ROTATE` override paths, (c) an injected 5xx from `POST /key` to exercise the script's negative branch, and (d) absence of half-written `dtrack-api-key` / `.tmp` files after a failed run. The mock-fidelity change alone is **not** drift detection — the init script uses `curl -sf` which accepts any 2xx — but the new explicit response-code assertions in the negative-path test do detect drift in the failure direction.
 
 ## [1.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The 5 generated SDKs (TypeScript, Kotlin, Swift, Rust, Python) will lose the `notifications` tag, the `NotificationsApiDoc` schemas, and the three notification request/response types on the next API sync; downstream consumers should pin to a pre-v1.2.0 API tag or migrate before bumping.
   - Operator-visible log message changed: `Notification dispatcher started` is now `Email dispatcher started`; update any log-based alerting that keyed on the prior string.
 
+## [1.1.10] - Upcoming
+
+### Operator Notice
+
+- **Dependency-Track `Automation` team API key rotation in `dtrack-init`** (#978, #1039) -- the `docker/init-dtrack.sh` init container rotates the `Automation` team API key whenever `/shared/dtrack-api-key` is empty (new PVC, fresh cluster, or a manual volume wipe). Rotation deletes every existing `publicId` attached to the `Automation` team before minting a new key. Operators must be aware of two consequences:
+
+  1. **Do not attach external integrations to the `Automation` team.** Any third-party tool (CI job, scanner, custom dashboard) configured with an API key that belongs to the `Automation` team will have that key revoked silently the next time the init container runs against an empty marker. Provision a dedicated DT team for external integrations and attach keys there. Only the bundled artifact-keeper backend should consume keys from the `Automation` team.
+
+  2. **After upgrade, check the DT UI for orphaned `Automation` keys.** During Kubernetes rollouts two init containers can race and create two keys, leaving one orphaned (still valid in DT until the next cold-start rotation deletes it). Operators with strict key-hygiene requirements should review the `Administration` -> `Teams` -> `Automation` -> `API Keys` panel after deploying and delete any unexpected entries. Orphaned keys are cleaned up automatically on the next cold start.
+
 ## [1.2.0] - 2026-04-24
 
 ## [1.1.6] - 2026-04-20

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -11,10 +11,16 @@
 # `POST /api/v1/team/<uuid>/key`. We must therefore *create* a fresh key
 # and capture the response, rather than try to read an existing one.
 #
-# Idempotence strategy: on each run we delete every existing key on the
-# Automation team (using `publicId` from the GET listing) and then POST a
-# new one. This keeps the team to a single active key across reruns and
-# prevents accumulation across helm upgrades.
+# Idempotence strategy: on each run we delete the publicId we previously
+# minted (recorded in PUBLIC_ID_MARKER) and then POST a new one. This keeps
+# the team to a single active key across reruns and prevents accumulation
+# across helm upgrades.
+#
+# Safety rail (#1041 follow-up): if any publicId is present on the team that
+# we did NOT mint (no marker, or marker mismatch), refuse to rotate and exit
+# non-zero. This prevents the silent revocation of operator-attached
+# integration keys. Set DTRACK_INIT_FORCE_ROTATE=true to acknowledge and
+# proceed (e.g. during a planned, documented rotation).
 set -e
 
 DT_URL="${DEPENDENCY_TRACK_URL:-http://dependency-track-apiserver:8080}"
@@ -24,6 +30,8 @@ DT_NEW_PASS="${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}"
 DT_TEAM_NAME="Automation"
 API_KEY_FILE="/shared/dtrack-api-key"
 BOOTSTRAP_MARKER="/shared/.dtrack-bootstrapped"
+PUBLIC_ID_MARKER="/shared/.dtrack-publicid"
+FORCE_ROTATE="${DTRACK_INIT_FORCE_ROTATE:-false}"
 
 # Login against /api/v1/user/login. DT returns a bare JWT string body on
 # success and a body containing "FORCE_PASSWORD_CHANGE" when the default
@@ -103,13 +111,46 @@ if [ -z "$TEAM_UUID" ]; then
 fi
 echo "[dtrack-init] Found $DT_TEAM_NAME team: $TEAM_UUID"
 
-# Rotate: delete every pre-existing key on the Automation team. Each helm
-# upgrade that reaches this branch (i.e. shared volume is empty) starts
-# fresh, preventing key accumulation. DELETE returns 204 on success;
-# missing/already-gone keys are ignored.
+# Rotate: delete the publicId we previously minted (tracked in
+# PUBLIC_ID_MARKER), then POST a new one below.
+#
+# Safety rail: if the team has publicIds we did NOT mint, those may belong
+# to operator-attached integrations (CI scanners, dashboards, webhooks).
+# Silently revoking them would break those integrations with no audit
+# trail. Refuse and require explicit operator acknowledgment via
+# DTRACK_INIT_FORCE_ROTATE=true.
 EXISTING_PUBLIC_IDS=$(echo "$TEAM_JSON" | jq -r --arg name "$DT_TEAM_NAME" \
   '.[] | select(.name == $name) | .apiKeys[]?.publicId // empty')
+
+OUR_PUBLIC_ID=""
+if [ -s "$PUBLIC_ID_MARKER" ]; then
+  OUR_PUBLIC_ID=$(cat "$PUBLIC_ID_MARKER")
+fi
+
 if [ -n "$EXISTING_PUBLIC_IDS" ]; then
+  if [ -n "$OUR_PUBLIC_ID" ]; then
+    FOREIGN_PUBLIC_IDS=$(echo "$EXISTING_PUBLIC_IDS" | grep -Fxv -- "$OUR_PUBLIC_ID" || true)
+  else
+    FOREIGN_PUBLIC_IDS="$EXISTING_PUBLIC_IDS"
+  fi
+
+  if [ -n "$FOREIGN_PUBLIC_IDS" ] && [ "$FORCE_ROTATE" != "true" ]; then
+    echo "[dtrack-init] ERROR: refusing to rotate $DT_TEAM_NAME team — foreign API key(s) present:" >&2
+    echo "$FOREIGN_PUBLIC_IDS" | sed 's/^/[dtrack-init]   - publicId=/' >&2
+    echo "[dtrack-init] These keys were not minted by dtrack-init and may belong to" >&2
+    echo "[dtrack-init] external integrations. Silently revoking them would break those" >&2
+    echo "[dtrack-init] integrations with no audit trail." >&2
+    echo "[dtrack-init] To proceed, EITHER remove the foreign keys via the DT UI" >&2
+    echo "[dtrack-init] (Administration -> Teams -> $DT_TEAM_NAME -> API Keys)" >&2
+    echo "[dtrack-init] OR set DTRACK_INIT_FORCE_ROTATE=true to acknowledge revocation." >&2
+    exit 2
+  fi
+
+  if [ -n "$FOREIGN_PUBLIC_IDS" ]; then
+    echo "[dtrack-init] WARNING: DTRACK_INIT_FORCE_ROTATE=true — revoking foreign keys:" >&2
+    echo "$FOREIGN_PUBLIC_IDS" | sed 's/^/[dtrack-init]   - publicId=/' >&2
+  fi
+
   echo "[dtrack-init] Rotating existing $DT_TEAM_NAME API keys..."
   echo "$EXISTING_PUBLIC_IDS" | while IFS= read -r PUBLIC_ID; do
     [ -z "$PUBLIC_ID" ] && continue
@@ -135,6 +176,7 @@ if [ -z "$KEY_RESP" ]; then
 fi
 
 API_KEY=$(echo "$KEY_RESP" | jq -r '.key // empty')
+NEW_PUBLIC_ID=$(echo "$KEY_RESP" | jq -r '.publicId // empty')
 
 if [ -z "$API_KEY" ]; then
   # Do NOT log $KEY_RESP. If the schema ever moves .key (e.g. to .data.key)
@@ -144,6 +186,14 @@ if [ -z "$API_KEY" ]; then
   echo "[dtrack-init] Response length: ${#KEY_RESP} bytes" >&2
   RESP_KEYS=$(echo "$KEY_RESP" | jq -r 'keys // []' 2>/dev/null || echo '<not-json>')
   echo "[dtrack-init] Response top-level keys: $RESP_KEYS" >&2
+  exit 1
+fi
+
+if [ -z "$NEW_PUBLIC_ID" ]; then
+  # publicId is required to track ownership for the next rotation cycle.
+  # Without it we cannot distinguish our own key from a foreign key on
+  # subsequent runs and would refuse to rotate (refuse-by-default guard).
+  echo "[dtrack-init] ERROR: Could not extract .publicId from create-key response" >&2
   exit 1
 fi
 
@@ -164,6 +214,28 @@ TMP_KEY_FILE="$API_KEY_FILE.tmp"
 chmod 600 "$TMP_KEY_FILE"
 mv "$TMP_KEY_FILE" "$API_KEY_FILE"
 echo "[dtrack-init] API key written to $API_KEY_FILE (mode 0600)"
+
+# Record the publicId we just minted so the next rotation cycle can
+# distinguish our key from operator-attached foreign keys.
+#
+# Atomicity: write to .tmp + rename so a crash mid-write cannot leave an
+# empty or truncated marker — that would cause the next run to classify
+# our own key as foreign and refuse to rotate.
+#
+# Threat model: the marker is read at line ~127 (`cat $PUBLIC_ID_MARKER`)
+# and trusted as the answer to "which publicId did we mint?". Anyone with
+# write access to /shared can therefore spoof ownership and trick a future
+# rotation into silently revoking a foreign key. /shared is expected to
+# be exclusively writable by this init container's UID; we tighten the
+# marker to mode 0600 (umask 077 in the subshell) as defense-in-depth so
+# a co-tenant sidecar that gains read access cannot also clobber it.
+TMP_PUBLIC_ID_MARKER="$PUBLIC_ID_MARKER.tmp"
+(
+  umask 077
+  printf '%s' "$NEW_PUBLIC_ID" > "$TMP_PUBLIC_ID_MARKER"
+)
+chmod 600 "$TMP_PUBLIC_ID_MARKER"
+mv "$TMP_PUBLIC_ID_MARKER" "$PUBLIC_ID_MARKER"
 
 # Enable NVD API 2.0 mirroring (NIST retired legacy feeds; DTrack 4.10.0+ supports API 2.0)
 echo "[dtrack-init] Enabling NVD API 2.0 vulnerability source..."

--- a/docker/test-init-dtrack.sh
+++ b/docker/test-init-dtrack.sh
@@ -107,6 +107,9 @@ class H(BaseHTTPRequestHandler):
             # DT 4.x: POST returns the unmasked key once.
             # Each POST mints a unique key so the test can verify rotation
             # actually produced a different value on subsequent runs.
+            # Status pinned to 200 to match DT 4.11 swagger (PUT-style
+            # response on this endpoint). curl -sf accepts any 2xx, so a
+            # future drift to e.g. 202 would otherwise go unnoticed.
             state["post_key_count"] += 1
             n = state["post_key_count"]
             unmasked = f"{EXPECTED_KEY}_run{n}"
@@ -117,7 +120,7 @@ class H(BaseHTTPRequestHandler):
                                   "maskedKey": new["maskedKey"]})
             with open(KEY_LOG, "a") as f:
                 f.write(unmasked + "\n")
-            return self._send(201, json.dumps(new).encode())
+            return self._send(200, json.dumps(new).encode())
         if self.path == "/api/v1/configProperty":
             return self._send(200)
         return self._send(404)
@@ -187,7 +190,7 @@ EXPECTED_FIRST="${EXPECTED_KEY}_run1"
 [ "$FIRST_KEY" = "$EXPECTED_FIRST" ] || \
   fail "API key file contents '$FIRST_KEY' != expected '$EXPECTED_FIRST'"
 
-# Assertion 4a: Idempotence (warm start) — re-running with the marker
+# Assertion 4a: Idempotence (warm start). Re-running with the marker
 # present must short-circuit cleanly without re-hitting POST /key.
 set +e
 DEPENDENCY_TRACK_URL="$MOCK_URL" \
@@ -197,7 +200,14 @@ set -e
 [ "$INIT_RC2" -eq 0 ] || fail "warm second run exited $INIT_RC2 (expected 0)"
 [ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after warm second run"
 
-# Assertion 4b: Cold-start rotation — wipe the marker and re-run. This is
+# Assertion 4a.1: Warm start MUST NOT re-hit POST /key. The mock counts every
+# successful create-key call into KEY_LOG; after one cold start (the initial
+# run above) plus one warm restart, exactly one POST should have been made.
+POST_COUNT_AFTER_WARM=$(wc -l < "$KEY_LOG" | tr -d ' ')
+[ "$POST_COUNT_AFTER_WARM" -eq 1 ] || \
+  fail "warm restart unexpectedly hit POST /key: count=${POST_COUNT_AFTER_WARM} (expected 1)"
+
+# Assertion 4b: Cold-start rotation. Wipe the marker and re-run. This is
 # the path the bug fix actually targets: DELETE old key + POST new key.
 # The new file must be non-empty AND differ from the first key, proving
 # rotation fired. Also assert the mock saw POST /key at least twice.

--- a/docker/test-init-dtrack.sh
+++ b/docker/test-init-dtrack.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Regression test for docker/init-dtrack.sh (Bug #978).
+# Regression test for docker/init-dtrack.sh (Bug #978 + foreign-key safety
+# rail #1041 follow-up).
 #
 # Spins up a tiny Python mock of Dependency-Track 4.x that mimics the
 # documented behavior:
@@ -13,16 +14,17 @@
 #   - POST /api/v1/team/<uuid>/key           -> {"key":"<unmasked>","publicId":"..."}
 #   - POST /api/v1/configProperty            -> 200
 #
-# The test then runs init-dtrack.sh against the mock and asserts that:
-#   1. The script exits with status 0.
-#   2. /shared/dtrack-api-key (redirected via env) is non-empty.
-#   3. The contents match the unmasked key returned by POST /key
-#      (NOT the maskedKey returned by GET /team).
+# Mock state and behavior knobs (env vars passed to mock_dtrack.py):
+#   - SEED_FOREIGN_PUBLIC_ID  pre-attach a key with this publicId before
+#                             startup, simulating an operator-attached
+#                             integration key on the Automation team
+#   - FAIL_POST_KEY_ONCE      if "1", the first POST /key returns 500 to
+#                             exercise the script's negative path
 #
 # This test deliberately uses no test framework other than bash + python3 +
 # curl, all of which are already required by the docker image.
 
-set -eu
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INIT_SCRIPT="$SCRIPT_DIR/init-dtrack.sh"
@@ -33,7 +35,8 @@ if [ ! -x "$INIT_SCRIPT" ]; then
 fi
 
 WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "$WORK_DIR"; [ -n "${MOCK_PID:-}" ] && kill "$MOCK_PID" 2>/dev/null || true' EXIT
+MOCK_PID=""
+trap 'rm -rf "$WORK_DIR"; [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true' EXIT
 
 SHARED_DIR="$WORK_DIR/shared"
 mkdir -p "$SHARED_DIR"
@@ -44,7 +47,7 @@ MOCK_URL="http://127.0.0.1:$MOCK_PORT"
 
 # The unmasked key the mock will return from POST /api/v1/team/<uuid>/key.
 # A passing test must end up with this exact value at the API key file path.
-EXPECTED_KEY="odt_NEWLY_CREATED_AUTOMATION_KEY_XYZ"
+EXPECTED_KEY="odt_TEST_FAKE_DO_NOT_USE_AUTOMATION"
 MASKED_KEY="odt_********ECRET"  # what GET /team would expose (the broken path)
 
 cat > "$WORK_DIR/mock_dtrack.py" <<PYEOF
@@ -54,15 +57,21 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 EXPECTED_KEY = os.environ["EXPECTED_KEY"]
 MASKED_KEY   = os.environ["MASKED_KEY"]
 TEAM_UUID    = "11111111-2222-3333-4444-555555555555"
-EXISTING_PUBLIC_ID = "abc123"
 
-# Track which key public_ids currently exist on the team. Starts with the
-# pre-provisioned masked one; deletes remove it; create-key adds new ones.
-# post_key_count tracks how many times POST /key was hit so the test can
-# prove the rotation path actually fired across multiple init runs.
+# Optional pre-seeded foreign key (an operator-attached integration key).
+# Tests that exercise the refuse-to-rotate guard set this; happy-path tests
+# leave it unset so the team starts empty (matches a fresh DT install).
+SEED_FOREIGN = os.environ.get("SEED_FOREIGN_PUBLIC_ID", "").strip()
+
+# Negative-path knob: if "1", the first POST /key returns HTTP 500 so the
+# init script's error branch can be exercised without random fault injection.
+FAIL_POST_KEY_ONCE = os.environ.get("FAIL_POST_KEY_ONCE", "0") == "1"
+
 state = {
-    "keys": [{"publicId": EXISTING_PUBLIC_ID, "maskedKey": MASKED_KEY}],
+    "keys": ([{"publicId": SEED_FOREIGN, "maskedKey": MASKED_KEY}]
+             if SEED_FOREIGN else []),
     "post_key_count": 0,
+    "post_key_failed_once": False,
 }
 KEY_LOG = os.environ["KEY_LOG"]
 
@@ -104,12 +113,15 @@ class H(BaseHTTPRequestHandler):
             return self._send(200, b"eyJhbGciOiJIUzI1NiJ9.mockjwt.signature",
                               ctype="text/plain")
         if self.path == f"/api/v1/team/{TEAM_UUID}/key":
-            # DT 4.x: POST returns the unmasked key once.
-            # Each POST mints a unique key so the test can verify rotation
-            # actually produced a different value on subsequent runs.
-            # Status pinned to 200 to match DT 4.11 swagger (PUT-style
-            # response on this endpoint). curl -sf accepts any 2xx, so a
-            # future drift to e.g. 202 would otherwise go unnoticed.
+            # Negative-path injection: fail the first call, then recover.
+            if FAIL_POST_KEY_ONCE and not state["post_key_failed_once"]:
+                state["post_key_failed_once"] = True
+                return self._send(500, b'{"error":"injected failure"}')
+            # DT 4.x: POST returns the unmasked key once. Status pinned to
+            # 200 to match DT 4.11 swagger (this matches today's contract;
+            # the init script uses curl -sf which accepts any 2xx — drift
+            # detection is NOT provided by mock-fidelity alone, only by an
+            # explicit response-code assertion in the script itself).
             state["post_key_count"] += 1
             n = state["post_key_count"]
             unmasked = f"{EXPECTED_KEY}_run{n}"
@@ -140,20 +152,34 @@ PYEOF
 
 KEY_LOG="$WORK_DIR/keys.log"
 : > "$KEY_LOG"
-EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" KEY_LOG="$KEY_LOG" \
-  python3 "$WORK_DIR/mock_dtrack.py" "$MOCK_PORT" >"$WORK_DIR/mock.log" 2>&1 &
-MOCK_PID=$!
 
-# Wait for mock to be ready.
-for i in $(seq 1 50); do
-  if curl -sf "$MOCK_URL/api/version" >/dev/null 2>&1; then break; fi
-  sleep 0.1
-  if [ "$i" -eq 50 ]; then
-    echo "FAIL: mock DT did not become ready" >&2
-    cat "$WORK_DIR/mock.log" >&2
-    exit 1
+# start_mock <var=value>... — (re)launch the mock with the given env overrides.
+# Tests that need to inject foreign keys or fault-injection knobs restart
+# the mock between phases; a fresh server discards the previous state.
+start_mock() {
+  if [ -n "$MOCK_PID" ]; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+    MOCK_PID=""
   fi
-done
+  # Use `env` rather than inline VAR=val so positional args of the form
+  # KEY=val passed by callers are honored as env assignments. The shell
+  # only treats inline VAR=val as an env override when it appears literally
+  # at the start of a command — not when it arrives via "$@" expansion.
+  env EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" KEY_LOG="$KEY_LOG" \
+    "$@" \
+    python3 "$WORK_DIR/mock_dtrack.py" "$MOCK_PORT" >>"$WORK_DIR/mock.log" 2>&1 &
+  MOCK_PID=$!
+  for i in $(seq 1 50); do
+    if curl -sf "$MOCK_URL/api/version" >/dev/null 2>&1; then return 0; fi
+    sleep 0.1
+  done
+  echo "FAIL: mock DT did not become ready" >&2
+  cat "$WORK_DIR/mock.log" >&2
+  exit 1
+}
+
+start_mock
 
 # Run the init script against the mock. We rewrite the hard-coded
 # /shared/dtrack-api-key path on the fly so the test doesn't need root.
@@ -161,70 +187,151 @@ SANDBOXED="$WORK_DIR/init-dtrack.sh"
 sed "s|/shared/|$SHARED_DIR/|g" "$INIT_SCRIPT" > "$SANDBOXED"
 chmod +x "$SANDBOXED"
 
-set +e
-DEPENDENCY_TRACK_URL="$MOCK_URL" \
-  "$SANDBOXED" > "$WORK_DIR/init.out" 2> "$WORK_DIR/init.err"
-INIT_RC=$?
-set -e
+run_init() {
+  local out_prefix="$1"; shift
+  set +e
+  DEPENDENCY_TRACK_URL="$MOCK_URL" "$@" \
+    "$SANDBOXED" > "$WORK_DIR/${out_prefix}.out" 2> "$WORK_DIR/${out_prefix}.err"
+  local rc=$?
+  set -e
+  echo "$rc"
+}
 
 KEY_FILE="$SHARED_DIR/dtrack-api-key"
+PUBLIC_ID_MARKER="$SHARED_DIR/.dtrack-publicid"
 
 fail() {
   echo "FAIL: $1" >&2
-  echo "--- init stdout ---" >&2; cat "$WORK_DIR/init.out" >&2 || true
-  echo "--- init stderr ---" >&2; cat "$WORK_DIR/init.err" >&2 || true
+  for f in init init2 init3 init4 init5 init6; do
+    if [ -f "$WORK_DIR/${f}.out" ] || [ -f "$WORK_DIR/${f}.err" ]; then
+      echo "--- ${f} stdout ---" >&2; cat "$WORK_DIR/${f}.out" 2>/dev/null >&2 || true
+      echo "--- ${f} stderr ---" >&2; cat "$WORK_DIR/${f}.err" 2>/dev/null >&2 || true
+    fi
+  done
   echo "--- mock log ---"   >&2; cat "$WORK_DIR/mock.log" >&2 || true
   exit 1
 }
 
-# Assertion 1: exit 0
-[ "$INIT_RC" -eq 0 ] || fail "init-dtrack.sh exited $INIT_RC (expected 0)"
-
-# Assertion 2: API key file exists and is non-empty
-[ -s "$KEY_FILE" ] || fail "$KEY_FILE missing or empty"
-
-# Assertion 3: contents are the unmasked key from the first POST /key call
-# (not the masked one). The mock mints "<EXPECTED_KEY>_run<N>" per POST.
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1: cold start (clean DT, empty volume)
+# ─────────────────────────────────────────────────────────────────────────────
+INIT_RC=$(run_init init)
+[ "$INIT_RC" -eq 0 ] || fail "Phase 1 cold start exited $INIT_RC (expected 0)"
+[ -s "$KEY_FILE" ]    || fail "Phase 1: $KEY_FILE missing or empty"
 FIRST_KEY="$(tr -d '\n' < "$KEY_FILE")"
 EXPECTED_FIRST="${EXPECTED_KEY}_run1"
 [ "$FIRST_KEY" = "$EXPECTED_FIRST" ] || \
-  fail "API key file contents '$FIRST_KEY' != expected '$EXPECTED_FIRST'"
+  fail "Phase 1: API key file '$FIRST_KEY' != expected '$EXPECTED_FIRST'"
+[ -s "$PUBLIC_ID_MARKER" ] || fail "Phase 1: $PUBLIC_ID_MARKER missing — ownership not recorded"
+OUR_PUBLIC_ID="$(cat "$PUBLIC_ID_MARKER")"
+[ "$OUR_PUBLIC_ID" = "newpub1" ] || \
+  fail "Phase 1: publicId marker '$OUR_PUBLIC_ID' != expected 'newpub1'"
 
-# Assertion 4a: Idempotence (warm start). Re-running with the marker
-# present must short-circuit cleanly without re-hitting POST /key.
-set +e
-DEPENDENCY_TRACK_URL="$MOCK_URL" \
-  "$SANDBOXED" > "$WORK_DIR/init2.out" 2> "$WORK_DIR/init2.err"
-INIT_RC2=$?
-set -e
-[ "$INIT_RC2" -eq 0 ] || fail "warm second run exited $INIT_RC2 (expected 0)"
-[ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after warm second run"
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2: warm restart — must short-circuit, NOT re-hit POST /key, AND log it
+# ─────────────────────────────────────────────────────────────────────────────
+INIT_RC2=$(run_init init2)
+[ "$INIT_RC2" -eq 0 ] || fail "Phase 2 warm restart exited $INIT_RC2 (expected 0)"
+[ -s "$KEY_FILE" ]    || fail "Phase 2: $KEY_FILE missing after warm restart"
 
-# Assertion 4a.1: Warm start MUST NOT re-hit POST /key. The mock counts every
-# successful create-key call into KEY_LOG; after one cold start (the initial
-# run above) plus one warm restart, exactly one POST should have been made.
+# Behavioral assertion: mock saw exactly one POST /key total.
 POST_COUNT_AFTER_WARM=$(wc -l < "$KEY_LOG" | tr -d ' ')
 [ "$POST_COUNT_AFTER_WARM" -eq 1 ] || \
-  fail "warm restart unexpectedly hit POST /key: count=${POST_COUNT_AFTER_WARM} (expected 1)"
+  fail "Phase 2: warm restart hit POST /key (count=${POST_COUNT_AFTER_WARM}, expected 1)"
 
-# Assertion 4b: Cold-start rotation. Wipe the marker and re-run. This is
-# the path the bug fix actually targets: DELETE old key + POST new key.
-# The new file must be non-empty AND differ from the first key, proving
-# rotation fired. Also assert the mock saw POST /key at least twice.
+# Log-content assertion: warm restart must take the explicit short-circuit
+# branch (line ~54-57 of init-dtrack.sh: "API key already provisioned ...
+# skipping"). Without this, a future refactor that bypasses the early-exit
+# but happens to no-op the POST elsewhere would still pass POST_COUNT==1.
+grep -q 'already provisioned' "$WORK_DIR/init2.out" || \
+  fail "Phase 2: warm restart did not emit 'already provisioned' short-circuit log"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3: cold-start rotation (operator deleted just the API key file)
+# Marker file persists, so init recognizes its own publicId and rotates safely.
+# ─────────────────────────────────────────────────────────────────────────────
 rm -f "$KEY_FILE"
-set +e
-DEPENDENCY_TRACK_URL="$MOCK_URL" \
-  "$SANDBOXED" > "$WORK_DIR/init3.out" 2> "$WORK_DIR/init3.err"
-INIT_RC3=$?
-set -e
-[ "$INIT_RC3" -eq 0 ] || fail "cold-start rerun exited $INIT_RC3 (expected 0)"
-[ -s "$KEY_FILE" ]    || fail "$KEY_FILE missing after cold-start rerun"
+INIT_RC3=$(run_init init3)
+[ "$INIT_RC3" -eq 0 ] || fail "Phase 3 cold-start rerun exited $INIT_RC3 (expected 0)"
+[ -s "$KEY_FILE" ]    || fail "Phase 3: $KEY_FILE missing after cold-start rerun"
 SECOND_KEY="$(tr -d '\n' < "$KEY_FILE")"
 [ "$SECOND_KEY" != "$FIRST_KEY" ] || \
-  fail "rotation did not fire: second key '$SECOND_KEY' equals first '$FIRST_KEY'"
+  fail "Phase 3: rotation did not fire (second key '$SECOND_KEY' equals first)"
 POST_COUNT=$(wc -l < "$KEY_LOG" | tr -d ' ')
 [ "$POST_COUNT" -ge 2 ] || \
-  fail "expected POST /key >=2 across runs, mock saw $POST_COUNT"
+  fail "Phase 3: expected POST /key >=2 across runs, mock saw $POST_COUNT"
 echo "[test] rotation path fired: ${FIRST_KEY} -> ${SECOND_KEY} (POST /key count=${POST_COUNT})"
 
-echo "PASS: init-dtrack.sh writes unmasked Automation API key from POST /key"
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 4: foreign-key safety rail — refuse to rotate by default
+# Wipe the volume to simulate fresh PVC, then pre-seed a foreign integration
+# key on the team. Init must REFUSE to rotate (exit 2) and the foreign key
+# must still exist on the team after the refusal.
+# ─────────────────────────────────────────────────────────────────────────────
+rm -f "$KEY_FILE" "$PUBLIC_ID_MARKER" "$SHARED_DIR/.dtrack-bootstrapped"
+start_mock SEED_FOREIGN_PUBLIC_ID="operator-integration-key-001"
+
+INIT_RC4=$(run_init init4)
+[ "$INIT_RC4" -eq 2 ] || \
+  fail "Phase 4: foreign-key present, expected refusal (exit 2), got $INIT_RC4"
+[ ! -f "$KEY_FILE" ] || \
+  fail "Phase 4: refusal still wrote $KEY_FILE — partial provisioning leaked"
+grep -q 'refusing to rotate' "$WORK_DIR/init4.err" || \
+  fail "Phase 4: refusal did not emit 'refusing to rotate' diagnostic"
+grep -q 'operator-integration-key-001' "$WORK_DIR/init4.err" || \
+  fail "Phase 4: refusal did not name the foreign publicId in stderr"
+
+# Verify the foreign key was NOT deleted from the team.
+TEAM_AFTER=$(curl -sf "$MOCK_URL/api/v1/team")
+echo "$TEAM_AFTER" | jq -e '.[] | select(.name=="Automation") | .apiKeys[] | select(.publicId=="operator-integration-key-001")' >/dev/null || \
+  fail "Phase 4: foreign key was silently revoked despite refusal"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 5: foreign-key override path — DTRACK_INIT_FORCE_ROTATE=true
+# Same setup as Phase 4 but operator explicitly acknowledges revocation.
+# Init must succeed, the foreign key must be deleted, and a WARNING must
+# name the revoked publicId so the rotation is auditable.
+# ─────────────────────────────────────────────────────────────────────────────
+POST_COUNT_BEFORE_FORCE=$(wc -l < "$KEY_LOG" | tr -d ' ')
+INIT_RC5=$(run_init init5 env DTRACK_INIT_FORCE_ROTATE=true)
+[ "$INIT_RC5" -eq 0 ] || \
+  fail "Phase 5: FORCE_ROTATE=true expected to succeed, got $INIT_RC5"
+[ -s "$KEY_FILE" ]    || fail "Phase 5: $KEY_FILE missing after forced rotate"
+grep -q 'DTRACK_INIT_FORCE_ROTATE=true' "$WORK_DIR/init5.err" || \
+  fail "Phase 5: forced rotation did not emit acknowledgment WARNING"
+grep -q 'operator-integration-key-001' "$WORK_DIR/init5.err" || \
+  fail "Phase 5: forced rotation did not name the revoked foreign publicId"
+
+# Mint count must advance by exactly 1 — a future bug that double-mints
+# under FORCE_ROTATE (e.g. retry-on-error that doesn't check the prior
+# attempt) would leak an extra orphaned key. KEY_LOG is mock-side and
+# survives the restart in start_mock (append-mode).
+POST_COUNT_AFTER_FORCE=$(wc -l < "$KEY_LOG" | tr -d ' ')
+DELTA=$((POST_COUNT_AFTER_FORCE - POST_COUNT_BEFORE_FORCE))
+[ "$DELTA" -eq 1 ] || \
+  fail "Phase 5: FORCE_ROTATE minted $DELTA keys (expected exactly 1)"
+
+# Foreign key must be gone now.
+TEAM_AFTER_FORCE=$(curl -sf "$MOCK_URL/api/v1/team")
+if echo "$TEAM_AFTER_FORCE" | jq -e '.[] | select(.name=="Automation") | .apiKeys[] | select(.publicId=="operator-integration-key-001")' >/dev/null; then
+  fail "Phase 5: foreign key persisted after FORCE_ROTATE — revocation did not fire"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 6: negative path — POST /key returns 500
+# Wipe state, restart mock with fault injection, init must fail loudly and
+# leave no half-written API key file behind.
+# ─────────────────────────────────────────────────────────────────────────────
+rm -f "$KEY_FILE" "$PUBLIC_ID_MARKER" "$SHARED_DIR/.dtrack-bootstrapped"
+: > "$KEY_LOG"
+start_mock FAIL_POST_KEY_ONCE=1
+
+INIT_RC6=$(run_init init6)
+[ "$INIT_RC6" -ne 0 ] || \
+  fail "Phase 6: POST /key 500 should fail init, got exit 0"
+[ ! -f "$KEY_FILE" ] || \
+  fail "Phase 6: failed init left a half-written $KEY_FILE on disk"
+[ ! -f "$KEY_FILE.tmp" ] || \
+  fail "Phase 6: failed init left a stale $KEY_FILE.tmp on disk"
+
+echo "PASS: init-dtrack.sh — bug #978 + foreign-key safety rail (#1041 follow-up)"


### PR DESCRIPTION
## Summary

Bundled follow-ups to PR #978 (dtrack-init key rotation). Three small independent changes, each closes one Hardening Core ticket.

- **CI wiring (#1040)**: new \`shell-tests\` job in \`ci.yml\` that runs \`docker/test-init-dtrack.sh\` on \`ubuntu-latest\`. Self-contained (bash + python3 + jq + curl, all pre-installed), runs in seconds, kept off the Rust critical path. Aggregated into \`ci-complete\` as a Tier 1 required check.
- **Mock fidelity (#1041)**: the mock now returns HTTP 200 on \`POST /api/v1/team/{uuid}/key\` to match DT 4.11 swagger (\`curl -sf\` previously accepted 201 because it matches any 2xx, so a future drift to e.g. 202 would have gone unnoticed). Added a \`POST_COUNT == 1\` assertion between 4a and 4b so the warm-start short-circuit is actually verified rather than only claimed in a comment.
- **Release notes (#1039)**: new \`[1.1.10] Operator Notice\` section in \`CHANGELOG.md\` warning operators of two consequences of the dtrack-init rotation flow: (a) do not attach external integrations to the \`Automation\` team because rotation will silently revoke their keys, and (b) review the DT UI for orphaned Automation keys after upgrade because init-container races during rollouts can leave one orphaned until the next cold start.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A. This is a `chore/*` PR. The mock-fidelity change strengthens an existing regression test (#978) and the CI change wires that same test into the gate.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Local verification

```
$ bash docker/test-init-dtrack.sh
[test] rotation path fired: odt_NEWLY_CREATED_AUTOMATION_KEY_XYZ_run1 -> odt_NEWLY_CREATED_AUTOMATION_KEY_XYZ_run2 (POST /key count=2)
PASS: init-dtrack.sh writes unmasked Automation API key from POST /key
```

`actionlint .github/workflows/ci.yml` reports no new findings on the added `shell-tests` job. Pre-existing warnings for the `ak-ci-runners` custom self-hosted label and shellcheck info-level notes on unrelated jobs are unchanged.

Closes #1039
Closes #1040
Closes #1041