### PR TITLE
fix(ci): mirror images as multi-arch manifests via buildx imagetools

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -32,6 +32,9 @@ jobs:
             target: ghcr.io/artifact-keeper/ci-mirror/rust:1.75-slim
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
@@ -39,10 +42,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Mirror image to GHCR
+      - name: Mirror image to GHCR (preserve multi-arch manifest)
+        # `buildx imagetools create` copies the full OCI index — every platform
+        # manifest the upstream image publishes — without re-pulling layers per
+        # platform. This is required so downstream multi-arch builds
+        # (e.g. docker-publish.yml builds linux/amd64 + linux/arm64) can resolve
+        # the correct arch manifest from the mirror.
         run: |
-          docker pull ${{ matrix.image }}
-          echo "FROM ${{ matrix.image }}" | docker build \
-            --label "org.opencontainers.image.source=https://github.com/artifact-keeper/artifact-keeper" \
-            -t ${{ matrix.target }} -
-          docker push ${{ matrix.target }}
+          docker buildx imagetools create \
+            --tag ${{ matrix.target }} \
+            ${{ matrix.image }}


### PR DESCRIPTION
## Summary

The previous Docker-Hub→GHCR mirror step (`docker pull` + `docker build` + `docker push`) only published a single-platform (amd64) manifest because it ran on an amd64 runner. That broke `docker-publish.yml` after f73ed88 (#1244) switched the `grype-db-seed` stage in `Dockerfile.backend` to `ghcr.io/artifact-keeper/ci-mirror/alpine:3.23`:

- Run [25990974798 / job 76396929274](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25990974798/job/76396929274) — `Backend (linux/arm64)` failed at  `apk add --no-cache ca-certificates` with exit 255 because the arm64 build pulled amd64 layers and crashed under QEMU emulation.

Fix: replace the build/push with `docker buildx imagetools create`, which copies the upstream image's full OCI index (every platform manifest the source publishes) into GHCR in one shot, no per-platform layer downloads required. The matrix and the target tag names are unchanged; the next mirror run overwrites each tag with the full multi-arch manifest.

I dispatched the workflow against this branch (run [25991844137](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25991844137)) so the multi-arch tags exist before this PR's downstream effects.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — CI infra change. The regression test is the `Backend (linux/arm64)` job in `docker-publish.yml`, which currently fails on `main` and will pass after the mirror is re-pushed multi-arch.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually verified — mirror workflow run [25991844137](https://github.com/artifact-keeper/artifact-keeper/actions/runs/25991844137) republishes the mirrored tags as multi-arch.
- [x] No regressions — workflow-only change.

## API Changes
- [x] N/A