### PR TITLE
fix(storage/s3): use multipart upload for large objects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,9 @@ STORAGE_PATH=/var/lib/artifact-keeper/artifacts
 # S3_SECRET_ACCESS_KEY=minioadmin   # falls back to AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
 # S3_REDIRECT_DOWNLOADS=false
 # S3_PRESIGN_EXPIRY_SECS=3600
+# S3_REQUEST_TIMEOUT_SECS=0         # per-request timeout; 0 = object_store ~30s
+                                    # default. Raise for slow on-prem S3.
+                                    # Objects >16 MiB use multipart regardless.
 
 # S3 presigned URL credentials (optional, overrides default AWS credentials)
 # S3_PRESIGN_ACCESS_KEY_ID=

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -20,6 +20,12 @@
 //! For HTTP connection pool tuning:
 //! - S3_POOL_MAX_IDLE_PER_HOST: Maximum idle connections per host (default: 256)
 //! - S3_POOL_IDLE_TIMEOUT_SECS: Idle connection timeout in seconds (default: 90)
+//! - S3_REQUEST_TIMEOUT_SECS: Per-request timeout in seconds. 0 (default)
+//!   keeps object_store's built-in timeout (~30s). Raise it for slow on-prem
+//!   S3 backends where a large single request legitimately takes longer.
+//!
+//! Large objects (> 16 MiB) are uploaded via S3 multipart automatically, so a
+//! single slow PUT can no longer exceed the client request timeout.
 //!
 //! For redirect downloads (302 to presigned URLs):
 //! - S3_REDIRECT_DOWNLOADS: Enable 302 redirects (default: false)
@@ -424,6 +430,35 @@ pub struct S3Backend {
     disable_multi_delete: bool,
 }
 
