### PR TITLE
fix(ci): migrate before integration tests + correct upload test path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,41 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # The integration suites under `backend/tests/` insert into real tables
+      # (users, api_tokens, repositories, ...) via the SQLx pool. The service
+      # container above starts an empty Postgres, so we MUST apply migrations
+      # before running tests or the suites panic with `relation "users" does
+      # not exist` (regression after #1190 added api_token_cache_flush_tests
+      # to this job). Matches the `coverage` job's pattern: sqlx-cli is
+      # pre-installed on the `ak-ci-runners` image (see
+      # artifact-keeper-iac/runner-images/rust/Dockerfile).
+      - name: Wait for Postgres
+        env:
+          PGPASSWORD: registry
+        run: |
+          set -euo pipefail
+          # The service container's --health-cmd already runs pg_isready
+          # internally, but GitHub Actions starts the step before health
+          # transitions to "healthy" on slower runners. A short readiness
+          # loop from the runner side avoids a flaky first connect. Uses a
+          # plain TCP probe via bash so we do not depend on postgresql-client
+          # being installed on the runner image.
+          for i in $(seq 1 30); do
+            if (echo > /dev/tcp/localhost/5432) >/dev/null 2>&1; then
+              echo "Postgres reachable on attempt $i"
+              exit 0
+            fi
+            echo "  waiting for postgres... ($i/30)"
+            sleep 1
+          done
+          echo "ERROR: Postgres did not become reachable within 30s"
+          exit 1
+
+      - name: Run database migrations
+        env:
+          DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
+        run: sqlx migrate run --source backend/migrations
+
       # `-- --ignored` runs the postgres-backed integration suites under
       # `backend/tests/` that were silently skipped before (#1031). The job
       # provisions postgres but NOT a running HTTP backend, Meilisearch,

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -1563,19 +1563,19 @@ mod tests {
         //    key (proves we no longer use the broken "uploads/<repo_id>/..."
         //    layout, regression for #1168 part 3).
         //
-        // FilesystemStorage::key_to_path prepends the first 2 chars of the
-        // sanitized key as a sharding prefix on top of the base path, so the
-        // on-disk layout becomes `<base>/<shard>/<key>` where `<shard>` is
-        // the first 2 chars of `<hash[:2]>/<hash[2:4]>/<full-hash>` -- i.e.
-        // `hash[:2]` again. We assert the bytes land there with the right
+        // The storage key produced by `storage_key_from_checksum` is
+        // hierarchical (`<hash[:2]>/<hash[2:4]>/<full-hash>`). For hierarchical
+        // keys, `FilesystemStorage::key_to_path` does NOT prepend an extra
+        // shard prefix (see #1073): keys containing `/` already distribute
+        // themselves across directories, so the on-disk layout is simply
+        // `<base>/<key>`. We assert the bytes land there with the right
         // content, and as a safety net, also verify the legacy "uploads/..."
         // path from before #1168 does NOT exist.
         let expected_key =
             crate::services::artifact_service::ArtifactService::storage_key_from_checksum(
                 &checksum,
             );
-        let shard = &expected_key[..2];
-        let on_disk_path = f.storage_dir.join(shard).join(&expected_key);
+        let on_disk_path = f.storage_dir.join(&expected_key);
         assert!(
             on_disk_path.exists(),
             "expected hashed bytes at {} (issue #1168 part 3)",


### PR DESCRIPTION
## Summary

Two post-merge regressions on `main` after the bundle wave (#1168, #1190):

1. `test-backend-integration` provisions a fresh Postgres service but never applies migrations, so all 8 tests in `api_token_cache_flush_tests.rs` (added by #1190) panic with `relation "users" does not exist`. Apply migrations between service startup and `cargo test`, matching the pattern in the `coverage` job (`sqlx migrate run --source backend/migrations`; sqlx-cli is pre-installed on the `ak-ci-runners` image via `artifact-keeper-iac/runner-images/rust/Dockerfile`). A short TCP readiness probe handles the gap before the service container reports healthy.
2. `complete_uses_repo_scoped_storage_and_writes_to_content_addressed_key` (the #1168-part-3 regression test) asserted a double-shard path `<base>/a9/a9/b2/<hash>`. `ArtifactService::storage_key_from_checksum` already returns a hierarchical key (`a9/b2/<hash>`), and `FilesystemStorage::key_to_path` intentionally skips the 2-char shard prefix for hierarchical keys (the #1073 fix). Correct on-disk path is `<base>/a9/b2/<hash>`. Drop the extra `.join(shard)`.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A, this is not a bug fix

The existing tests in `backend/tests/api_token_cache_flush_tests.rs` and `backend/src/api/handlers/upload.rs::tests::complete_uses_repo_scoped_storage_and_writes_to_content_addressed_key` ARE the regression. They were merged broken; this PR makes them pass against `main` infrastructure.

## Test Checklist
- [x] Unit tests added/updated (upload test path corrected)
- [x] Integration tests added/updated (CI now migrates before running them)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification (ephemeral Postgres on port 35817, migrations applied):
- `cargo test --test api_token_cache_flush_tests -- --ignored --test-threads=1` -> 8 passed
- Full integration suite list from the workflow (7 suites) -> 33 passed
- `cargo test --lib ...::complete_uses_repo_scoped_storage_and_writes_to_content_addressed_key` -> 1 passed
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `actionlint .github/workflows/ci.yml` -> no new diagnostics from this change

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A, no API changes