### PR TITLE
fix(proxy): pypi/composer/docker/error-categorization (#1130, #1096, #1139, #1073)

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -227,6 +227,34 @@ async fn metadata_v2(
     })?;
 
     if artifacts.is_empty() {
+        // #1096: For remote repos, proxy the v2 metadata document from
+        // upstream when we have nothing cached locally. The composer CLI
+        // hits `/p2/{vendor}/{package}.json` as its first lookup; returning
+        // 404 here means `composer install` fails even when the upstream
+        // (packagist.org or any mirror) has the package. The proxy_service
+        // also caches the response body so subsequent requests hit the
+        // cache, matching the behaviour of the PyPI and OCI handlers.
+        if repo.repo_type == RepositoryType::Remote {
+            if let (Some(ref upstream_url), Some(ref proxy)) =
+                (&repo.upstream_url, &state.proxy_service)
+            {
+                let upstream_path = format!("p2/{}.json", full_name);
+                let (content, content_type) = proxy_helpers::proxy_fetch(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    &upstream_path,
+                )
+                .await?;
+                let ct = content_type.unwrap_or_else(|| "application/json".to_string());
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, ct)
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+        }
         return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
     }
 
@@ -300,6 +328,29 @@ async fn metadata_v1(
     })?;
 
     if artifacts.is_empty() {
+        // #1096: Also proxy the v1 metadata format for older composer
+        // clients. The upstream path mirrors the v1 URL shape (`p/`).
+        if repo.repo_type == RepositoryType::Remote {
+            if let (Some(ref upstream_url), Some(ref proxy)) =
+                (&repo.upstream_url, &state.proxy_service)
+            {
+                let upstream_path = format!("p/{}.json", full_name);
+                let (content, content_type) = proxy_helpers::proxy_fetch(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    &upstream_path,
+                )
+                .await?;
+                let ct = content_type.unwrap_or_else(|| "application/json".to_string());
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, ct)
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+        }
         return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
     }
 

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -66,6 +66,40 @@ async fn resolve_composer_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, 
 // Composer metadata helpers
 // ---------------------------------------------------------------------------
 
+/// Build the upstream path for the Composer v2 metadata document of a package.
+///
+/// The Composer v2 wire shape is `p2/{vendor}/{package}.json`. Helper-extracted
+/// so the proxy fallback in `metadata_v2` is unit-testable without spinning up
+/// a database + proxy_service (#1096).
+fn composer_v2_upstream_path(full_name: &str) -> String {
+    format!("p2/{}.json", full_name)
+}
+
+/// Build the upstream path for the Composer v1 metadata document of a package.
+///
+/// The Composer v1 wire shape is `p/{vendor}/{package}.json`. Helper-extracted
+/// for the same reason as [`composer_v2_upstream_path`] (#1096).
+fn composer_v1_upstream_path(full_name: &str) -> String {
+    format!("p/{}.json", full_name)
+}
+
+/// Build the 200 response that the metadata_v1 / metadata_v2 proxy fallback
+/// returns to the composer client. Extracted from the handler body so the
+/// response-construction path (status, content-type default, body wiring) is
+/// unit-testable without DB or proxy_service (#1096).
+///
+/// `content_type` is taken from the upstream response when present; we default
+/// to `application/json` because the composer client treats anything else as
+/// a fetch error.
+fn build_composer_proxy_response(content: Bytes, content_type: Option<String>) -> Response {
+    let ct = content_type.unwrap_or_else(|| "application/json".to_string());
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, ct)
+        .body(Body::from(content))
+        .unwrap()
+}
+
 /// Keys from composer.json that should be merged into version entries.
 const COMPOSER_METADATA_KEYS: &[&str] = &[
     "description",
@@ -238,7 +272,7 @@ async fn metadata_v2(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let upstream_path = format!("p2/{}.json", full_name);
+                let upstream_path = composer_v2_upstream_path(&full_name);
                 let (content, content_type) = proxy_helpers::proxy_fetch(
                     proxy,
                     repo.id,
@@ -247,12 +281,7 @@ async fn metadata_v2(
                     &upstream_path,
                 )
                 .await?;
-                let ct = content_type.unwrap_or_else(|| "application/json".to_string());
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(CONTENT_TYPE, ct)
-                    .body(Body::from(content))
-                    .unwrap());
+                return Ok(build_composer_proxy_response(content, content_type));
             }
         }
         return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
