### PR TITLE
chore(ci): integration --ignored, migration-slot lint, nightly diagnostics (#1031, #1128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Catch migration-slot collisions before they reach the e2e/nightly job.
+      # The nightly run on 2026-05-09 (#1128) crashed at startup with
+      # `duplicate key value violates unique constraint "_sqlx_migrations_pkey"
+      # Key (version)=(73)` because a forward-port attempted to reuse a slot
+      # already taken on main. A cheap filename-prefix dedup catches the
+      # entire class of failures without needing a Postgres to apply them.
+      - name: Lint migration slots are unique
+        run: |
+          set -euo pipefail
+          dupes=$(ls backend/migrations/ | awk -F_ '{print $1}' | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "::error::duplicate migration version slot(s): $dupes"
+            ls backend/migrations/ | grep -E "^($(echo "$dupes" | paste -sd'|'))_"
+            exit 1
+          fi
+
       - name: Run unit tests
         env:
           SQLX_OFFLINE: true
@@ -359,11 +375,43 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # `-- --ignored` runs the postgres-backed integration suites under
+      # `backend/tests/` that were silently skipped before (#1031). The job
+      # provisions postgres but NOT a running HTTP backend, Meilisearch,
+      # Trivy, or live cloud credentials, so the suite list below is
+      # restricted to tests that need only a Postgres connection:
+      #
+      #   - lifecycle_policy_tests, api_token_cache_flush_tests,
+      #     search_reindex_tests, scan_convert_to_reused_tests,
+      #     virtual_members_atomicity_test, virtual_members_duplicate_test,
+      #     grpc_sbom_tests (in-process gRPC, no HTTP server).
+      #
+      # Deliberately excluded (would panic on first .expect() without
+      # extra infra, so `--ignored` stays the right gate):
+      #
+      #   - azure_rbac_live_test, azure_shared_key_live_test, s3_integration,
+      #     incus_upload_tests  (live cloud creds via std::env::var().expect)
+      #   - integration_tests, replication_integration,
+      #     tag_filtered_replication_tests, storage_backend_tests
+      #     (read TEST_BASE_URL, need a running HTTP backend)
+      #
+      # `--test-threads=1` because the DB-backed suites share schema state
+      # through global DELETEs in their cleanup helpers and would race under
+      # parallel execution.
       - name: Run integration tests
         env:
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
           SQLX_OFFLINE: true
-        run: cargo test --workspace --test '*' --verbose
+        run: |
+          cargo test --workspace --verbose \
+            --test lifecycle_policy_tests \
+            --test api_token_cache_flush_tests \
+            --test grpc_sbom_tests \
+            --test search_reindex_tests \
+            --test scan_convert_to_reused_tests \
+            --test virtual_members_atomicity_test \
+            --test virtual_members_duplicate_test \
+            -- --ignored --test-threads=1
 
   # ════════════════════════════════════════════════════════════════════════════
   # SMOKE E2E (Every Push/PR) — self-contained via Docker-in-Docker on ARC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,19 @@ jobs:
       - name: Lint migration slots are unique
         run: |
           set -euo pipefail
-          dupes=$(ls backend/migrations/ | awk -F_ '{print $1}' | sort | uniq -d)
+          # Glob-based to keep shellcheck (SC2010/SC2012) happy and handle
+          # filenames with spaces, though migrations follow `NNN_*.sql`.
+          slots=$(for f in backend/migrations/*.sql; do
+            basename "$f" | awk -F_ '{print $1}'
+          done)
+          dupes=$(echo "$slots" | sort | uniq -d)
           if [ -n "$dupes" ]; then
             echo "::error::duplicate migration version slot(s): $dupes"
-            ls backend/migrations/ | grep -E "^($(echo "$dupes" | paste -sd'|'))_"
+            pattern=$(echo "$dupes" | paste -sd'|' -)
+            for f in backend/migrations/*.sql; do
+              name=$(basename "$f")
+              echo "$name" | grep -E "^(${pattern})_" || true
+            done
             exit 1
           fi
 

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -30,6 +30,29 @@ jobs:
             --build \
             --abort-on-container-exit
 
+      # Capture container logs and migration state when the suite fails so the
+      # auto-filed `Nightly E2E Tests Failed` issue (see Notify step below) can
+      # be triaged from the issue alone, without re-running the workflow.
+      # The 2026-05-09 failure (#1128) surfaced only the final exit code; the
+      # root-cause `_sqlx_migrations_pkey` violation took a deep log dive to
+      # find. Dumping the backend log and the migrations table on failure
+      # makes the same class of failure self-diagnosing next time.
+      - name: Dump failure diagnostics
+        if: failure()
+        run: |
+          echo "::group::backend container logs"
+          docker compose -f docker-compose.test.yml logs backend || true
+          echo "::endgroup::"
+          echo "::group::postgres container logs (last 200 lines)"
+          docker compose -f docker-compose.test.yml logs --tail=200 postgres || true
+          echo "::endgroup::"
+          echo "::group::_sqlx_migrations table"
+          docker compose -f docker-compose.test.yml exec -T postgres \
+            psql -U registry -d artifact_registry \
+            -c "SELECT version, description, success, execution_time FROM _sqlx_migrations ORDER BY version" \
+            || true
+          echo "::endgroup::"
+
       - name: Cleanup
         if: always()
         run: docker compose -f docker-compose.test.yml --profile smoke down -v --remove-orphans


### PR DESCRIPTION
## Summary

CI hygiene slice of Bundle 13. The two forward-port issues in the original bundle (#1065, #1196) are deferred because their prerequisite feature PRs (#1064 stuck-scan janitor, #1068 proxy-storage routing) have not landed on main yet, so the follow-up patches would be dead code. Details in the deferral note below.

- **#1031** -- Tier 2 integration job now runs the seven postgres-backed suites under `backend/tests/` with `-- --ignored --test-threads=1`. The list is explicit (`--test lifecycle_policy_tests`, `--test api_token_cache_flush_tests`, `--test grpc_sbom_tests`, `--test search_reindex_tests`, `--test scan_convert_to_reused_tests`, `--test virtual_members_atomicity_test`, `--test virtual_members_duplicate_test`) rather than `--test '*'` because four sibling files in `backend/tests/` (azure_rbac, azure_shared_key, s3_integration, incus_upload_tests) read live cloud creds via `std::env::var().expect()` and would panic, and four others (integration_tests, replication_integration, tag_filtered_replication_tests, storage_backend_tests) need a running HTTP backend via `TEST_BASE_URL` which the job does not provision. `--test-threads=1` because these suites share schema state through global DELETEs.

- **#1128** -- The 2026-05-09 nightly failed at backend startup with `duplicate key value violates unique constraint "_sqlx_migrations_pkey" Key (version)=(73)`. Two changes prevent and diagnose this class of failure:
  1. **Migration-slot lint** in the unit-test job fails the build if `backend/migrations/` has two files sharing the same numeric prefix. Cheap (one `awk | sort | uniq -d`), runs before the integration job and the e2e workflow, catches forward-port collisions at the PR stage.
  2. **Failure-diagnostic step** in the nightly workflow now dumps the backend container log, the last 200 lines of postgres, and the `_sqlx_migrations` table contents on failure. The auto-filed `Nightly E2E Tests Failed` issue (#1128 itself) surfaced only the final exit code; the dump makes the same class of failure self-diagnosing next time.

## Regression test (required for `fix/*` PRs)
- [x] N/A -- this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated -- N/A (CI-only changes)
- [x] Integration tests added/updated -- N/A
- [x] E2E tests added/updated -- the change IS in the E2E pipeline (this PR's `--ignored` invocation is itself the test plan for #1031, and the diagnostic step is exercised on every future failure)
- [x] Manually tested locally -- `python3 -c \"import yaml; yaml.safe_load(open(...))\"` for both YAML files; `ls backend/migrations/ | awk -F_ '{print \$1}' | sort | uniq -d` returns empty on current main; manually confirmed each cherry-picked test file's expected-env via `head -25`.
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

## Bundle 13 deferral note: #1065 and #1196 are NOT in this PR

Both forward-port issues depend on feature PRs that have not yet landed on `main`:

- **#1196** depends on **#1064** (`fix(scan): reap stuck 'running' scan_results rows via background janitor` -- the janitor itself). `cleanup_stuck_scans` does not exist in `backend/src/services/scan_result_service.rs` on main, so #1187's follow-ups (partial index, audit emission, CHANGELOG) cannot be applied -- they edit a function that has not been created. The forward-port needs to be **#1064 + #1187 together**. Reopen #1196 with the combined scope, or split into a `feat: forward-port stuck-scan janitor (#1064)` PR followed by the #1187 follow-ups.

- **#1065** depends on **#1068** (`fix(proxy): route remote repo cache I/O through per-repo backend`). #1068 was merged on release/1.1.x and then **reverted by #1079** the next day. The release/1.1.x bug it addresses (#1016) was eventually fixed there by a different approach in **#1177** (`fix(storage): map filesystem ENOENT to AppError::NotFound`). Forward-porting #1068 verbatim is not the right move; the issue should be retargeted to forward-port #1177 instead, which is much smaller (one file: `backend/src/storage/filesystem.rs`) and known-good on release/1.1.x. Recommend re-scoping #1065 accordingly.

Both findings are surfaced on the respective issues so the next session can pick them up with the correct scope. The CI hygiene work in this PR (migration-slot lint, nightly diagnostics) reduces the risk class that the forward-port work itself runs into when it lands.

Closes #1031
Closes #1128