### PR TITLE
feat(proxy): ETag-based integrity revalidation on fast path (#1051)

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -287,6 +287,14 @@ pub struct CacheMetadata {
     /// means revalidation is skipped (filesystem backend or legacy
     /// sidecar written before this field existed); `#[serde(default)]`
     /// preserves wire-compat with pre-#1051 sidecars.
+    ///
+    /// Trust boundary: the pin lives in a JSON sidecar at the cache
+    /// metadata key with no integrity binding. An actor that can write
+    /// to the storage backend can rewrite both the body and the sidecar
+    /// in lockstep, defeating tamper detection. Treat this as a defense
+    /// against accidental upstream-vs-cache divergence, not against an
+    /// adversary with storage-write capability. A sidecar HMAC is the
+    /// natural hardening if that threat model becomes relevant.
     #[serde(default)]
     pub storage_etag: Option<String>,
     /// When the cache entry expires

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -201,24 +201,12 @@ fn tee_upstream_to_cache(
         match put_result {
             Ok(result) => {
                 let now = Utc::now();
-                // Pin the storage backend's ETag at write time so the fast
-                // path can re-HEAD on each hit and detect tampering /
-                // backend-side replacement (#1051). Best-effort: if the
-                // backend errors on the HEAD or returns no ETag (e.g.
-                // filesystem) we fall back to `None`, which makes the
-                // freshness probe skip revalidation rather than fail the
-                // cache write.
-                let storage_etag = storage_clone
-                    .head_etag(&cache_key_for_writer)
-                    .await
-                    .unwrap_or_else(|e| {
-                        tracing::debug!(
-                            cache_key = %cache_key_for_writer,
-                            error = %e,
-                            "head_etag after put_stream failed; skipping fast-path revalidation pin"
-                        );
-                        None
-                    });
+                // Pin the storage backend's ETag at write time so the
+                // fast path can re-HEAD on each hit and detect tampering
+                // / backend-side replacement (#1051). See [`pin_storage_etag`]
+                // for the best-effort semantics on backends without an
+                // ETag concept or on transport error.
+                let storage_etag = pin_storage_etag(&storage_clone, &cache_key_for_writer).await;
                 let metadata = CacheMetadata {
                     cached_at: now,
                     upstream_etag: template.etag,
@@ -293,19 +281,12 @@ pub struct CacheMetadata {
     pub cached_at: DateTime<Utc>,
     /// ETag from upstream (if available)
     pub upstream_etag: Option<String>,
-    /// ETag the storage backend reported for the cached object at write
-    /// time, used by the fast-path integrity revalidation in
-    /// [`ProxyService::is_cache_fresh`] (#1051). On each fast-path hit we
-    /// re-HEAD the object and compare ETags; a mismatch means the object
-    /// was replaced or tampered with since we cached it, and we fall
-    /// through to the slow path (which recomputes the SHA-256 and
-    /// self-heals).
-    ///
-    /// `None` when the backend did not surface an ETag (filesystem,
-    /// older cache entries written before this field existed). In that
-    /// case revalidation is a no-op and the cache behaves as it did
-    /// pre-#1051. `#[serde(default)]` lets us load metadata sidecars
-    /// written by older builds without breaking the cache.
+    /// ETag pinned from the storage backend at cache-write time. See
+    /// [`ProxyService::is_cache_fresh`] for the revalidation contract,
+    /// per-backend behavior, and the legacy-entry fall-through. `None`
+    /// means revalidation is skipped (filesystem backend or legacy
+    /// sidecar written before this field existed); `#[serde(default)]`
+    /// preserves wire-compat with pre-#1051 sidecars.
     #[serde(default)]
     pub storage_etag: Option<String>,
     /// When the cache entry expires
@@ -331,6 +312,25 @@ struct RegistryTokenResponse {
     token: Option<String>,
     access_token: Option<String>,
     expires_in: Option<u64>,
+}
+
+/// Best-effort fetch of the backend's ETag for a freshly-written cache
+/// object, used by both the streaming-tee and buffered cache-write paths
+/// to pin [`CacheMetadata::storage_etag`] (#1051).
+///
+/// Returns `None` on either `Ok(None)` (backend has no ETag concept) or
+/// transport error; the caller then writes the sidecar without a pin and
+/// fast-path revalidation falls back to pre-#1051 existence-only
+/// semantics for that entry.
+async fn pin_storage_etag(storage: &StorageService, cache_key: &str) -> Option<String> {
+    storage.head_etag(cache_key).await.unwrap_or_else(|e| {
+        tracing::debug!(
+            cache_key = %cache_key,
+            error = %e,
+            "head_etag after cache write failed; skipping fast-path revalidation pin"
+        );
+        None
+    })
 }
 
 /// Proxy service for fetching and caching artifacts from upstream repositories
@@ -1394,16 +1394,10 @@ impl ProxyService {
 
         // Best-effort: capture the backend's ETag right after the PUT so
         // the fast path can re-HEAD on each hit and reject tampered or
-        // replaced objects. A failure here only disables revalidation for
-        // this entry; the cache write itself still succeeds.
-        let storage_etag = self.storage.head_etag(cache_key).await.unwrap_or_else(|e| {
-            tracing::debug!(
-                cache_key = %cache_key,
-                error = %e,
-                "head_etag after buffered put failed; skipping fast-path revalidation pin"
-            );
-            None
-        });
+        // replaced objects. See [`pin_storage_etag`] for the failure
+        // semantics; a failure here only disables revalidation for this
+        // entry, the cache write itself still succeeds.
+        let storage_etag = pin_storage_etag(&self.storage, cache_key).await;
 
         // Create metadata
         let now = Utc::now();
@@ -2998,21 +2992,24 @@ mod tests {
         head_etag_calls: AtomicUsize,
     }
 
-    /// What the mock's `head_etag` should return per call.
+    /// What the mock's `head_etag` should return per call. Variant
+    /// names deliberately avoid `None` / `Some` / `Err` so callsite
+    /// literals don't visually collide with the `Option`/`Result` the
+    /// trait method returns.
     enum HeadEtagBehavior {
         /// Return `Ok(None)`. Models backends that do not surface ETags
         /// (filesystem) or objects without one.
-        None,
+        Absent,
         /// Return `Ok(Some(value))`. Models S3/GCS/Azure happy path.
-        Some(String),
+        Present(String),
         /// Return `Err(AppError::Storage(...))`. Models a transport
         /// failure during revalidation.
-        Err,
+        Failed,
     }
 
     impl CacheFreshMock {
         fn new(metadata: Option<Bytes>, content_exists: bool) -> Self {
-            Self::with_head_etag(metadata, content_exists, HeadEtagBehavior::None)
+            Self::with_head_etag(metadata, content_exists, HeadEtagBehavior::Absent)
         }
 
         fn with_head_etag(
@@ -3062,9 +3059,9 @@ mod tests {
         async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
             self.head_etag_calls.fetch_add(1, AtomicOrdering::SeqCst);
             match &self.head_etag_value {
-                HeadEtagBehavior::None => Ok(None),
-                HeadEtagBehavior::Some(v) => Ok(Some(v.clone())),
-                HeadEtagBehavior::Err => {
+                HeadEtagBehavior::Absent => Ok(None),
+                HeadEtagBehavior::Present(v) => Ok(Some(v.clone())),
+                HeadEtagBehavior::Failed => {
                     Err(AppError::Storage("mock head_etag failure".to_string()))
                 }
             }
@@ -3221,7 +3218,7 @@ mod tests {
                 "\"deadbeef\"".to_string(),
             ))),
             /* content_exists = */ true,
-            HeadEtagBehavior::Some("\"deadbeef\"".to_string()),
+            HeadEtagBehavior::Present("\"deadbeef\"".to_string()),
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
@@ -3257,7 +3254,7 @@ mod tests {
                 "\"pinned\"".to_string(),
             ))),
             /* content_exists = */ true,
-            HeadEtagBehavior::Some("\"different\"".to_string()),
+            HeadEtagBehavior::Present("\"different\"".to_string()),
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
@@ -3284,7 +3281,7 @@ mod tests {
                 "\"pinned\"".to_string(),
             ))),
             /* content_exists = */ true,
-            HeadEtagBehavior::None,
+            HeadEtagBehavior::Absent,
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
@@ -3305,7 +3302,7 @@ mod tests {
                 "\"pinned\"".to_string(),
             ))),
             /* content_exists = */ true,
-            HeadEtagBehavior::Err,
+            HeadEtagBehavior::Failed,
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
@@ -3327,7 +3324,7 @@ mod tests {
             /* content_exists = */ true,
             // Even if backend would surface an ETag, the absence of a pin
             // means revalidation is skipped entirely.
-            HeadEtagBehavior::Some("\"would-be-current\"".to_string()),
+            HeadEtagBehavior::Present("\"would-be-current\"".to_string()),
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 
@@ -3356,7 +3353,7 @@ mod tests {
         let mock = Arc::new(CacheFreshMock::with_head_etag(
             Some(fresh_metadata_bytes_with_storage_etag(None)),
             /* content_exists = */ false,
-            HeadEtagBehavior::None,
+            HeadEtagBehavior::Absent,
         ));
         let service = build_proxy_service_with_storage(mock.clone());
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -201,9 +201,28 @@ fn tee_upstream_to_cache(
         match put_result {
             Ok(result) => {
                 let now = Utc::now();
+                // Pin the storage backend's ETag at write time so the fast
+                // path can re-HEAD on each hit and detect tampering /
+                // backend-side replacement (#1051). Best-effort: if the
+                // backend errors on the HEAD or returns no ETag (e.g.
+                // filesystem) we fall back to `None`, which makes the
+                // freshness probe skip revalidation rather than fail the
+                // cache write.
+                let storage_etag = storage_clone
+                    .head_etag(&cache_key_for_writer)
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::debug!(
+                            cache_key = %cache_key_for_writer,
+                            error = %e,
+                            "head_etag after put_stream failed; skipping fast-path revalidation pin"
+                        );
+                        None
+                    });
                 let metadata = CacheMetadata {
                     cached_at: now,
                     upstream_etag: template.etag,
+                    storage_etag,
                     expires_at: now + chrono::Duration::seconds(template.ttl_secs),
                     content_type: template.content_type,
                     size_bytes: result.bytes_written as i64,
@@ -274,6 +293,21 @@ pub struct CacheMetadata {
     pub cached_at: DateTime<Utc>,
     /// ETag from upstream (if available)
     pub upstream_etag: Option<String>,
+    /// ETag the storage backend reported for the cached object at write
+    /// time, used by the fast-path integrity revalidation in
+    /// [`ProxyService::is_cache_fresh`] (#1051). On each fast-path hit we
+    /// re-HEAD the object and compare ETags; a mismatch means the object
+    /// was replaced or tampered with since we cached it, and we fall
+    /// through to the slow path (which recomputes the SHA-256 and
+    /// self-heals).
+    ///
+    /// `None` when the backend did not surface an ETag (filesystem,
+    /// older cache entries written before this field existed). In that
+    /// case revalidation is a no-op and the cache behaves as it did
+    /// pre-#1051. `#[serde(default)]` lets us load metadata sidecars
+    /// written by older builds without breaking the cache.
+    #[serde(default)]
+    pub storage_etag: Option<String>,
     /// When the cache entry expires
     pub expires_at: DateTime<Utc>,
     /// Content type from upstream
@@ -382,21 +416,34 @@ impl ProxyService {
     ///
     /// The fast path that this probe gates (presigned redirect to the
     /// cached object) does **not** download the body and therefore cannot
-    /// recompute the SHA-256. It trusts the storage backend's own
-    /// integrity guarantees (S3/GCS/Azure object checksums, ETags,
-    /// versioning, etc.). Concretely:
+    /// recompute the SHA-256. As of #1051 it does, however, perform an
+    /// ETag-based revalidation: we pin the storage backend's ETag at
+    /// cache-write time into [`CacheMetadata::storage_etag`] and re-HEAD
+    /// on every fast-path hit. A mismatch (object replaced, tampered, or
+    /// restored from a different version) returns `false` here so the
+    /// caller drops into the slow path, which then recomputes the SHA-256
+    /// and self-heals the cache.
     ///
-    ///   * a SHA-mismatched cache entry served via a presigned URL will
-    ///     **not** be detected or healed until either (a) the next slow-path
-    ///     access of the same key, or (b) the cache TTL expires and the
-    ///     entry is refreshed from upstream;
-    ///   * this matches existing presign+redirect semantics elsewhere in
-    ///     the codebase — presigned URLs have always trusted the storage
-    ///     backend, the proxy cache is no different.
+    /// Per-backend behavior:
     ///
-    /// ETag-based revalidation on the fast path is a deliberate follow-up
-    /// (not implemented here) so the #1018 fix stays scoped to "do not
-    /// buffer the body".
+    ///   * **S3 / GCS / Azure**: ETag is the backend's per-object value.
+    ///     For S3 single-part PUTs this equals the MD5 of the body and
+    ///     gives cryptographic-grade replacement detection; for multipart
+    ///     uploads it is an opaque per-upload identifier that still
+    ///     changes on any rewrite. Both are sufficient for tamper
+    ///     detection in the cache-poisoning threat model.
+    ///   * **Filesystem**: no native ETag. `storage_etag` is `None` for
+    ///     these entries, revalidation is a no-op, and behavior matches
+    ///     pre-#1051 semantics — i.e. the local filesystem is the trust
+    ///     boundary.
+    ///   * **Legacy cache entries** written before #1051 have
+    ///     `storage_etag = None` via `#[serde(default)]`. They also skip
+    ///     revalidation; once the TTL expires and the entry is rewritten
+    ///     the new entry picks up an ETag.
+    ///
+    /// If the HEAD itself errors (transport failure mid-revalidation), we
+    /// treat the cache as not-fresh and fall through to the slow path
+    /// rather than silently serving a possibly-stale URL.
     pub async fn is_cache_fresh(&self, repo_key: &str, path: &str) -> bool {
         // A path that fails validation cannot have produced a cache entry
         // we'd want to redirect to anyway: treat it as a miss so the caller
@@ -415,9 +462,46 @@ impl ProxyService {
         if Utc::now() > metadata.expires_at {
             return false;
         }
-        // exists() is a HEAD-equivalent on cloud backends and does not pull
-        // the object body into memory.
-        matches!(self.storage.exists(&cache_key).await, Ok(true))
+
+        // ETag-based integrity revalidation (#1051). Only meaningful when
+        // we have a pinned ETag from cache-write time AND the backend
+        // surfaces an ETag now. Either side being `None` falls back to
+        // pre-#1051 behavior (existence check only): filesystem entries
+        // and legacy sidecars are unaffected.
+        match metadata.storage_etag {
+            Some(ref pinned) => match self.storage.head_etag(&cache_key).await {
+                Ok(Some(current)) => {
+                    if current != *pinned {
+                        tracing::warn!(
+                            cache_key = %cache_key,
+                            pinned_etag = %pinned,
+                            current_etag = %current,
+                            "proxy cache ETag mismatch on fast-path revalidation; falling back to slow path"
+                        );
+                        return false;
+                    }
+                    // ETag matched → object is present and unchanged
+                    // since cache write. Skip the redundant exists() call.
+                    true
+                }
+                // Backend lost the object (None) or errored: treat as
+                // not-fresh. The slow path will re-fetch and re-cache.
+                Ok(None) => false,
+                Err(e) => {
+                    tracing::warn!(
+                        cache_key = %cache_key,
+                        error = %e,
+                        "proxy cache head_etag failed during revalidation; treating as not fresh"
+                    );
+                    false
+                }
+            },
+            None => {
+                // No pinned ETag (filesystem / legacy entry). Preserve
+                // pre-#1051 semantics: existence check only.
+                matches!(self.storage.exists(&cache_key).await, Ok(true))
+            }
+        }
     }
 
     /// Fetch artifact from upstream, but use `cache_path` instead of
@@ -1304,19 +1388,34 @@ impl ProxyService {
         // Calculate checksum
         let checksum = StorageService::calculate_hash(content);
 
+        // Store content first so we can read the backend's ETag back for
+        // the integrity-revalidation pin (#1051).
+        self.storage.put(cache_key, content.clone()).await?;
+
+        // Best-effort: capture the backend's ETag right after the PUT so
+        // the fast path can re-HEAD on each hit and reject tampered or
+        // replaced objects. A failure here only disables revalidation for
+        // this entry; the cache write itself still succeeds.
+        let storage_etag = self.storage.head_etag(cache_key).await.unwrap_or_else(|e| {
+            tracing::debug!(
+                cache_key = %cache_key,
+                error = %e,
+                "head_etag after buffered put failed; skipping fast-path revalidation pin"
+            );
+            None
+        });
+
         // Create metadata
         let now = Utc::now();
         let metadata = CacheMetadata {
             cached_at: now,
             upstream_etag: etag,
+            storage_etag,
             expires_at: now + chrono::Duration::seconds(ttl_secs),
             content_type,
             size_bytes: content.len() as i64,
             checksum_sha256: checksum.clone(),
         };
-
-        // Store content
-        self.storage.put(cache_key, content.clone()).await?;
 
         // Store metadata
         let metadata_json = serde_json::to_vec(&metadata)?;
@@ -2075,6 +2174,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: Utc::now(),
             upstream_etag: Some("\"abc123\"".to_string()),
+            storage_etag: None,
             expires_at: Utc::now() + chrono::Duration::hours(24),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: 1024,
@@ -2095,6 +2195,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: now,
             upstream_etag: None,
+            storage_etag: None,
             expires_at: now + chrono::Duration::seconds(3600),
             content_type: None,
             size_bytes: 0,
@@ -2116,6 +2217,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: now,
             upstream_etag: Some("\"etag-value\"".to_string()),
+            storage_etag: Some("\"storage-etag\"".to_string()),
             expires_at: expires,
             content_type: Some("application/json".to_string()),
             size_bytes: 4096,
@@ -2134,6 +2236,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: Utc::now(),
             upstream_etag: None,
+            storage_etag: None,
             expires_at: Utc::now() + chrono::Duration::hours(1),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: i64::MAX,
@@ -2173,6 +2276,7 @@ mod tests {
         let expired_metadata = CacheMetadata {
             cached_at: now - chrono::Duration::hours(25),
             upstream_etag: None,
+            storage_etag: None,
             expires_at: now - chrono::Duration::hours(1),
             content_type: None,
             size_bytes: 100,
@@ -2187,6 +2291,7 @@ mod tests {
         let valid_metadata = CacheMetadata {
             cached_at: now,
             upstream_etag: None,
+            storage_etag: None,
             expires_at: now + chrono::Duration::hours(23),
             content_type: None,
             size_bytes: 100,
@@ -2364,6 +2469,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: now - chrono::Duration::hours(25),
             upstream_etag: Some("\"old-etag\"".to_string()),
+            storage_etag: None,
             expires_at: now - chrono::Duration::hours(1),
             content_type: Some("application/java-archive".to_string()),
             size_bytes: 2048,
@@ -2384,6 +2490,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: now,
             upstream_etag: None,
+            storage_etag: None,
             expires_at: now + chrono::Duration::hours(23),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: 512,
@@ -2400,6 +2507,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: now - chrono::Duration::seconds(DEFAULT_CACHE_TTL_SECS + 1),
             upstream_etag: None,
+            storage_etag: None,
             expires_at: now - chrono::Duration::seconds(1),
             content_type: Some("application/gzip".to_string()),
             size_bytes: 4096,
@@ -2872,20 +2980,53 @@ mod tests {
     ///   * `metadata` is the JSON bytes returned by `get(metadata_key)`,
     ///     or `None` to simulate a missing sidecar (`AppError::NotFound`).
     ///   * `content_exists` is what `exists(content_key)` returns.
+    ///   * `head_etag_value` is what `head_etag(content_key)` returns;
+    ///     `Some(Ok(...))` returns the inner result, `None` returns
+    ///     `Ok(None)`. Used by #1051 revalidation tests to drive
+    ///     match / mismatch / error / missing paths.
     ///   * `get_calls` records every `get(...)` call so tests can assert
     ///     the body was never downloaded.
+    ///   * `exists_calls` / `head_etag_calls` let revalidation tests
+    ///     verify that the ETag fast-path short-circuits the redundant
+    ///     `exists()` call.
     struct CacheFreshMock {
         metadata: Option<Bytes>,
         content_exists: bool,
+        head_etag_value: HeadEtagBehavior,
         get_calls: AtomicUsize,
+        exists_calls: AtomicUsize,
+        head_etag_calls: AtomicUsize,
+    }
+
+    /// What the mock's `head_etag` should return per call.
+    enum HeadEtagBehavior {
+        /// Return `Ok(None)`. Models backends that do not surface ETags
+        /// (filesystem) or objects without one.
+        None,
+        /// Return `Ok(Some(value))`. Models S3/GCS/Azure happy path.
+        Some(String),
+        /// Return `Err(AppError::Storage(...))`. Models a transport
+        /// failure during revalidation.
+        Err,
     }
 
     impl CacheFreshMock {
         fn new(metadata: Option<Bytes>, content_exists: bool) -> Self {
+            Self::with_head_etag(metadata, content_exists, HeadEtagBehavior::None)
+        }
+
+        fn with_head_etag(
+            metadata: Option<Bytes>,
+            content_exists: bool,
+            head_etag_value: HeadEtagBehavior,
+        ) -> Self {
             Self {
                 metadata,
                 content_exists,
+                head_etag_value,
                 get_calls: AtomicUsize::new(0),
+                exists_calls: AtomicUsize::new(0),
+                head_etag_calls: AtomicUsize::new(0),
             }
         }
     }
@@ -2910,11 +3051,22 @@ mod tests {
             }
         }
         async fn exists(&self, key: &str) -> Result<bool> {
+            self.exists_calls.fetch_add(1, AtomicOrdering::SeqCst);
             if key.ends_with("__content__") {
                 Ok(self.content_exists)
             } else {
                 // Metadata sidecar exists iff metadata bytes are present.
                 Ok(self.metadata.is_some())
+            }
+        }
+        async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
+            self.head_etag_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            match &self.head_etag_value {
+                HeadEtagBehavior::None => Ok(None),
+                HeadEtagBehavior::Some(v) => Ok(Some(v.clone())),
+                HeadEtagBehavior::Err => {
+                    Err(AppError::Storage("mock head_etag failure".to_string()))
+                }
             }
         }
         async fn delete(&self, _key: &str) -> Result<()> {
@@ -2943,9 +3095,18 @@ mod tests {
     }
 
     fn fresh_metadata_bytes() -> Bytes {
+        fresh_metadata_bytes_with_storage_etag(None)
+    }
+
+    /// Build a fresh metadata sidecar with the supplied pinned storage
+    /// ETag. Used by #1051 revalidation tests to wire a known pin into
+    /// `is_cache_fresh` and then assert the matching / mismatching
+    /// behavior on the storage HEAD.
+    fn fresh_metadata_bytes_with_storage_etag(storage_etag: Option<String>) -> Bytes {
         let metadata = CacheMetadata {
             cached_at: Utc::now(),
             upstream_etag: None,
+            storage_etag,
             expires_at: Utc::now() + chrono::Duration::hours(1),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: 42,
@@ -2958,6 +3119,7 @@ mod tests {
         let metadata = CacheMetadata {
             cached_at: Utc::now() - chrono::Duration::hours(2),
             upstream_etag: None,
+            storage_etag: None,
             expires_at: Utc::now() - chrono::Duration::seconds(1),
             content_type: None,
             size_bytes: 0,
@@ -3033,6 +3195,205 @@ mod tests {
             1,
             "is_cache_fresh must read metadata exactly once and never the body"
         );
+    }
+
+    // =======================================================================
+    // ETag fast-path revalidation tests (#1051)
+    //
+    // The fast path pins the storage backend's ETag at cache-write time into
+    // `CacheMetadata::storage_etag`. On each hit the freshness probe must
+    // re-HEAD the object and:
+    //   * match               -> true  (object unchanged since cache write)
+    //   * mismatch            -> false (replaced/tampered; slow-path heals)
+    //   * head_etag = None    -> false (object lost since write)
+    //   * head_etag = Err     -> false (revalidation failed; fail closed)
+    //   * legacy (no pin)     -> existence-only behavior (pre-#1051 entries)
+    // The matched-ETag path must also skip the redundant `exists()` call.
+    // =======================================================================
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_true_when_storage_etag_matches_pin() {
+        // Metadata pins a known storage ETag; backend reports the same
+        // value on HEAD. Revalidation must pass and short-circuit the
+        // redundant exists() probe.
+        let mock = Arc::new(CacheFreshMock::with_head_etag(
+            Some(fresh_metadata_bytes_with_storage_etag(Some(
+                "\"deadbeef\"".to_string(),
+            ))),
+            /* content_exists = */ true,
+            HeadEtagBehavior::Some("\"deadbeef\"".to_string()),
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            fresh,
+            "matching storage ETag must yield is_cache_fresh=true"
+        );
+        assert_eq!(
+            mock.head_etag_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "revalidation must HEAD the cached object exactly once"
+        );
+        assert_eq!(
+            mock.exists_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "matched-ETag path must skip the redundant exists() call"
+        );
+        assert_eq!(
+            mock.get_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "revalidation must still never download the body"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_storage_etag_mismatches_pin() {
+        // The object was rewritten (or tampered with) between cache write
+        // and this read. ETag mismatch must force the slow path.
+        let mock = Arc::new(CacheFreshMock::with_head_etag(
+            Some(fresh_metadata_bytes_with_storage_etag(Some(
+                "\"pinned\"".to_string(),
+            ))),
+            /* content_exists = */ true,
+            HeadEtagBehavior::Some("\"different\"".to_string()),
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "mismatched storage ETag must yield is_cache_fresh=false"
+        );
+        assert_eq!(
+            mock.head_etag_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "mismatch path still only HEADs once"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_storage_etag_pin_lost() {
+        // We pinned an ETag at write time but the backend now returns
+        // None for HEAD (object missing or stripped). Treat as not-fresh
+        // — the slow path will re-fetch and rewrite the cache.
+        let mock = Arc::new(CacheFreshMock::with_head_etag(
+            Some(fresh_metadata_bytes_with_storage_etag(Some(
+                "\"pinned\"".to_string(),
+            ))),
+            /* content_exists = */ true,
+            HeadEtagBehavior::None,
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "lost storage ETag with active pin must yield is_cache_fresh=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_false_when_head_etag_errors() {
+        // Backend transport error on the revalidation HEAD: fail closed.
+        // Better to slow-path than to silently serve a possibly-stale URL.
+        let mock = Arc::new(CacheFreshMock::with_head_etag(
+            Some(fresh_metadata_bytes_with_storage_etag(Some(
+                "\"pinned\"".to_string(),
+            ))),
+            /* content_exists = */ true,
+            HeadEtagBehavior::Err,
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "head_etag transport error must yield is_cache_fresh=false (fail closed)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_legacy_entry_falls_back_to_exists_check() {
+        // Cache entry written before #1051: `storage_etag = None`. Must
+        // preserve pre-#1051 behavior — existence check only, no HEAD for
+        // ETag — so legacy caches keep working without rewrite.
+        let mock = Arc::new(CacheFreshMock::with_head_etag(
+            Some(fresh_metadata_bytes_with_storage_etag(None)),
+            /* content_exists = */ true,
+            // Even if backend would surface an ETag, the absence of a pin
+            // means revalidation is skipped entirely.
+            HeadEtagBehavior::Some("\"would-be-current\"".to_string()),
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            fresh,
+            "legacy entry without storage_etag pin must still yield true on existence"
+        );
+        assert_eq!(
+            mock.head_etag_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "legacy path must not waste a HEAD when no pin is available"
+        );
+        assert_eq!(
+            mock.exists_calls.load(AtomicOrdering::SeqCst),
+            1,
+            "legacy path must fall back to a single exists() probe"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_cache_fresh_legacy_entry_false_when_content_missing() {
+        // Legacy entry (no pin) plus a missing content object: existence
+        // check returns false, fast path correctly declines to redirect.
+        let mock = Arc::new(CacheFreshMock::with_head_etag(
+            Some(fresh_metadata_bytes_with_storage_etag(None)),
+            /* content_exists = */ false,
+            HeadEtagBehavior::None,
+        ));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let fresh = service.is_cache_fresh("npm-proxy", "lodash").await;
+
+        assert!(
+            !fresh,
+            "legacy entry with missing content must still yield false"
+        );
+        assert_eq!(
+            mock.head_etag_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "no pin -> no revalidation HEAD"
+        );
+    }
+
+    #[test]
+    fn test_cache_metadata_legacy_sidecar_deserializes_without_storage_etag() {
+        // Sidecars written before #1051 do not include `storage_etag`.
+        // The new field must use `#[serde(default)]` so old JSON parses
+        // cleanly; otherwise the cache breaks for every existing entry on
+        // upgrade.
+        let legacy_json = r#"{
+            "cached_at": "2026-01-01T00:00:00Z",
+            "upstream_etag": "\"upstream-abc\"",
+            "expires_at": "2099-01-01T00:00:00Z",
+            "content_type": "application/octet-stream",
+            "size_bytes": 1234,
+            "checksum_sha256": "abcd"
+        }"#;
+        let parsed: CacheMetadata = serde_json::from_str(legacy_json)
+            .expect("legacy sidecar without storage_etag must still deserialize");
+        assert!(
+            parsed.storage_etag.is_none(),
+            "legacy sidecar must default storage_etag to None"
+        );
+        assert_eq!(parsed.upstream_etag.as_deref(), Some("\"upstream-abc\""));
     }
 
     // -----------------------------------------------------------------------
@@ -3374,6 +3735,125 @@ mod tests {
             (7195..=7205).contains(&ttl_seen),
             "expected expires_at - cached_at ~= 7200s, got {}s",
             ttl_seen
+        );
+    }
+
+    /// Recording backend that surfaces a configurable `head_etag` so we
+    /// can prove the tee writer pins the backend's ETag (#1051) into
+    /// `CacheMetadata::storage_etag` right after `put_stream`.
+    struct TeeEtagBackend {
+        inner: tokio::sync::Mutex<Vec<(String, Bytes)>>,
+        etag: Option<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceStorageBackend for TeeEtagBackend {
+        async fn put(&self, key: &str, content: Bytes) -> Result<()> {
+            self.inner.lock().await.push((key.to_string(), content));
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> Result<Bytes> {
+            Err(AppError::NotFound("n/a".into()))
+        }
+        async fn exists(&self, _key: &str) -> Result<bool> {
+            Ok(false)
+        }
+        async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
+            Ok(self.etag.clone())
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _p: Option<&str>) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _s: &str, _d: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _k: &str) -> Result<u64> {
+            Ok(0)
+        }
+        async fn put_stream(
+            &self,
+            _key: &str,
+            stream: ServiceBoxStream<'static, Result<Bytes>>,
+        ) -> Result<ServicePutStreamResult> {
+            use futures::StreamExt;
+            let mut hasher = Sha256::new();
+            let mut total: u64 = 0;
+            tokio::pin!(stream);
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                hasher.update(&chunk);
+                total += chunk.len() as u64;
+            }
+            Ok(ServicePutStreamResult {
+                checksum_sha256: format!("{:x}", hasher.finalize()),
+                bytes_written: total,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tee_writer_pins_storage_etag_when_backend_surfaces_one() {
+        // When the backend reports an ETag after the streaming put, the
+        // tee writer must persist it into `CacheMetadata::storage_etag`
+        // so the next fast-path read can revalidate against it (#1051).
+        let backend = Arc::new(TeeEtagBackend {
+            inner: tokio::sync::Mutex::new(Vec::new()),
+            etag: Some("\"after-put-etag\"".to_string()),
+        });
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        let upstream = upstream_chunks(vec![b"payload"]);
+        let mut client = tee_upstream_to_cache(
+            upstream,
+            storage,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            template(),
+        );
+        while client.next().await.is_some() {}
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let writes = backend.inner.lock().await;
+        let (_, json) = writes.last().expect("metadata sidecar must be written");
+        let metadata: CacheMetadata = serde_json::from_slice(json).unwrap();
+        assert_eq!(
+            metadata.storage_etag.as_deref(),
+            Some("\"after-put-etag\""),
+            "tee writer must pin the backend's post-put ETag for fast-path revalidation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tee_writer_leaves_storage_etag_none_when_backend_has_no_etag() {
+        // Filesystem-style backends return `Ok(None)` from `head_etag`.
+        // The writer must accept that and leave `storage_etag = None` so
+        // the fast path falls back to the existence-only legacy semantics.
+        let backend = Arc::new(TeeEtagBackend {
+            inner: tokio::sync::Mutex::new(Vec::new()),
+            etag: None,
+        });
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        let upstream = upstream_chunks(vec![b"payload"]);
+        let mut client = tee_upstream_to_cache(
+            upstream,
+            storage,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            template(),
+        );
+        while client.next().await.is_some() {}
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let writes = backend.inner.lock().await;
+        let (_, json) = writes.last().expect("metadata sidecar must be written");
+        let metadata: CacheMetadata = serde_json::from_slice(json).unwrap();
+        assert!(
+            metadata.storage_etag.is_none(),
+            "no backend ETag means no pin, preserving pre-#1051 fast-path semantics"
         );
     }
 

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -38,6 +38,18 @@ pub trait StorageBackend: Send + Sync {
     /// Check if content exists
     async fn exists(&self, key: &str) -> Result<bool>;
 
+    /// Return the storage backend's opaque ETag for `key`, or `Ok(None)`
+    /// when the backend has no ETag concept (filesystem) or the object is
+    /// missing. Used by the proxy cache fast-path revalidation (#1051) to
+    /// detect tampering before signing a presigned URL. Default
+    /// implementation returns `Ok(None)` so legacy mock backends keep
+    /// compiling and the fast path simply skips revalidation, matching
+    /// pre-#1051 behavior for filesystem and test backends.
+    async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+        let _ = key;
+        Ok(None)
+    }
+
     /// Delete content by key
     async fn delete(&self, key: &str) -> Result<()>;
 
@@ -325,6 +337,9 @@ macro_rules! impl_storage_wrapper {
             async fn exists(&self, key: &str) -> Result<bool> {
                 crate::storage::StorageBackend::exists(&self.inner, key).await
             }
+            async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+                crate::storage::StorageBackend::head_etag(&self.inner, key).await
+            }
             async fn delete(&self, key: &str) -> Result<()> {
                 crate::storage::StorageBackend::delete(&self.inner, key).await
             }
@@ -493,6 +508,13 @@ impl StorageService {
     /// Check if key exists
     pub async fn exists(&self, key: &str) -> Result<bool> {
         self.backend.exists(key).await
+    }
+
+    /// Return the backend's opaque ETag for `key`. Used by the proxy
+    /// cache fast-path revalidation (#1051). See
+    /// [`StorageBackend::head_etag`] for the per-backend contract.
+    pub async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+        self.backend.head_etag(key).await
     }
 
     /// Delete content

--- a/backend/src/storage/azure.rs
+++ b/backend/src/storage/azure.rs
@@ -857,6 +857,33 @@ impl StorageBackend for AzureBackend {
         Ok(())
     }
 
+    /// Surface Azure Blob's `ETag` response header on a HEAD. Azure quotes
+    /// ETags ("0x8D..."); we return the value verbatim so equality
+    /// comparisons remain string-stable. Used by the #1051 fast-path
+    /// revalidation. Returns `Ok(None)` for a missing blob or for a
+    /// response without an `ETag` header so the freshness probe can fall
+    /// through to the slow path without surfacing a backend error.
+    async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+        let url = self.read_url(key, Duration::from_secs(60))?;
+        let response = self.authorized_head(&url).await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(AppError::Storage(format!(
+                "Azure head_etag for '{}' returned {}",
+                key,
+                response.status()
+            )));
+        }
+        let etag = response
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        Ok(etag)
+    }
+
     fn supports_redirect(&self) -> bool {
         // SAS redirect downloads require Shared Key auth
         self.config.redirect_downloads && !self.is_rbac()

--- a/backend/src/storage/gcs.rs
+++ b/backend/src/storage/gcs.rs
@@ -870,6 +870,37 @@ impl StorageBackend for GcsBackend {
         Ok(())
     }
 
+    /// Fetch the GCS object's `etag` field via the JSON metadata endpoint
+    /// (no body transfer). GCS ETags change on every object replacement,
+    /// which makes them suitable for the #1051 fast-path tamper check.
+    /// Returns `Ok(None)` for a missing object so the freshness probe can
+    /// fall through to the slow path without losing the I/O-error
+    /// distinction.
+    async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+        let url = self.object_metadata_url(key);
+        let response = self.authorized_get(&url).await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            require_success(response, "GCS head_etag failed").await?;
+            unreachable!();
+        }
+
+        // Object metadata is a small JSON blob. We only need the `etag`
+        // field; deserialize directly rather than pulling in a full schema.
+        #[derive(serde::Deserialize)]
+        struct ObjectMeta {
+            etag: Option<String>,
+        }
+        let meta: ObjectMeta = response
+            .json()
+            .await
+            .map_err(|e| AppError::Storage(format!("GCS head_etag: parse metadata json: {}", e)))?;
+        Ok(meta.etag)
+    }
+
     fn supports_redirect(&self) -> bool {
         matches!(self.auth, GcsAuthMode::ServiceAccountKey { .. }) && self.config.redirect_downloads
     }

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -62,6 +62,25 @@ pub trait StorageBackend: Send + Sync {
     /// Check if key exists
     async fn exists(&self, key: &str) -> Result<bool>;
 
+    /// Return the storage backend's opaque ETag for `key` if the backend
+    /// supports per-object ETags (S3, GCS, Azure). Returns `Ok(None)` when
+    /// the backend has no concept of an ETag (filesystem) or when the
+    /// object exists but the backend did not surface an ETag header.
+    /// Returns an error only on transport/auth failures; a missing object
+    /// is reported as `Ok(None)` so callers can distinguish "no ETag to
+    /// revalidate against" from "backend is broken".
+    ///
+    /// Used by the proxy cache fast path (#1051) to detect cache-entry
+    /// tampering or backend-side replacement before signing a presigned
+    /// URL: we pin the storage ETag at cache-write time into the metadata
+    /// sidecar, then re-HEAD on each fast-path hit and compare. A mismatch
+    /// forces a fall-through to the slow path which recomputes the SHA-256
+    /// and self-heals the cache.
+    async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+        let _ = key; // Suppress unused warning for default impl
+        Ok(None)
+    }
+
     /// Delete content by key
     async fn delete(&self, key: &str) -> Result<()>;
 

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -760,6 +760,28 @@ impl super::StorageBackend for S3Backend {
         Ok(())
     }
 
+    /// Surface S3's ETag from a HEAD on `key`. For single-part PUTs the
+    /// ETag equals the MD5 of the object; for multipart uploads it is an
+    /// opaque per-upload value. Either way the value is stable per object
+    /// version and changes if the object is overwritten, which is exactly
+    /// the integrity signal #1051's fast-path revalidation needs.
+    ///
+    /// Returns `Ok(None)` when the object is missing rather than an error,
+    /// so the freshness probe can treat "ETag unavailable" as "do not
+    /// fast-path" without losing the distinction from a real I/O failure.
+    async fn head_etag(&self, key: &str) -> Result<Option<String>> {
+        let full_key = self.full_key(key);
+        let path: ObjectPath = full_key.into();
+        match self.store.head(&path).await {
+            Ok(meta) => Ok(meta.e_tag),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(e) => Err(AppError::Storage(format!(
+                "head_etag failed for '{}': {}",
+                key, e
+            ))),
+        }
+    }
+
     fn supports_redirect(&self) -> bool {
         self.redirect_downloads
     }


### PR DESCRIPTION
## Summary
Follow-up to #1018. The fast path that serves proxy-cached artifacts via presigned redirects previously did a metadata-only freshness check and trusted the storage backend to keep the object intact. That left a window where an out-of-band replacement, restored snapshot, or tampered object would be served with no detection until the TTL expired or the same key happened to take the slow path.

This PR pins the storage backend's ETag at cache-write time into a new `CacheMetadata::storage_etag` field, then re-HEADs on every fast-path hit and compares. A mismatch (or lost ETag, or HEAD transport error) returns `false` from `is_cache_fresh` so the caller drops into the slow path, which recomputes SHA-256 and self-heals the cache. Revalidation fails closed: any uncertainty during the HEAD treats the cache as not-fresh rather than silently signing a possibly-stale URL.

Per-backend behavior:
- **S3 / GCS / Azure**: backend's per-object ETag, surfaced via a new `StorageBackend::head_etag` trait method. For S3 single-part PUTs this equals the MD5 of the body and gives cryptographic-grade replacement detection; multipart ETags still change on rewrite, sufficient for the cache-poisoning threat model.
- **Filesystem**: no native ETag, so `storage_etag` stays `None` and the legacy existence-only check applies. The local filesystem remains the trust boundary, matching pre-#1051 semantics.
- **Legacy cache entries** written before this change have `storage_etag = None` via `#[serde(default)]` and skip revalidation; they pick up an ETag the next time the entry is rewritten (post-TTL).

The matched-ETag path also short-circuits the redundant `exists()` probe since a successful HEAD already proves the object is present, so the happy path is one HEAD instead of HEAD + exists.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A, this is a hardening follow-up (feat/)

## Test Checklist
- [x] Unit tests added/updated
  - 6 new `is_cache_fresh` revalidation tests: match / mismatch / lost pin / transport error / legacy (no pin) existence / legacy + missing content
  - 2 new tee-writer tests verifying `storage_etag` is pinned when the backend surfaces an ETag and left `None` when it does not
  - Legacy sidecar deserialization test ensures pre-#1051 JSON keeps parsing after upgrade
- [ ] Integration tests added/updated (if applicable). The `cache_artifact` buffered-path pin is exercised end-to-end by the existing proxy integration tests once a real S3/MinIO is available
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally: `cargo test --workspace --lib` 9165 pass, 0 fail
- [x] No regressions in existing tests

## API Changes
- [x] N/A, no API changes

## Quality gates verified locally
- `cargo fmt --check`: clean
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- New-lines coverage gate (mirrors CI logic): 86% (210/244 instrumented new lines), above the 70% threshold
- jscpd on changed files: 0 clones, 0% duplication, under the 3% threshold

Closes #1051.