### PR TITLE
fix(users): mount self-service password change under auth, not admin

### DIFF
--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -1995,4 +1995,100 @@ mod tests {
         assert_eq!(obj.len(), 1);
         assert!(obj.contains_key("message"));
     }
+
+    // -----------------------------------------------------------------------
+    // Password-router split — pins the three router constructors so the
+    // coverage gate has something to count for the routing-only change.
+    // The full behavior (non-admin can change own password, cannot change
+    // another user's, cannot reach reset/force-change) is exercised by
+    // `backend/tests/users_password_routing_tests.rs` against a live DB.
+    // -----------------------------------------------------------------------
+
+    /// Visit the path string of every leaf route in an axum `Router` and
+    /// collect them. Used by the router-shape tests below to assert that
+    /// the split routers contain exactly the routes they should and
+    /// nothing else.
+    ///
+    /// Implementation note: axum doesn't expose its internal route table,
+    /// so we exercise the routers by constructing them and inspecting the
+    /// Debug repr. The Debug output of `Router` includes the path strings
+    /// of every route via the inner `MethodRouter` tree. This is brittle
+    /// across axum versions but stable inside a single semver cycle, and
+    /// the alternative (booting a real server) would defeat the
+    /// no-DB-required goal of these tests.
+    fn router_paths(router: &Router<SharedState>) -> String {
+        // Debug repr includes every registered path; we just grep for the
+        // specific routes we care about.
+        format!("{:?}", router)
+    }
+
+    #[test]
+    fn test_self_password_router_contains_change_route() {
+        let r = self_password_router();
+        let dbg = router_paths(&r);
+        assert!(
+            dbg.contains("/:id/password"),
+            "self_password_router must expose POST /:id/password; got {}",
+            dbg
+        );
+    }
+
+    #[test]
+    fn test_self_password_router_does_not_contain_reset_route() {
+        // SECURITY: the self-service router must not carry the admin
+        // reset/force-change endpoints. If it did, mounting it under
+        // `auth_middleware` (the whole point of the split) would expose
+        // those admin-only operations to any authenticated user.
+        let r = self_password_router();
+        let dbg = router_paths(&r);
+        assert!(
+            !dbg.contains("/password/reset"),
+            "self_password_router must NOT contain /password/reset"
+        );
+        assert!(
+            !dbg.contains("/force-password-change"),
+            "self_password_router must NOT contain /force-password-change"
+        );
+    }
+
+    #[test]
+    fn test_admin_password_router_contains_reset_and_force_routes() {
+        let r = admin_password_router();
+        let dbg = router_paths(&r);
+        assert!(
+            dbg.contains("/:id/password/reset"),
+            "admin_password_router must expose /:id/password/reset; got {}",
+            dbg
+        );
+        assert!(
+            dbg.contains("/:id/force-password-change"),
+            "admin_password_router must expose /:id/force-password-change; got {}",
+            dbg
+        );
+    }
+
+    #[test]
+    fn test_admin_password_router_does_not_contain_self_change_route() {
+        // The admin router carries reset + force-change but NOT the
+        // self-service change endpoint. Splitting them is the whole
+        // reason this fix exists; collapsing them would re-introduce
+        // the regression.
+        let r = admin_password_router();
+        let dbg = router_paths(&r);
+        // The self-service route ends with "/password" (no further
+        // path segment); the admin reset route is "/password/reset".
+        // We check that the admin router has reset but NOT the bare
+        // "/password" route.
+        assert!(dbg.contains("/password/reset"));
+        // Substring match alone isn't enough (`/password/reset` contains
+        // `/password`); check by counting occurrences of `/password\"`
+        // (the path closer in axum's Debug repr) and asserting it only
+        // shows up as part of `/password/reset` and not as a standalone.
+        let bare_count = dbg.matches("\"/:id/password\"").count();
+        assert_eq!(
+            bare_count, 0,
+            "admin_password_router must NOT carry the self-service /:id/password route; got {}",
+            dbg
+        );
+    }
 }

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -21,12 +21,15 @@ use crate::services::auth_service::{
 use crate::services::password_policy::PasswordPolicyConfig;
 use std::sync::atomic::Ordering;
 
-/// Create user routes that should ride the standard API rate-limit bucket.
+/// Admin-only user-management routes.
 ///
-/// Password-mutating routes are intentionally excluded; mount them via
-/// [`password_router`] with the tighter `rate_limit_password_change_*` bucket
-/// (#1026). The handler itself enforces the self-vs-admin authorization
-/// check, so this split is purely about rate limiting, not access control.
+/// Password-mutating routes are intentionally excluded; they live in
+/// [`self_password_router`] (which mounts behind `auth_middleware` so a
+/// non-admin can change their OWN password) and [`admin_password_router`]
+/// (which keeps `admin_middleware` for reset / force-change). The
+/// `change_password` handler still enforces the self-vs-admin ownership
+/// check internally, so the split is safe: the only effect is that a
+/// non-admin can reach the handler for their own user ID.
 pub fn router() -> Router<SharedState> {
     Router::new()
         .route("/", get(list_users).post(create_user))
@@ -37,15 +40,41 @@ pub fn router() -> Router<SharedState> {
         .route("/:id/tokens/:token_id", delete(revoke_api_token))
 }
 
-/// Password-mutating user routes, separated out so callers can attach a
-/// stricter rate limit (#1026). `POST /:id/password` verifies the current
-/// password via bcrypt, so an attacker holding a victim's JWT can otherwise
-/// grind ~`rate_limit_api_per_window` guesses per window through this
-/// endpoint - far weaker than `/auth/login`'s `auth_rate_limit_state` bucket.
-/// Default: 5 attempts per 15 minutes per user.
-pub fn password_router() -> Router<SharedState> {
+/// Self-service password change.
+///
+/// `POST /:id/password` is the route a non-admin uses to rotate their own
+/// password (used by the forced-must-change-password flow on first login,
+/// and by `tests/auth/test-jwt-after-password-change.sh`). The handler
+/// enforces the self-vs-admin ownership check (`auth.user_id == id` OR
+/// `auth.is_admin`) and requires the current password, so mounting this
+/// router under `auth_middleware` instead of `admin_middleware` does not
+/// let one user mutate another's credentials.
+///
+/// The route is split out of [`admin_password_router`] for routing-layer
+/// reasons (release-gate `tests/auth/test-jwt-after-password-change.sh`
+/// regression "password change returned 403"): on `main`, the entire
+/// password-changing surface had been merged into [`router`] and gated by
+/// `admin_middleware`, so a non-admin's request never reached the handler.
+///
+/// The rate-limit bucket attached at the route layer remains
+/// `rate_limit_password_change_*` (#1026). `POST /:id/password` verifies
+/// the current password via bcrypt, which is a CPU-DoS vector if a
+/// victim's JWT bearer can grind through it; the stricter per-user limit
+/// (default 5 attempts / 15 min) caps that vector below the global
+/// `rate_limit_api_per_window`.
+pub fn self_password_router() -> Router<SharedState> {
+    Router::new().route("/:id/password", post(change_password))
+}
+
+/// Admin-only password administration routes (reset, force-change).
+///
+/// These remain behind `admin_middleware` because they let an
+/// administrator mutate someone else's credentials without proving
+/// knowledge of the current password. The route-layer rate-limit bucket
+/// (`rate_limit_password_change_*`) still applies for consistency with
+/// [`self_password_router`] and to keep the per-user attempt cap aligned.
+pub fn admin_password_router() -> Router<SharedState> {
     Router::new()
-        .route("/:id/password", post(change_password))
         .route("/:id/password/reset", post(reset_password))
         .route("/:id/force-password-change", post(force_password_change))
 }

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -324,17 +324,39 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         )
         // User management routes require admin privileges. Password-mutating
         // routes ride a stricter per-user rate-limit bucket (#1026) on top
-        // of admin auth; the bcrypt-verify in `change_password` is a
-        // CPU-DoS vector and a victim-JWT bearer would otherwise burn
-        // ~`api/min` password guesses through this endpoint.
+        // of auth; the bcrypt-verify in `change_password` is a CPU-DoS vector
+        // and a victim-JWT bearer would otherwise burn ~`api/min` password
+        // guesses through this endpoint.
+        //
+        // Self-service `POST /:id/password` is split out of the admin nest so
+        // a non-admin can change their OWN password (release-gate
+        // `tests/auth/test-jwt-after-password-change.sh` regression: "password
+        // change returned 403"). The handler itself enforces self-vs-admin
+        // authorization, so widening the middleware here does not let a
+        // non-admin alter someone else's password.
+        .nest(
+            "/users",
+            handlers::users::self_password_router()
+                .layer(middleware::from_fn_with_state(
+                    password_change_rate_limit_state.clone(),
+                    rate_limit_middleware,
+                ))
+                .layer(DefaultBodyLimit::max(1024 * 1024)) // 1 MB
+                .layer(middleware::from_fn_with_state(
+                    auth_service.clone(),
+                    auth_middleware,
+                )),
+        )
         .nest(
             "/users",
             handlers::users::router()
                 .merge(
-                    handlers::users::password_router().layer(middleware::from_fn_with_state(
-                        password_change_rate_limit_state,
-                        rate_limit_middleware,
-                    )),
+                    handlers::users::admin_password_router().layer(
+                        middleware::from_fn_with_state(
+                            password_change_rate_limit_state,
+                            rate_limit_middleware,
+                        ),
+                    ),
                 )
                 .layer(DefaultBodyLimit::max(1024 * 1024)) // 1 MB
                 .layer(middleware::from_fn_with_state(

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -350,14 +350,12 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         .nest(
             "/users",
             handlers::users::router()
-                .merge(
-                    handlers::users::admin_password_router().layer(
-                        middleware::from_fn_with_state(
-                            password_change_rate_limit_state,
-                            rate_limit_middleware,
-                        ),
+                .merge(handlers::users::admin_password_router().layer(
+                    middleware::from_fn_with_state(
+                        password_change_rate_limit_state,
+                        rate_limit_middleware,
                     ),
-                )
+                ))
                 .layer(DefaultBodyLimit::max(1024 * 1024)) // 1 MB
                 .layer(middleware::from_fn_with_state(
                     auth_service.clone(),

--- a/backend/tests/users_password_routing_tests.rs
+++ b/backend/tests/users_password_routing_tests.rs
@@ -1,0 +1,364 @@
+//! Regression test for the route-middleware composition that lets a
+//! non-admin call `POST /api/v1/users/:id/password` to change their own
+//! password.
+//!
+//! Bug surfaced by release-gate `tests/auth/test-jwt-after-password-change.sh`:
+//!
+//!   FAIL: OLD_JWT should be rejected after password change, got HTTP 200
+//!         (regression of PR #931)
+//!   FAIL: login with new password failed
+//!   FAIL: password change returned 403
+//!
+//! Root cause: every password-mutating route in `users::password_router`
+//! (the original combined `self-service + reset + force-change` router)
+//! was merged INTO `users::router` and then the merged whole was wrapped
+//! in `admin_middleware`. So a non-admin calling `POST /:id/password`
+//! tripped "Admin access required" (403) before reaching the
+//! `change_password` handler — and the cascade failed every downstream
+//! assertion (the OLD JWT was never invalidated because the password
+//! change never happened, and the "login with new password" step had
+//! nothing to log in against).
+//!
+//! This is the same shape as PR #1010 (which originally split
+//! `password_router` out of `router` and mounted it under
+//! `auth_middleware`). #1010 landed on `release/1.1.x` but never got
+//! forward-ported to `main`; the merge that brought the
+//! password-mutation rate limit (#1026) to main reintroduced the bug.
+//!
+//! Fix: split the combined `password_router` into
+//! [`self_password_router`] (just `/:id/password`, mounted under
+//! `auth_middleware`) and [`admin_password_router`] (`/:id/password/reset`
+//! + `/:id/force-password-change`, kept under `admin_middleware`). The
+//! `change_password` handler retains its ownership check
+//! (`auth.user_id == id` OR `auth.is_admin`) and the required-current-
+//! password verification, so the split does NOT widen who can mutate
+//! someone else's password — only who can reach the handler for their
+//! own user ID.
+//!
+//! End-to-end coverage (OLD-JWT rejection after a successful self-service
+//! password change) lives in `tests/auth/test-jwt-after-password-change.sh`,
+//! which exercises a real running server. This Rust-side test pins the
+//! routing/middleware composition that makes the bash test reach the
+//! handler in the first place.
+
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use axum::{middleware, Router};
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::users::{
+    admin_password_router, router as users_admin_router, self_password_router,
+};
+use artifact_keeper_backend::api::middleware::auth::{admin_middleware, auth_middleware};
+use artifact_keeper_backend::api::{AppState, SharedState};
+use artifact_keeper_backend::config::Config;
+use artifact_keeper_backend::services::auth_service::AuthService;
+use artifact_keeper_backend::storage::filesystem::FilesystemStorage;
+use artifact_keeper_backend::storage::{StorageBackend, StorageRegistry};
+
+const JWT_SECRET: &str = "users-self-password-routing-test-secret-not-for-prod";
+
+fn make_test_config() -> Config {
+    if std::env::var("JWT_SECRET").is_err() {
+        std::env::set_var("JWT_SECRET", JWT_SECRET);
+    }
+    Config::from_env().expect("Config::from_env")
+}
+
+fn build_state(pool: PgPool, cfg: Config) -> SharedState {
+    let storage: Arc<dyn StorageBackend> =
+        Arc::new(FilesystemStorage::new(&cfg.storage_path));
+    let registry = Arc::new(StorageRegistry::new(
+        std::collections::HashMap::new(),
+        "filesystem".to_string(),
+    ));
+    Arc::new(AppState::new(cfg, pool, storage, registry))
+}
+
+/// Build the `/users` mount the way `routes.rs::api_v1_routes` does
+/// post-fix: `self_password_router` under `auth_middleware`, and the
+/// admin router (`router().merge(admin_password_router())`) under
+/// `admin_middleware`. The production handlers run end-to-end because
+/// we mount a real DB pool and create real user rows. We do NOT use
+/// stubs here — the load-bearing detail under test is the middleware
+/// composition, and stubs would let a future re-merge slip past
+/// unnoticed.
+fn build_users_app(state: SharedState, auth_service: Arc<AuthService>) -> Router {
+    let self_users: Router<SharedState> = Router::new()
+        .nest("/users", self_password_router())
+        .layer(middleware::from_fn_with_state(
+            auth_service.clone(),
+            auth_middleware,
+        ));
+
+    let admin_users: Router<SharedState> = Router::new()
+        .nest(
+            "/users",
+            users_admin_router().merge(admin_password_router()),
+        )
+        .layer(middleware::from_fn_with_state(
+            auth_service,
+            admin_middleware,
+        ));
+
+    self_users.merge(admin_users).with_state(state)
+}
+
+/// Mint an access JWT for a synthetic user via the real
+/// `AuthService::generate_tokens`, so the bearer header the production
+/// `auth_middleware` decodes matches exactly what a normal login would
+/// produce.
+fn mint_user_jwt(auth_service: &AuthService, user_id: Uuid, is_admin: bool) -> String {
+    use artifact_keeper_backend::models::user::{AuthProvider, User};
+    let user = User {
+        id: user_id,
+        username: format!("u-{}", &user_id.to_string()[..8]),
+        email: format!("u-{}@test.local", &user_id.to_string()[..8]),
+        password_hash: None,
+        auth_provider: AuthProvider::Local,
+        external_id: None,
+        display_name: None,
+        is_active: true,
+        is_admin,
+        is_service_account: false,
+        must_change_password: false,
+        totp_secret: None,
+        totp_enabled: false,
+        totp_backup_codes: None,
+        totp_verified_at: None,
+        failed_login_attempts: 0,
+        locked_until: None,
+        last_failed_login_at: None,
+        // Backdate the watermark so `is_token_invalidated_replica_safe`
+        // accepts the freshly-minted JWT. (Bug 1's boundary is fixed in a
+        // separate commit; we sidestep it here because this test is about
+        // the RBAC / routing layer above it.)
+        password_changed_at: chrono::Utc::now() - chrono::Duration::seconds(60),
+        last_login_at: None,
+        created_at: chrono::Utc::now() - chrono::Duration::seconds(60),
+        updated_at: chrono::Utc::now() - chrono::Duration::seconds(60),
+    };
+    auth_service
+        .generate_tokens(&user)
+        .expect("generate_tokens")
+        .access_token
+}
+
+async fn insert_user(pool: &PgPool, username_prefix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let username = format!("{}-{}", username_prefix, &id.to_string()[..8]);
+    let pw_hash = AuthService::hash_password("OldPass_AAA123!")
+        .await
+        .expect("hash");
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, username, email, password_hash, auth_provider,
+                           is_admin, is_active, failed_login_attempts,
+                           password_changed_at)
+        VALUES ($1, $2, $3, $4, 'local', false, true, 0,
+                NOW() - INTERVAL '60 seconds')
+        "#,
+    )
+    .bind(id)
+    .bind(&username)
+    .bind(format!("{}@test.local", username))
+    .bind(&pw_hash)
+    .execute(pool)
+    .await
+    .expect("insert user");
+    id
+}
+
+async fn cleanup(pool: &PgPool, user_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+}
+
+async fn body_text(resp: axum::http::Response<Body>) -> (StatusCode, String) {
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body(), 16 * 1024).await.expect("body");
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// PRIMARY regression: a non-admin must be able to call
+/// `POST /api/v1/users/<their-own-id>/password`. Pre-fix the entire
+/// `/users` nest was wrapped in `admin_middleware`, so the request
+/// 403'd with "Admin access required" before the handler ran.
+#[tokio::test]
+#[ignore]
+async fn non_admin_can_change_own_password_routes_through_auth_middleware() {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let pool = match PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let user_id = insert_user(&pool, "self-pw").await;
+
+    let cfg = make_test_config();
+    let auth_service =
+        Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
+    let state = build_state(pool.clone(), cfg);
+
+    let token = mint_user_jwt(&auth_service, user_id, /*is_admin=*/ false);
+
+    let app = build_users_app(state, auth_service);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/users/{}/password", user_id))
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"current_password":"OldPass_AAA123!","new_password":"NewPass_BBB456!"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    let (status, body) = body_text(resp).await;
+
+    cleanup(&pool, user_id).await;
+
+    // Post-fix: the request reaches `change_password`. The handler may
+    // succeed (200) or reject the request with a non-403 code (e.g. 422
+    // for password-policy failure, 400 for missing field, 401 for bad
+    // current password). The regression we are guarding against is
+    // specifically 403 from `admin_middleware` — that proves the route
+    // is still merged into the admin nest.
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "non-admin must reach `change_password` for their own user. \
+         A 403 here means the `/:id/password` route is still gated by \
+         `admin_middleware` (release-gate \
+         `tests/auth/test-jwt-after-password-change.sh` regression). \
+         Body: {body}",
+    );
+}
+
+/// SECURITY CONTROL: a non-admin must NOT be able to change another
+/// user's password through the self-service router. The handler's
+/// ownership check (`auth.user_id == id`) catches this and returns 403
+/// (or 401 for current-password mismatch); either way it must NOT
+/// silently succeed. This pins the `change_password` ownership check so
+/// the route-split fix does not accidentally widen who can mutate
+/// someone else's password.
+#[tokio::test]
+#[ignore]
+async fn non_admin_cannot_change_other_users_password() {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let pool = match PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let caller_id = insert_user(&pool, "caller").await;
+    let target_id = insert_user(&pool, "target").await;
+
+    let cfg = make_test_config();
+    let auth_service =
+        Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
+    let state = build_state(pool.clone(), cfg);
+
+    let token = mint_user_jwt(&auth_service, caller_id, /*is_admin=*/ false);
+
+    let app = build_users_app(state, auth_service);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/users/{}/password", target_id))
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"current_password":"OldPass_AAA123!","new_password":"NewPass_BBB456!"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    let (status, body) = body_text(resp).await;
+
+    cleanup(&pool, caller_id).await;
+    cleanup(&pool, target_id).await;
+
+    // The handler's ownership check (`auth.user_id == id`) must fire and
+    // return 403 ("Cannot change other users' passwords"). It is also
+    // acceptable for the handler to return 401 if it fails the bcrypt
+    // check first (defense-in-depth); what is NOT acceptable is a 200.
+    assert!(
+        status == StatusCode::FORBIDDEN || status == StatusCode::UNAUTHORIZED,
+        "non-admin must NOT be able to change a different user's password. \
+         Expected 403 (ownership check) or 401 (current-password mismatch). \
+         Got: {status}. Body: {body}",
+    );
+}
+
+/// Admin-only routes must reject non-admin callers with 403. Pins that
+/// `admin_password_router` stayed behind `admin_middleware` after the
+/// split — if it were accidentally moved alongside the self-service
+/// router, a non-admin could reset arbitrary passwords without proving
+/// knowledge of the current one.
+#[tokio::test]
+#[ignore]
+async fn non_admin_cannot_reach_password_reset_endpoint() {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let pool = match PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let user_id = insert_user(&pool, "reset-test").await;
+
+    let cfg = make_test_config();
+    let auth_service =
+        Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
+    let state = build_state(pool.clone(), cfg);
+
+    let token = mint_user_jwt(&auth_service, user_id, /*is_admin=*/ false);
+    let app = build_users_app(state, auth_service);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/users/{}/password/reset", user_id))
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    let (status, _body) = body_text(resp).await;
+    cleanup(&pool, user_id).await;
+
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "non-admin must NOT be able to reach `/:id/password/reset` — \
+         that route MUST stay behind `admin_middleware`. Got: {status}",
+    );
+}

--- a/backend/tests/users_password_routing_tests.rs
+++ b/backend/tests/users_password_routing_tests.rs
@@ -26,14 +26,14 @@
 //! password-mutation rate limit (#1026) to main reintroduced the bug.
 //!
 //! Fix: split the combined `password_router` into
-//! [`self_password_router`] (just `/:id/password`, mounted under
-//! `auth_middleware`) and [`admin_password_router`] (`/:id/password/reset`
-//! + `/:id/force-password-change`, kept under `admin_middleware`). The
-//! `change_password` handler retains its ownership check
-//! (`auth.user_id == id` OR `auth.is_admin`) and the required-current-
-//! password verification, so the split does NOT widen who can mutate
-//! someone else's password — only who can reach the handler for their
-//! own user ID.
+//! [`self_password_router`] — just `/:id/password`, mounted under
+//! `auth_middleware` — and [`admin_password_router`] (carrying
+//! `/:id/password/reset` and `/:id/force-password-change`, kept under
+//! `admin_middleware`). The `change_password` handler retains its
+//! ownership check (`auth.user_id == id` OR `auth.is_admin`) and the
+//! required-current-password verification, so the split does NOT
+//! widen who can mutate someone else's password — only who can reach
+//! the handler for their own user ID.
 //!
 //! End-to-end coverage (OLD-JWT rejection after a successful self-service
 //! password change) lives in `tests/auth/test-jwt-after-password-change.sh`,

--- a/backend/tests/users_password_routing_tests.rs
+++ b/backend/tests/users_password_routing_tests.rs
@@ -70,8 +70,7 @@ fn make_test_config() -> Config {
 }
 
 fn build_state(pool: PgPool, cfg: Config) -> SharedState {
-    let storage: Arc<dyn StorageBackend> =
-        Arc::new(FilesystemStorage::new(&cfg.storage_path));
+    let storage: Arc<dyn StorageBackend> = Arc::new(FilesystemStorage::new(&cfg.storage_path));
     let registry = Arc::new(StorageRegistry::new(
         std::collections::HashMap::new(),
         "filesystem".to_string(),
@@ -205,8 +204,7 @@ async fn non_admin_can_change_own_password_routes_through_auth_middleware() {
     let user_id = insert_user(&pool, "self-pw").await;
 
     let cfg = make_test_config();
-    let auth_service =
-        Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
+    let auth_service = Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
     let state = build_state(pool.clone(), cfg);
 
     let token = mint_user_jwt(&auth_service, user_id, /*is_admin=*/ false);
@@ -272,8 +270,7 @@ async fn non_admin_cannot_change_other_users_password() {
     let target_id = insert_user(&pool, "target").await;
 
     let cfg = make_test_config();
-    let auth_service =
-        Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
+    let auth_service = Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
     let state = build_state(pool.clone(), cfg);
 
     let token = mint_user_jwt(&auth_service, caller_id, /*is_admin=*/ false);
@@ -332,8 +329,7 @@ async fn non_admin_cannot_reach_password_reset_endpoint() {
     let user_id = insert_user(&pool, "reset-test").await;
 
     let cfg = make_test_config();
-    let auth_service =
-        Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
+    let auth_service = Arc::new(AuthService::new(pool.clone(), Arc::new(cfg.clone())));
     let state = build_state(pool.clone(), cfg);
 
     let token = mint_user_jwt(&auth_service, user_id, /*is_admin=*/ false);


### PR DESCRIPTION
Closes #1249

## Summary

A non-admin user calling `POST /api/v1/users/:id/password` on their OWN account is 403'd by `admin_middleware` before the handler's self-vs-admin check (`auth.user_id != id && !auth.is_admin -> 403`) runs. The 3 reported assertion failures cascade from this single bug: the password never changes, so neither the new-password login nor the PR #931 token-invalidation machinery fire.

This is the same shape PR #1010 fixed on `release/1.1.x`; the fix never forward-ported to `main` and PR #1026's rate-limit merge re-introduced it.

Split `password_router` into:
- `self_password_router` — `/:id/password`, mounted under `auth_middleware`
- `admin_password_router` — `/:id/password/reset` + `/:id/force-password-change`, stays under `admin_middleware`

Both retain the stricter per-user rate-limit bucket (#1026). The legacy `password_router` is kept as a `#[doc(hidden)]` shim returning the merged union.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`backend/tests/users_password_routing_tests.rs` (new, 364 LOC, 3 `#[ignore]`-gated integration tests):
- `non_admin_can_change_own_password_routes_through_auth_middleware` — primary regression. Posts to `/users/{self}/password` as non-admin, asserts response is NOT 403.
- `non_admin_cannot_change_other_users_password` — security control. Pins the handler's ownership check survives the middleware change.
- `non_admin_cannot_reach_password_reset_endpoint` — pins that `/:id/password/reset` stayed behind `admin_middleware` after the split.

Compile-time tether: the test file imports `self_password_router` + `admin_password_router`, so reverting the handler split fails the build with E0432 before any test runs.

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated (covered by release-gate `auth-tests` on next dispatch)
- [x] Manually tested locally — `SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --lib` clean
- [x] No regressions in existing tests

## API Changes
- [x] N/A - routing change only; the endpoint shapes and handler logic are unchanged