@@ -334,7 +363,7 @@ async fn metadata_v1(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let upstream_path = format!("p/{}.json", full_name);
+                let upstream_path = composer_v1_upstream_path(&full_name);
                 let (content, content_type) = proxy_helpers::proxy_fetch(
                     proxy,
                     repo.id,
@@ -343,12 +372,7 @@ async fn metadata_v1(
                     &upstream_path,
                 )
                 .await?;
-                let ct = content_type.unwrap_or_else(|| "application/json".to_string());
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(CONTENT_TYPE, ct)
-                    .body(Body::from(content))
-                    .unwrap());
+                return Ok(build_composer_proxy_response(content, content_type));
             }
         }
         return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
@@ -1366,5 +1390,158 @@ mod tests {
         assert_eq!(metadata["name"], "vendor/pkg");
         assert_eq!(metadata["version"], "2.0.0");
         assert_eq!(metadata["composer"]["description"], "Test");
+    }
+
+    // -----------------------------------------------------------------------
+    // Upstream path construction for remote-proxy fallback (#1096)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_composer_v2_upstream_path_simple() {
+        // The v2 wire shape is `p2/{vendor}/{package}.json` (no leading slash;
+        // proxy_service prepends the upstream base URL itself).
+        assert_eq!(
+            composer_v2_upstream_path("monolog/monolog"),
+            "p2/monolog/monolog.json"
+        );
+    }
+
+    #[test]
+    fn test_composer_v2_upstream_path_keeps_full_name_verbatim() {
+        // No re-canonicalization: a hyphen-separated package name flows
+        // through unchanged so Packagist sees the same path the client used.
+        assert_eq!(
+            composer_v2_upstream_path("symfony/http-foundation"),
+            "p2/symfony/http-foundation.json"
+        );
+    }
+
+    #[test]
+    fn test_composer_v2_upstream_path_does_not_include_leading_slash() {
+        // proxy_service::build_upstream_url joins base + "/" + path; a leading
+        // slash here would produce `https://packagist.org//p2/...` which some
+        // mirrors reject.
+        let path = composer_v2_upstream_path("acme/widget");
+        assert!(!path.starts_with('/'), "path must be relative: {}", path);
+    }
+
+    #[test]
+    fn test_composer_v1_upstream_path_simple() {
+        // The v1 wire shape is `p/{vendor}/{package}.json` (older Composer
+        // clients hit this before p2).
+        assert_eq!(
+            composer_v1_upstream_path("monolog/monolog"),
+            "p/monolog/monolog.json"
+        );
+    }
+
+    #[test]
+    fn test_composer_v1_upstream_path_keeps_full_name_verbatim() {
+        assert_eq!(
+            composer_v1_upstream_path("symfony/http-foundation"),
+            "p/symfony/http-foundation.json"
+        );
+    }
+
+    #[test]
+    fn test_composer_v1_and_v2_paths_diverge_on_p_segment() {
+        // Regression guard: the only difference between v1 and v2 in the
+        // upstream URL is the leading `p/` vs `p2/`. If a future refactor
+        // unifies the two helpers, this assertion fails loudly.
+        let v1 = composer_v1_upstream_path("vendor/pkg");
+        let v2 = composer_v2_upstream_path("vendor/pkg");
+        assert_ne!(v1, v2);
+        assert!(v1.starts_with("p/"));
+        assert!(v2.starts_with("p2/"));
+        assert!(v1.ends_with(".json"));
+        assert!(v2.ends_with(".json"));
+    }
+
+    // -----------------------------------------------------------------------
+    // build_composer_proxy_response (#1096)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_composer_proxy_response_status_is_ok() {
+        let body = Bytes::from_static(br#"{"packages":{}}"#);
+        let resp = build_composer_proxy_response(body, Some("application/json".to_string()));
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_build_composer_proxy_response_uses_upstream_content_type() {
+        // Upstream told us the body is JSON: pass that through unchanged.
+        let body = Bytes::from_static(b"{}");
+        let resp = build_composer_proxy_response(body, Some("application/json".to_string()));
+        let ct = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .expect("response must set Content-Type");
+        assert_eq!(ct.to_str().unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_build_composer_proxy_response_defaults_content_type_to_json() {
+        // Cache hits with empty metadata can land here without a content_type;
+        // default to `application/json` because the composer client treats
+        // anything else as a fetch error.
+        let body = Bytes::from_static(b"{}");
+        let resp = build_composer_proxy_response(body, None);
+        let ct = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .expect("response must set Content-Type");
+        assert_eq!(ct.to_str().unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_build_composer_proxy_response_preserves_custom_content_type() {
+        // If the upstream returns a vendor-prefixed JSON content type
+        // (some mirrors do), we must not silently rewrite it.
+        let body = Bytes::from_static(b"{}");
+        let resp = build_composer_proxy_response(
+            body,
+            Some("application/vnd.composer+json; charset=utf-8".to_string()),
+        );
+        let ct = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .expect("response must set Content-Type");
+        assert_eq!(
+            ct.to_str().unwrap(),
+            "application/vnd.composer+json; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn test_build_composer_proxy_response_empty_body_is_ok() {
+        // Upstream returned an empty body but a 200 status: pass through.
+        let resp = build_composer_proxy_response(Bytes::new(), None);
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_composer_v2_upstream_path_with_subnamespace() {
+        // Vendor namespaces with dots / numeric suffixes (e.g.
+        // `phpunit/phpunit`, `psr/log`, `aws/aws-sdk-php-v2`) must round-trip
+        // through the helper untouched.
+        assert_eq!(composer_v2_upstream_path("psr/log"), "p2/psr/log.json");
+        assert_eq!(
+            composer_v2_upstream_path("aws/aws-sdk-php-v2"),
+            "p2/aws/aws-sdk-php-v2.json"
+        );
+        assert_eq!(
+            composer_v2_upstream_path("phpunit/phpunit"),
+            "p2/phpunit/phpunit.json"
+        );
+    }
+
+    #[test]
+    fn test_composer_v1_upstream_path_with_subnamespace() {
+        assert_eq!(composer_v1_upstream_path("psr/log"), "p/psr/log.json");
+        assert_eq!(
+            composer_v1_upstream_path("aws/aws-sdk-php-v2"),
+            "p/aws/aws-sdk-php-v2.json"
+        );
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -170,11 +170,33 @@ pub fn reject_write_if_not_hosted(repo_type: &str) -> Result<(), Response> {
 /// Map a proxy service error to an HTTP error response.
 ///
 /// `NotFound` errors become 404; everything else becomes 502 Bad Gateway.
-/// The error is logged at `warn` level with the repo key and path for context.
+///
+/// Log-level discipline (#1139): an upstream 404 (`AppError::NotFound`) is
+/// **normal proxy traffic**, not a failure of artifact-keeper. Docker / OCI
+/// clients routinely probe for tags that do not exist (`:latest` for a project
+/// that only publishes versioned tags), and PyPI / npm clients probe optional
+/// metadata files (`.metadata`, `.sig`) the same way. Logging those at WARN
+/// floods operators with false-positive alerts and reads as "the proxy is
+/// broken" when the proxy is in fact doing its job correctly.
+///
+/// * **`NotFound`** is logged at `info` with wording that names the cause
+///   (upstream returned 404). Operators triaging "why is my mirror not
+///   working" see immediately that the upstream does not have the requested
+///   artifact, not that artifact-keeper malfunctioned.
+/// * **`Validation`** stays at `warn` because it indicates a malformed path
+///   (often a probe / attack attempt the path-traversal guard rejected).
+/// * **Everything else** (timeouts, TLS errors, 5xx, auth challenge parse
+///   failures, body read errors) stays at `warn` because those genuinely
+///   warrant operator attention.
 fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Response {
-    tracing::warn!("Proxy fetch failed for {}/{}: {}", repo_key, path, e);
     match &e {
         crate::error::AppError::NotFound(_) => {
+            tracing::info!(
+                repo_key = %repo_key,
+                path = %path,
+                "Upstream returned 404 (artifact or tag does not exist): {}",
+                e
+            );
             (StatusCode::NOT_FOUND, "Artifact not found upstream").into_response()
         }
         // AppError::Validation here means the request path failed
@@ -185,13 +207,27 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
         // letting an attacker enumerate which characters/segments are
         // blocked.
         crate::error::AppError::Validation(_) => {
+            tracing::warn!(
+                repo_key = %repo_key,
+                path = %path,
+                "Proxy rejected request path: {}",
+                e
+            );
             (StatusCode::BAD_REQUEST, "Invalid artifact path").into_response()
         }
-        _ => (
-            StatusCode::BAD_GATEWAY,
-            format!("Failed to fetch from upstream: {}", e),
-        )
-            .into_response(),
+        _ => {
+            tracing::warn!(
+                repo_key = %repo_key,
+                path = %path,
+                "Proxy fetch failed: {}",
+                e
+            );
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("Failed to fetch from upstream: {}", e),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -1791,6 +1827,21 @@ mod tests {
         );
         let response = map_proxy_error("repo-key", "pkg", err);
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // #1139 regression: upstream-404 must still resolve to a 404 response.
+    // The log-level change (`warn` -> `info` with re-worded message) is a
+    // behavioural change visible to operators only; the API contract for the
+    // OCI / PyPI / generic-proxy client is unchanged. This guards against an
+    // accidental re-routing of NotFound through the 502 branch.
+    #[test]
+    fn test_map_proxy_error_not_found_still_returns_404_after_logging_rework() {
+        let err = crate::error::AppError::NotFound(
+            "Artifact not found at upstream: https://ghcr.io/v2/example/manifests/latest"
+                .to_string(),
+        );
+        let response = map_proxy_error("ghcr", "v2/example/manifests/latest", err);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     // ── RepoInfo::storage_location tests ───────────────────────────────

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1455,6 +1455,50 @@ mod tests {
         assert_eq!(path, "simple/flask/Flask-3.0.0.tar.gz");
     }
 
+    #[test]
+    fn test_pypi_upstream_bare_simple_collapses_to_root() {
+        // Edge case: configured upstream is literally "/simple" — strip the
+        // suffix and substitute "/" so build_upstream_url has a non-empty
+        // base to operate on. Exercises the `if base.is_empty()` branch.
+        let (url, path) = pypi_upstream_url_and_path("/simple", "flask/");
+        assert_eq!(url, "/");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_bare_simple_with_trailing_slash_collapses_to_root() {
+        let (url, path) = pypi_upstream_url_and_path("/simple/", "flask/");
+        assert_eq!(url, "/");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_strips_leading_slash_from_tail() {
+        // Tail with a stray leading slash should not produce `simple//flask/`.
+        let (url, path) = pypi_upstream_url_and_path("https://pypi.org", "/flask/");
+        assert_eq!(url, "https://pypi.org");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_simple_substring_not_stripped() {
+        // `simple-index` ends with `simple` substring but NOT the `/simple`
+        // path segment, so it must not be stripped.
+        let (url, path) =
+            pypi_upstream_url_and_path("https://mirror.example.com/pypi-simple-index", "flask/");
+        assert_eq!(url, "https://mirror.example.com/pypi-simple-index");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_multiple_trailing_slashes_handled() {
+        // trim_end_matches('/') strips all trailing slashes; the resulting
+        // URL must still strip the `/simple` segment correctly.
+        let (url, path) = pypi_upstream_url_and_path("https://pypi.org/simple///", "flask/");
+        assert_eq!(url, "https://pypi.org");
+        assert_eq!(path, "simple/flask/");
+    }
+
     // -----------------------------------------------------------------------
     // normalize_pep503
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -89,6 +89,44 @@ fn normalize_pep503(name: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Upstream URL normalization for the PEP 503 simple index
+// ---------------------------------------------------------------------------
+
+/// Build the upstream path for a PyPI Simple-API request without duplicating
+/// the `simple/` segment when the configured upstream URL already ends in
+/// `/simple` or `/simple/` (issue #1130).
+///
+/// The PyPI Simple API canonically lives at `https://pypi.org/simple/`. Users
+/// reasonably copy that URL verbatim into the remote-repo "upstream URL"
+/// field. The handler also conventionally prefixes `simple/{project}/` onto
+/// the proxied path, producing requests like
+/// `https://pypi.org/simple/simple/{project}/` which return 404. Detect the
+/// suffix and emit `{project}/` (or `{project}/{filename}`) instead.
+///
+/// `tail` is the relative portion below the `simple/` segment (e.g.
+/// `flask/`, `flask/Flask-3.0.0-py3-none-any.whl`). Callers must NOT include
+/// the leading `simple/` themselves.
+///
+/// Returns `(adjusted_upstream_url, upstream_path)`. The URL has any trailing
+/// `/simple` or `/simple/` stripped so [`crate::services::proxy_service::ProxyService::build_upstream_url`]
+/// (which trims one trailing slash on the base and joins with `/`) produces
+/// a single `simple/` segment in the final outbound URL.
+fn pypi_upstream_url_and_path(upstream_url: &str, tail: &str) -> (String, String) {
+    let trimmed_url = upstream_url.trim_end_matches('/');
+    let tail = tail.trim_start_matches('/');
+    if let Some(base) = trimmed_url.strip_suffix("/simple") {
+        let normalized = if base.is_empty() {
+            "/".to_string()
+        } else {
+            base.to_string()
+        };
+        (normalized, format!("simple/{}", tail))
+    } else {
+        (upstream_url.to_string(), format!("simple/{}", tail))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Internal struct used to decouple DB query results from response rendering.
 // ---------------------------------------------------------------------------
 
@@ -276,12 +314,13 @@ async fn simple_project(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let upstream_path = format!("simple/{}/", normalized);
+                let (effective_upstream, upstream_path) =
+                    pypi_upstream_url_and_path(upstream_url, &format!("{}/", normalized));
                 let (content, content_type) = proxy_helpers::proxy_fetch(
                     proxy,
                     repo.id,
                     &repo_key,
-                    upstream_url,
+                    &effective_upstream,
                     &upstream_path,
                 )
                 .await?;
@@ -306,7 +345,9 @@ async fn simple_project(
         // For virtual repos, iterate through members in priority order.
         // Local/staging members are queried via DB; remote members use proxy.
         if repo.repo_type == RepositoryType::Virtual {
-            let upstream_path = format!("simple/{}/", normalized);
+            // Per-member upstream_url adjustment happens inside the loop below
+            // so each remote member can carry its own `…/simple` suffix without
+            // polluting siblings.
             let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
 
             if members.is_empty() {
@@ -372,11 +413,13 @@ async fn simple_project(
                     continue;
                 };
 
+                let (effective_upstream, upstream_path) =
+                    pypi_upstream_url_and_path(upstream_url, &format!("{}/", normalized));
                 let result = proxy_helpers::proxy_fetch(
                     proxy,
                     member.id,
                     &member.key,
-                    upstream_url,
+                    &effective_upstream,
                     &upstream_path,
                 )
                 .await;
@@ -766,10 +809,20 @@ async fn fetch_from_pypi_remote(
 ) -> Result<Bytes, Response> {
     let normalized = PypiHandler::normalize_name(project);
 
-    let index_path = format!("simple/{}/", normalized);
-    let (index_bytes, _ct, effective_url) =
-        proxy_helpers::proxy_fetch_uncached(proxy, repo_id, repo_key, upstream_url, &index_path)
-            .await?;
+    // Strip a trailing `/simple` from the configured upstream URL so we do
+    // not produce `https://pypi.org/simple/simple/{project}/` when the user
+    // copies the canonical Simple-API base verbatim into the repo config
+    // (issue #1130).
+    let (effective_upstream, index_path) =
+        pypi_upstream_url_and_path(upstream_url, &format!("{}/", normalized));
+    let (index_bytes, _ct, effective_url) = proxy_helpers::proxy_fetch_uncached(
+        proxy,
+        repo_id,
+        repo_key,
+        &effective_upstream,
+        &index_path,
+    )
+    .await?;
 
     let index_html = String::from_utf8_lossy(&index_bytes);
 
@@ -781,10 +834,9 @@ async fn fetch_from_pypi_remote(
     let file_url = find_upstream_url_for_file(&index_html, filename, Some(&full_index_url));
 
     let fallback = || {
-        (
-            upstream_url.to_string(),
-            format!("simple/{}/{}", normalized, filename),
-        )
+        let (base, path) =
+            pypi_upstream_url_and_path(upstream_url, &format!("{}/{}", normalized, filename));
+        (base, path)
     };
 
     // Validate resolved URL against SSRF before making the outbound request.
@@ -1361,6 +1413,47 @@ fn rewrite_upstream_urls(html: &str, repo_key: &str, project: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // pypi_upstream_url_and_path (#1130)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pypi_upstream_strips_trailing_simple() {
+        let (url, path) = pypi_upstream_url_and_path("https://pypi.org/simple/", "flask/");
+        assert_eq!(url, "https://pypi.org");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_strips_trailing_simple_no_slash() {
+        let (url, path) = pypi_upstream_url_and_path("https://pypi.org/simple", "flask/");
+        assert_eq!(url, "https://pypi.org");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_keeps_non_simple_url() {
+        let (url, path) = pypi_upstream_url_and_path("https://pypi.org", "flask/");
+        assert_eq!(url, "https://pypi.org");
+        assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_keeps_devpi_path() {
+        let (url, path) =
+            pypi_upstream_url_and_path("https://devpi.example.com/root/pypi", "numpy/");
+        assert_eq!(url, "https://devpi.example.com/root/pypi");
+        assert_eq!(path, "simple/numpy/");
+    }
+
+    #[test]
+    fn test_pypi_upstream_trailing_simple_with_file() {
+        let (url, path) =
+            pypi_upstream_url_and_path("https://pypi.org/simple/", "flask/Flask-3.0.0.tar.gz");
+        assert_eq!(url, "https://pypi.org");
+        assert_eq!(path, "simple/flask/Flask-3.0.0.tar.gz");
+    }
 
     // -----------------------------------------------------------------------
     // normalize_pep503

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -30,16 +30,41 @@ impl FilesystemStorage {
         }
     }
 
-    /// Get full path for a key (using first 2 chars as subdirectory for distribution).
+    /// Get full path for a key.
     ///
     /// Keys are sanitized to prevent path traversal: only normal path components
     /// are kept, stripping `..`, `/`, and other special components.
+    ///
+    /// Two layouts are supported, selected by whether the key already encodes
+    /// a directory hierarchy:
+    ///
+    /// * **Hierarchical keys** (containing `/`, e.g. `proxy-cache/repo/path/__content__`,
+    ///   `maven/org/example/.../file.jar`): written under `base_path` verbatim.
+    ///   The key's own path segments provide directory distribution, and adding a
+    ///   2-char shard prefix on top of that produced the bug behind #1073, where
+    ///   `put_stream` (via `StorageService::FilesystemBackend`) and `get` (via this
+    ///   backend) ended up writing to and reading from different directories for
+    ///   the same proxy-cache key.
+    /// * **Flat keys** (no `/`, e.g. a bare sha256 hash `916f0027...`): written
+    ///   under a 2-char prefix subdirectory so a single directory does not accumulate
+    ///   millions of entries. This is the original behaviour and is preserved for
+    ///   the legacy hash-key callers.
     fn key_to_path(&self, key: &str) -> PathBuf {
         let sanitized: PathBuf = std::path::Path::new(key)
             .components()
             .filter(|c| matches!(c, std::path::Component::Normal(_)))
             .collect();
         let sanitized_str = sanitized.to_string_lossy();
+
+        // Hierarchical keys (the key contains its own `/` separators) already
+        // distribute themselves across directories. Skip the shard prefix so
+        // path-style keys land where every other call site expects them.
+        // See #1073: proxy-cache writes went to `<base>/proxy-cache/...` while
+        // reads looked under `<base>/pr/proxy-cache/...`.
+        if sanitized.components().count() > 1 {
+            return self.base_path.join(&sanitized);
+        }
+
         let prefix = &sanitized_str[..2.min(sanitized_str.len())];
         self.base_path.join(prefix).join(&sanitized)
     }
@@ -261,29 +286,61 @@ mod tests {
     fn test_key_to_path_traversal_dot_dot() {
         let storage = FilesystemStorage::new("/data");
         let path = storage.key_to_path("../../etc/passwd");
-        // "../" components are stripped; only "etc" and "passwd" remain
+        // "../" components are stripped; only "etc" and "passwd" remain.
+        // Multi-segment hierarchical key, so no shard prefix is added.
         assert!(path.starts_with("/data"));
         assert!(!path.to_string_lossy().contains(".."));
-        assert_eq!(path, PathBuf::from("/data/et/etc/passwd"));
+        assert_eq!(path, PathBuf::from("/data/etc/passwd"));
     }
 
     #[test]
     fn test_key_to_path_absolute_key() {
         let storage = FilesystemStorage::new("/data");
         let path = storage.key_to_path("/etc/passwd");
-        // Leading "/" (RootDir component) is stripped; result stays inside base
+        // Leading "/" (RootDir component) is stripped; result stays inside base.
+        // Multi-segment hierarchical key, so no shard prefix is added.
         assert!(path.starts_with("/data"));
-        assert_eq!(path, PathBuf::from("/data/et/etc/passwd"));
+        assert_eq!(path, PathBuf::from("/data/etc/passwd"));
     }
 
     #[test]
     fn test_key_to_path_mixed_traversal() {
         let storage = FilesystemStorage::new("/data");
         let path = storage.key_to_path("maven/../../../etc/passwd");
-        // ".." components stripped, only Normal components kept
+        // ".." components stripped, only Normal components kept.
+        // Multi-segment hierarchical key, so no shard prefix is added.
         assert!(path.starts_with("/data"));
         assert!(!path.to_string_lossy().contains(".."));
-        assert_eq!(path, PathBuf::from("/data/ma/maven/etc/passwd"));
+        assert_eq!(path, PathBuf::from("/data/maven/etc/passwd"));
+    }
+
+    // #1073: proxy-cache keys must not be sharded. They already carry a
+    // hierarchical layout (`proxy-cache/<repo>/<path>/__content__`) that the
+    // proxy_service writer in `services::storage_service::FilesystemBackend`
+    // honors verbatim. Sharding under the first 2 chars made `get` look in
+    // `<base>/pr/proxy-cache/...` while the file was at `<base>/proxy-cache/...`.
+    #[test]
+    fn test_key_to_path_proxy_cache_key_not_sharded() {
+        let storage = FilesystemStorage::new("/data/storage");
+        let key = "proxy-cache/docker-hub-remote/v2/library/nginx/manifests/latest/__content__";
+        let path = storage.key_to_path(key);
+        assert_eq!(
+            path,
+            PathBuf::from(
+                "/data/storage/proxy-cache/docker-hub-remote/v2/library/nginx/manifests/latest/__content__"
+            )
+        );
+    }
+
+    #[test]
+    fn test_key_to_path_proxy_cache_meta_not_sharded() {
+        let storage = FilesystemStorage::new("/data/storage");
+        let key = "proxy-cache/pypi-remote/simple/flask/__cache_meta__.json";
+        let path = storage.key_to_path(key);
+        assert_eq!(
+            path,
+            PathBuf::from("/data/storage/proxy-cache/pypi-remote/simple/flask/__cache_meta__.json")
+        );
     }
 
     #[test]
@@ -307,10 +364,11 @@ mod tests {
     fn test_key_to_path_current_dir_traversal() {
         let storage = FilesystemStorage::new("/data");
         let path = storage.key_to_path("./secret/../passwords");
-        // "." and ".." are stripped, only "secret" and "passwords" remain
+        // "." and ".." are stripped, only "secret" and "passwords" remain.
+        // Multi-segment hierarchical key, so no shard prefix is added.
         assert!(path.starts_with("/data"));
         assert!(!path.to_string_lossy().contains(".."));
-        assert_eq!(path, PathBuf::from("/data/se/secret/passwords"));
+        assert_eq!(path, PathBuf::from("/data/secret/passwords"));
     }
 
     #[tokio::test]
@@ -325,6 +383,61 @@ mod tests {
 
         let retrieved = storage.get(key).await.unwrap();
         assert_eq!(retrieved, content);
+    }
+
+    // #1073 regression: a proxy-cache key written by the un-sharded writer
+    // (`services::storage_service::FilesystemBackend`) must be readable by
+    // this backend's `get`. Before the fix, this backend sharded the key
+    // under the first 2 chars and looked in `<base>/pr/proxy-cache/...`,
+    // missing the file that lived at `<base>/proxy-cache/...`.
+    #[tokio::test]
+    async fn test_proxy_cache_key_readable_at_unsharded_path() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        // Simulate what the proxy writer puts on disk: file at
+        // `<base>/proxy-cache/<repo>/<path>/__content__` with no shard prefix.
+        let key = "proxy-cache/docker-hub-remote/v2/library/nginx/manifests/latest/__content__";
+        let on_disk = temp_dir
+            .path()
+            .join("proxy-cache/docker-hub-remote/v2/library/nginx/manifests/latest/__content__");
+        tokio::fs::create_dir_all(on_disk.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&on_disk, b"manifest body").await.unwrap();
+
+        // Reader path must resolve to the same on-disk location.
+        let bytes = storage.get(key).await.expect("get must find file");
+        assert_eq!(bytes.as_ref(), b"manifest body");
+    }
+
+    // #1073 regression: roundtrip via this backend's own put/get for a
+    // proxy-cache key. With sharding still enabled this previously wrote to
+    // `<base>/pr/proxy-cache/...` (matching the get path), but the bug was
+    // that the *writer* in `services::storage_service::FilesystemBackend`
+    // didn't shard. Today both paths land at `<base>/proxy-cache/...`.
+    #[tokio::test]
+    async fn test_proxy_cache_key_roundtrip_unsharded() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "proxy-cache/pypi-remote/simple/flask/__content__";
+        storage
+            .put(key, Bytes::from_static(b"index html"))
+            .await
+            .unwrap();
+
+        let expected_path = temp_dir
+            .path()
+            .join("proxy-cache/pypi-remote/simple/flask/__content__");
+        assert!(
+            expected_path.exists(),
+            "proxy-cache key must land at unsharded path; expected {} to exist",
+            expected_path.display()
+        );
+
+        let bytes = storage.get(key).await.unwrap();
+        assert_eq!(bytes.as_ref(), b"index html");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Bundle four independent remote-proxy bug fixes that all touch the error-handling and storage path the proxy hits on cache miss. Reviewers see the whole picture once.

- **#1130 PyPI Simple Remote**: strip a trailing `/simple` from the configured upstream URL before prefixing `simple/{pkg}/`. Users who copy the canonical `https://pypi.org/simple/` base into the repo config no longer see `https://pypi.org/simple/simple/<pkg>/` go out the wire and 404.
- **#1096 Composer Remote 404**: `/p2/{vendor}/{package}.json` and `/p/{vendor}/{package_hash}.json` now proxy upstream on cache miss instead of returning 404 unconditionally. The composer CLI can now resolve packagist.org packages through a remote-type composer repo on first install.
- **#1139 Upstream-404 log re-categorization**: `map_proxy_error` no longer emits `WARN "Proxy fetch failed"` for upstream 404. It logs at `INFO` with `"Upstream returned 404 (artifact or tag does not exist)"`. `WARN` stays for actual proxy malfunctions (timeouts, TLS, 5xx, auth challenge parse failures). HTTP response contract is unchanged.
- **#1073 Docker proxy-cache scan failure**: `storage::filesystem::FilesystemStorage::key_to_path` no longer applies its 2-char shard prefix to hierarchical keys. Sharding is for flat hash keys; proxy-cache keys already encode their own hierarchy. Before the fix, proxy writes landed at `<base>/proxy-cache/...` (un-sharded writer) while reads looked under `<base>/pr/proxy-cache/...`, so scans of proxy-cached Docker artifacts always failed with ENOENT despite the file existing on disk.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Eight regression tests across three files. `filesystem.rs` adds `test_proxy_cache_key_readable_at_unsharded_path` and `test_proxy_cache_key_roundtrip_unsharded`, which would have failed on `main` because the get path went under `pr/...`. `pypi.rs` adds five tests covering the trailing-`/simple` detection helper. `proxy_helpers.rs` asserts that the upstream-404 path still returns a 404 status after the log-level rework.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full backend lib suite: `9166 passed; 0 failed; 2 ignored`. `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` both clean. `jscpd` duplication on `backend/src` came in at 3.17% on this branch vs. 4.38% on `origin/main`, so duplication trended down with the new tests.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #1130
Closes #1096
Closes #1139
Closes #1073