### PR TITLE
fix: unblock main CI (Docker Hub rate-limit + lettre security audit)

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -22,6 +22,8 @@ jobs:
             target: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
           - image: alpine:3.19
             target: ghcr.io/artifact-keeper/ci-mirror/alpine:3.19
+          - image: alpine:3.23
+            target: ghcr.io/artifact-keeper/ci-mirror/alpine:3.23
           - image: python:3.12-slim
             target: ghcr.io/artifact-keeper/ci-mirror/python:3.12-slim
           - image: node:20-slim

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -888,7 +888,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -1913,7 +1913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2009,7 +2009,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2138,7 +2138,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2881,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3102,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",
@@ -3351,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -3550,7 +3550,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4386,7 +4386,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4883,7 +4883,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4896,7 +4896,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4964,7 +4964,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5733,7 +5733,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -5764,7 +5764,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7372,15 +7372,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -7665,7 +7656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -152,7 +152,10 @@ FROM ghcr.io/anchore/grype:v0.111.1 AS grype-bin
 # Populates the Grype DB at build time so the image works on egress-restricted
 # networks (e.g. ARC runner pods) without a first-scan network fetch from
 # grype.anchore.io. See artifact-keeper#1001.
-FROM alpine:3.23 AS grype-db-seed
+#
+# Uses the GHCR mirror (maintained by .github/workflows/mirror-images.yml) to
+# avoid Docker Hub anonymous-pull rate limits that intermittently break CI.
+FROM ghcr.io/artifact-keeper/ci-mirror/alpine:3.23 AS grype-db-seed
 RUN apk add --no-cache ca-certificates
 COPY --from=grype-bin /grype /usr/local/bin/grype
 ENV GRYPE_DB_CACHE_DIR=/grype-db


### PR DESCRIPTION
## Summary

Two CI gates have been failing on every push to `main`. Bundling both fixes in a single PR because they share a CI run on merge.

### 1. `🐳 Build Backend Image` — Docker Hub anonymous-pull rate limit (429)

The `grype-db-seed` stage in `docker/Dockerfile.backend` (added in #1002) pulls `alpine:3.23` directly from `docker.io`. GitHub-hosted runners share a single anonymous-pull pool, and that pool has been exceeded on consecutive `main` builds:

- Run [25973925699](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25973925699) (`26fe252`) — `toomanyrequests`
- Run [25980813750](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25980813750) (`3bfcb93`) — `toomanyrequests`

Fix: add `alpine:3.23` to `.github/workflows/mirror-images.yml` (alongside the existing `postgres:16-alpine` and `alpine:3.19` mirrors), and switch the `grype-db-seed` stage to pull from `ghcr.io/artifact-keeper/ci-mirror/alpine:3.23`. The mirror workflow was dispatched against this branch (run [25990706066](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25990706066)) so the image exists in GHCR before the docker build job needs it.

### 2. `🔒 Security Audit` — RUSTSEC-2026-0141 (`lettre <0.11.22`)

`cargo audit` is rejecting every PR on `Cargo.lock` because `lettre 0.11.21` has a critical advisory (TLS hostname verification disabled with the `boring-tls` backend). We compile with `tokio1-native-tls`, so the vulnerability does not affect us at runtime, but `cargo audit` does not inspect feature flags. The `metrics 0.24.5` yanked warning is also bumped.

This is cherry-picked verbatim from #1234 (`cb020ed`) so the same change can land in one CI run instead of two.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — both regressions are infra: the `🐳 Build Backend Image` job and the `🔒 Security Audit` job *are* the regression tests. Both were failing on `main` before this PR and will pass after it lands.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually verified — mirror workflow run [25990706066](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25990706066) publishes `ghcr.io/artifact-keeper/ci-mirror/alpine:3.23`. `cargo audit` exits 0 locally with the lockfile bump.
- [x] No regressions — lockfile-only and Dockerfile base-image swap; no source code modified.

## API Changes
- [x] N/A