+/// Objects at or below this size go through a single `put`; larger objects
+/// use multipart so each part is a small request that cannot blow past the
+/// client request timeout (the original cause of `STORAGE_ERROR` on big
+/// uploads to slow S3-compatible backends).
+const S3_MULTIPART_PUT_THRESHOLD: usize = 16 * 1024 * 1024;
+
+/// Whether a buffered `put` of `len` bytes should use multipart upload.
+fn should_multipart_put(len: usize) -> bool {
+    len > S3_MULTIPART_PUT_THRESHOLD
+}
+
+/// Upload `content` as one object via S3 multipart. Each part is a small
+/// request, so a large object can no longer exceed the per-request timeout
+/// (the original large-upload failure). Generic over the store so it is
+/// unit-testable with an in-memory backend.
+async fn multipart_put(store: &dyn ObjectStore, path: &ObjectPath, content: Bytes) -> Result<()> {
+    let upload = store
+        .put_multipart(path)
+        .await
+        .map_err(|e| AppError::Storage(format!("Failed to start multipart upload: {}", e)))?;
+    let mut write = WriteMultipart::new(upload);
+    write.put(content);
+    write
+        .finish()
+        .await
+        .map_err(|e| AppError::Storage(format!("Failed to complete multipart upload: {}", e)))?;
+    Ok(())
+}
+
 impl S3Backend {
     fn build_store(
         config: &S3Config,
@@ -433,6 +468,17 @@ impl S3Backend {
         let mut client_opts = object_store::ClientOptions::new()
             .with_pool_max_idle_per_host(config.pool_max_idle_per_host)
             .with_pool_idle_timeout(Duration::from_secs(config.pool_idle_timeout_secs));
+
+        // Optional per-request timeout override. object_store's default
+        // (~30s) aborts slow large single PUTs against on-prem S3; multipart
+        // (below) fixes the common case, this is the escape hatch for the rest.
+        if let Some(secs) = std::env::var("S3_REQUEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|s| *s > 0)
+        {
+            client_opts = client_opts.with_timeout(Duration::from_secs(secs));
+        }
 
         if config
             .endpoint
@@ -783,6 +829,16 @@ impl super::StorageBackend for S3Backend {
     async fn put(&self, key: &str, content: Bytes) -> Result<()> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
+
+        // A single object_store `put` is one HTTP request bounded by the
+        // client request timeout; a slow multi-GB PUT to an on-prem S3
+        // backend exceeds it ("transport error of kind Timeout"). Large
+        // objects go through multipart so every part is a small request.
+        if should_multipart_put(content.len()) {
+            multipart_put(&self.store, &path, content).await?;
+            tracing::debug!(key = %key, "S3 multipart put object successful");
+            return Ok(());
+        }
 
         self.store.put(&path, content.into()).await.map_err(|e| {
             tracing::error!(key = %key, error = %e, "S3 put_object failed");
@@ -1166,6 +1222,70 @@ impl S3Backend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- multipart threshold ---
+
+    #[test]
+    fn test_should_multipart_put_threshold() {
+        assert!(!should_multipart_put(0));
+        assert!(!should_multipart_put(1024));
+        // Boundary: exactly at the threshold stays single-PUT.
+        assert!(!should_multipart_put(S3_MULTIPART_PUT_THRESHOLD));
+        // One byte over must switch to multipart (the regression).
+        assert!(should_multipart_put(S3_MULTIPART_PUT_THRESHOLD + 1));
+        assert!(should_multipart_put(2 * 1024 * 1024 * 1024));
+    }
+
+    // Exercises the multipart code path put() takes for large objects,
+    // offline via the in-memory object store (covers multipart_put under
+    // `cargo llvm-cov --lib`; the real-S3 ETag assertion lives in the
+    // s3_integration regression test).
+    #[tokio::test]
+    async fn test_multipart_put_roundtrip_in_memory() {
+        use object_store::memory::InMemory;
+        use object_store::path::Path;
+
+        let store = InMemory::new();
+        let path = Path::from("multipart-test-object");
+        let data = bytes::Bytes::from(vec![0xABu8; S3_MULTIPART_PUT_THRESHOLD + 4096]);
+
+        multipart_put(&store, &path, data.clone())
+            .await
+            .expect("multipart_put failed");
+
+        let got = store
+            .get(&path)
+            .await
+            .expect("get failed")
+            .bytes()
+            .await
+            .expect("bytes failed");
+        assert_eq!(got, data, "round-trip mismatch");
+    }
+
+    // Covers the S3_REQUEST_TIMEOUT_SECS -> with_timeout branch in
+    // build_store. Constructing the client is offline (no network), so this
+    // runs under `cargo test --lib`.
+    #[test]
+    fn test_s3_request_timeout_env_is_applied() {
+        let saved = std::env::var("S3_REQUEST_TIMEOUT_SECS").ok();
+        std::env::set_var("S3_REQUEST_TIMEOUT_SECS", "7");
+
+        let config = S3Config::new(
+            "test-bucket".to_string(),
+            "us-east-1".to_string(),
+            Some("http://localhost:1".to_string()),
+            None,
+        );
+        let built = S3Backend::build_store(&config, Some("ak"), Some("sk"));
+
+        match saved {
+            Some(v) => std::env::set_var("S3_REQUEST_TIMEOUT_SECS", v),
+            None => std::env::remove_var("S3_REQUEST_TIMEOUT_SECS"),
+        }
+
+        assert!(built.is_ok(), "build_store failed: {:?}", built.err());
+    }
 
     // --- free function tests: make_full_key ---
 

--- a/backend/tests/s3_integration.rs
+++ b/backend/tests/s3_integration.rs
@@ -82,6 +82,49 @@ async fn test_put_and_get() {
     println!("Cleanup ok");
 }
 
+// Regression test for the large-object upload bug: `put()` of an object
+// larger than the multipart threshold must use S3 multipart, not a single
+// PUT. A single PUT is one HTTP request bounded by the client request
+// timeout, so large/slow uploads failed with STORAGE_ERROR. Multipart
+// uploads produce an ETag of the form "<md5>-<partcount>"; a single PUT
+// produces a plain 32-hex MD5 with no dash. Pre-fix this assertion fails
+// (plain ETag); post-fix it passes (dashed multipart ETag).
+#[tokio::test]
+#[ignore]
+async fn test_large_put_uses_multipart() {
+    if skip_unless_configured().is_none() {
+        println!("Skipping: S3 not configured");
+        return;
+    }
+    let prefix = test_prefix();
+    let backend = make_backend(&prefix, false).await;
+
+    let key = "test-large-multipart.bin";
+    let size = 20 * 1024 * 1024; // 20 MiB, above the 16 MiB multipart threshold
+    let content = Bytes::from(vec![0u8; size]);
+
+    backend
+        .put(key, content.clone())
+        .await
+        .expect("large put failed");
+
+    let etag = backend
+        .head_etag(key)
+        .await
+        .expect("head_etag failed")
+        .expect("etag present");
+    assert!(
+        etag.contains('-'),
+        "expected multipart ETag (<md5>-<parts>) for a >16 MiB object, got {etag}"
+    );
+
+    let got = backend.get(key).await.expect("get failed");
+    assert_eq!(got.len(), size, "round-trip size mismatch");
+
+    backend.delete(key).await.expect("delete failed");
+    println!("large multipart put ok: {key} etag={etag}");
+}
+
 #[tokio::test]
 #[ignore]
 async fn test_exists_and_not_exists() {


### PR DESCRIPTION
  ## Summary
  Large uploads to S3-compatible backends failed with `STORAGE_ERROR`.
  `S3Backend::put()` issued one monolithic `object_store` PUT, bounded by
  the client's ~30s request timeout. Multi-GB objects to a slow on-prem S3
  (self-hosted Garage) blew past it → repeated `transport error of kind
  Timeout` → `STORAGE_ERROR`; small objects only worked because they
  finished within 30s.

  Fix: objects > 16 MiB go through S3 multipart (`multipart_put`), so each
  part is a small request and total size no longer races a single-request
  timeout. Adds optional `S3_REQUEST_TIMEOUT_SECS`. Small objects keep the
  original single-PUT fast path unchanged.

  ## Regression test (required for `fix/*` PRs)
  - [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
  - [ ] N/A — this is not a bug fix


 backend/tests/s3_integration.rs::test_large_put_uses_multipart: 
 a >16 MiB `put()` must land as a multipart upload (dashed ETag). Fails on
 `main` (plain single-PUT ETag), passes here. Multipart logic also covered
 offline by `s3::tests::test_multipart_put_roundtrip_in_memory.

  ## Test Checklist
  - [x] Unit tests added/updated
  - [x] Integration tests added/updated (if applicable)
  - [ ] E2E tests added/updated (if applicable)
  - [x] Manually tested locally
  - [x] No regressions in existing tests

  ## API Changes
  - [x] N/A - no API changes