### PR TITLE
fix(scanner): pin Grype DB auto-update + drop -q so seeded DB survives

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -81,6 +81,28 @@ pub struct GrypeArtifact {
 // Scanner implementation
 // ---------------------------------------------------------------------------
 
+/// Cap a captured subprocess stream at `max` bytes for inclusion in an error
+/// message. Keeps the *tail* (most recent output) because Grype's failure
+/// reason is typically the last line it logs before exiting. Adds a
+/// `…[truncated]` marker so the caller can tell the message was clipped.
+///
+/// Returns an owned `String` so the result is safe to interpolate into
+/// `format!`. The `s` argument is a `Cow<str>` flavor from
+/// `String::from_utf8_lossy`, so an as-ref accepts both arms.
+fn truncate_stream(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    // Slice on a char boundary to avoid panicking on a multibyte split.
+    // `floor_char_boundary` is unstable, so walk manually.
+    let start = s.len().saturating_sub(max);
+    let mut boundary = start;
+    while boundary < s.len() && !s.is_char_boundary(boundary) {
+        boundary += 1;
+    }
+    format!("…[truncated]{}", &s[boundary..])
+}
+
 /// Resolve the registry host string Grype's `registry:` mode targets. The
 /// first non-empty source wins, in priority order:
 ///   1. `AK_GRYPE_REGISTRY_HOST` — explicit override (full URL accepted).
@@ -167,9 +189,34 @@ impl GrypeScanner {
     /// Run grype against an arbitrary target string (e.g. `dir:/path`,
     /// `registry:host/name:tag`). Centralized so both modes share output
     /// parsing and "binary not installed" handling.
+    ///
+    /// Two behaviors worth calling out:
+    ///
+    /// 1. We do **not** pass `-q`. Grype's `-q` flag suppresses *all* logging,
+    ///    including the messages it writes on a DB-load/refresh failure. With
+    ///    `-q`, an exit-1 failure surfaces to the caller as `"Grype scan
+    ///    failed (exit status: 1): "` with an empty stderr slot — which is
+    ///    exactly what release-gate #1001-followup reported. Letting Grype
+    ///    log to stderr keeps the JSON report on stdout (Grype separates
+    ///    structured output from logging) while preserving a useful error
+    ///    payload on the failure path.
+    ///
+    /// 2. We pin the DB-update-related env vars defensively. Grype defaults
+    ///    `db.auto-update=true` and `db.validate-age=true`. With those
+    ///    defaults, after the pre-seeded DB ages past `db.max-allowed-built-
+    ///    age` (5 days), Grype tries to fetch a fresh copy from
+    ///    grype.anchore.io, which fails in network-restricted environments
+    ///    (ARC runner pods, release-gate jobs) and exits 1. The Dockerfile
+    ///    also sets these vars, but injecting them here means the scanner
+    ///    keeps working under deployment configs that wipe inherited env
+    ///    (Helm charts, k8s `env:` blocks that replace rather than append).
+    ///    See artifact-keeper#1001 and PR #1002 (commit 23d9743).
     async fn run_grype_target(&self, target: &str) -> Result<GrypeReport> {
         let output = tokio::process::Command::new("grype")
-            .args([target, "-o", "json", "-q"])
+            .args([target, "-o", "json"])
+            .env("GRYPE_DB_AUTO_UPDATE", "false")
+            .env("GRYPE_DB_VALIDATE_AGE", "false")
+            .env("GRYPE_CHECK_FOR_APP_UPDATE", "false")
             .output()
             .await
             .map_err(|e| AppError::Internal(format!("Failed to execute Grype: {}", e)))?;
@@ -179,9 +226,17 @@ impl GrypeScanner {
             if stderr.contains("not found") || stderr.contains("No such file") {
                 return Err(AppError::Internal("Grype binary not available".to_string()));
             }
+            // Include a stdout tail too: Grype writes its progress/ETUI to
+            // stderr, but a hard failure during JSON encoding can leave a
+            // partial payload on stdout that is the only clue to the cause.
+            // Cap each stream at 4 KiB so a runaway log does not produce a
+            // megabyte-class AppError message.
+            let stderr_tail = truncate_stream(&stderr, 4096);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stdout_tail = truncate_stream(&stdout, 4096);
             return Err(AppError::Internal(format!(
-                "Grype scan failed ({}): {}",
-                output.status, stderr
+                "Grype scan failed ({}): stderr={:?} stdout={:?}",
+                output.status, stderr_tail, stdout_tail
             )));
         }
 
@@ -783,5 +838,119 @@ mod tests {
         );
 
         std::env::remove_var("PEER_PUBLIC_ENDPOINT");
+    }
+
+    // -----------------------------------------------------------------------
+    // truncate_stream: stderr/stdout payload framing in subprocess error
+    // messages. Regression guard for the diagnostic-improvement half of the
+    // #1001-followup fix (PR linked to #1002 / commit 23d9743). Without
+    // these, an `AppError::Internal` carrying multi-megabyte grype log
+    // output could blow up downstream consumers that interpolate the error
+    // into a JSON field (audit log, scan_results.error_message column).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_truncate_stream_returns_input_when_under_limit() {
+        let s = "short message";
+        assert_eq!(truncate_stream(s, 4096), "short message");
+    }
+
+    #[test]
+    fn test_truncate_stream_preserves_tail_when_over_limit() {
+        // 100 'a's followed by a distinctive ending. With max=10, only the
+        // tail should be kept (the failure reason is the last thing logged).
+        let s = format!("{}END", "a".repeat(100));
+        let out = truncate_stream(&s, 10);
+        assert!(
+            out.ends_with("END"),
+            "tail must be preserved so the actual failure line survives; got {:?}",
+            out
+        );
+        assert!(
+            out.starts_with("…[truncated]"),
+            "truncation marker must be present: {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_truncate_stream_handles_multibyte_split() {
+        // A multibyte UTF-8 char (Greek capital alpha, 2 bytes) repeated
+        // enough to force a truncation point in the middle of one. The
+        // function must not panic and must produce valid UTF-8.
+        let s: String = "\u{0391}".repeat(20); // 40 bytes
+        let out = truncate_stream(&s, 15);
+        // Result must be valid UTF-8 (String type guarantees this) and the
+        // boundary walk must have advanced past any partial multibyte.
+        assert!(
+            out.is_char_boundary(0) && out.is_char_boundary(out.len()),
+            "truncate_stream must not split inside a UTF-8 multibyte sequence"
+        );
+        assert!(out.contains("[truncated]"));
+    }
+
+    /// The fix removes `-q` from the grype invocation so DB-fetch / DB-load
+    /// failures surface in stderr. Verifying the *exact* arg vector is the
+    /// most direct regression guard against a future refactor that
+    /// reintroduces `-q` and silences the next #1001-class failure.
+    ///
+    /// This test reads the source file rather than instrumenting the
+    /// subprocess invocation because `run_grype_target` is private to the
+    /// module and the only externally visible behavior here is the args we
+    /// pass. Reading the source is acceptable for a single-line invariant.
+    #[test]
+    fn test_grype_invocation_does_not_pass_quiet_flag() {
+        let src = include_str!("grype_scanner.rs");
+        // Find the args() line for the grype subprocess. There is exactly
+        // one in this module (run_grype_target).
+        let args_line = src
+            .lines()
+            .find(|l| l.contains(".args([target, \"-o\", \"json\""))
+            .expect(
+                "run_grype_target must invoke grype with .args([target, \"-o\", \"json\", ...]); \
+                 the arg-vector shape changed and this test needs updating",
+            );
+        assert!(
+            !args_line.contains("\"-q\"") && !args_line.contains("\"--quiet\""),
+            "Grype must be invoked WITHOUT -q / --quiet so DB-load and \
+             DB-refresh failures appear in stderr. See artifact-keeper#1001 \
+             and the followup that traced 'Grype scan failed (exit status: \
+             1): ' with an empty stderr slot back to this flag. Offending \
+             line: {}",
+            args_line
+        );
+    }
+
+    /// Regression guard for the env-var defaults applied to the grype
+    /// subprocess. The Dockerfile sets these too, but a Helm chart or k8s
+    /// deployment that *replaces* the container env (rather than appending)
+    /// would lose the Dockerfile values. Pinning them at the `Command`
+    /// level keeps the scanner working under either deployment shape.
+    #[test]
+    fn test_grype_invocation_pins_db_auto_update_env_vars() {
+        let src = include_str!("grype_scanner.rs");
+
+        for (var, why) in [
+            (
+                "GRYPE_DB_AUTO_UPDATE",
+                "would let Grype refetch the DB and fail in egress-restricted envs (#1001)",
+            ),
+            (
+                "GRYPE_DB_VALIDATE_AGE",
+                "would let Grype reject the seeded DB once it ages past 5 days (#1001 followup)",
+            ),
+            (
+                "GRYPE_CHECK_FOR_APP_UPDATE",
+                "would let Grype phone home for self-updates and add a network dependency",
+            ),
+        ] {
+            assert!(
+                src.contains(&format!(".env(\"{}\", \"false\")", var)),
+                "run_grype_target must pin {}=\"false\" at the subprocess level; \
+                 removing it {}",
+                var,
+                why
+            );
+        }
     }
 }

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -180,11 +180,24 @@ COPY --from=builder /app/target/release/artifact-keeper /usr/local/bin/
 WORKDIR /app
 USER 1001
 
+# Grype defaults `db.auto-update=true` and `db.validate-age=true`. With those
+# defaults, Grype at scan time checks the pre-seeded DB's build timestamp; if
+# it is older than `db.max-allowed-built-age` (5 days), Grype refuses to use
+# it and tries to download a fresh copy from grype.anchore.io. In the
+# network-restricted environments PR #1002 (#1001) was meant to fix (ARC
+# runner pods, release-gate jobs), that fetch fails and Grype exits 1 with
+# no stderr (because the scanner invocation passes `-q`). We disable both
+# knobs so the seeded DB is honored for the full image lifetime; the DB is
+# refreshed by rebuilding the image, not at runtime. See artifact-keeper#1001
+# and PR #1002 (commit 23d9743) which added the seed stage.
 ENV RUST_LOG=info \
     DATABASE_URL=set-database-url-at-runtime \
     STORAGE_PATH=/data/storage \
     BACKUP_PATH=/data/backups \
     GRYPE_DB_CACHE_DIR=/home/artifact/.cache/grype \
+    GRYPE_DB_AUTO_UPDATE=false \
+    GRYPE_DB_VALIDATE_AGE=false \
+    GRYPE_CHECK_FOR_APP_UPDATE=false \
     HOST=0.0.0.0 \
     PORT=8080
 

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -112,11 +112,22 @@ COPY --from=builder /app/target/release/artifact-keeper /usr/local/bin/
 WORKDIR /app
 USER 1001
 
+# Grype defaults `db.auto-update=true` and `db.validate-age=true`. With those
+# defaults, Grype at scan time refuses to use the pre-seeded DB if its build
+# timestamp is older than `db.max-allowed-built-age` (5 days) and tries to
+# refetch from grype.anchore.io. That fetch fails in network-restricted
+# environments and Grype exits 1 with no stderr (because the scanner passes
+# `-q`). Disable both knobs so the seeded DB is honored for the full image
+# lifetime; refresh the DB by rebuilding the image. See artifact-keeper#1001
+# and PR #1002 (commit 23d9743) which added the seed stage.
 ENV RUST_LOG=info \
     DATABASE_URL=set-database-url-at-runtime \
     STORAGE_PATH=/data/storage \
     BACKUP_PATH=/data/backups \
     GRYPE_DB_CACHE_DIR=/home/artifact/.cache/grype \
+    GRYPE_DB_AUTO_UPDATE=false \
+    GRYPE_DB_VALIDATE_AGE=false \
+    GRYPE_CHECK_FOR_APP_UPDATE=false \
     HOST=0.0.0.0 \
     PORT=8080
 


### PR DESCRIPTION
Closes #1251
Refs #1001 #1002

## Summary

PR #1002 added the pre-seeded Grype DB stage but didn't disable Grype's runtime auto-update + age-validation defaults. After 5 days the seeded DB ages out, Grype tries to refetch from `grype.anchore.io`, fails in egress-restricted runners, and exits 1. The `-q` flag silenced all log output so the diagnostic was empty.

Fix:
- Pin `GRYPE_DB_AUTO_UPDATE=false`, `GRYPE_DB_VALIDATE_AGE=false`, `GRYPE_CHECK_FOR_APP_UPDATE=false` at `docker/Dockerfile.backend` + `Dockerfile.backend.alpine` (ENV block) AND in `grype_scanner.rs`'s `Command` builder via `.env(...)`. Subprocess-level pin survives a Helm chart that overrides container env.
- Drop `-q` from the grype invocation.
- Rework the error payload to include truncated stderr + stdout tails so a future scanner failure isn't invisible.

This addresses the 3 release-gate failures (`scan-completion-gate (npm)`, `pullthrough-tests`, `real-flow-smoke`) that all share this root cause.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

5 static-analysis unit tests added (no DB or grype binary needed):
- `test_truncate_stream_*` × 3 — the new diagnostic-truncation helper
- `test_grype_invocation_does_not_pass_quiet_flag` — pins -q removal
- `test_grype_invocation_pins_db_auto_update_env_vars` — pins the three env vars at subprocess level

## Manual verification

```bash
docker build -f docker/Dockerfile.backend -t ak-backend:grype-fix .
docker run --rm --network=none ak-backend:grype-fix grype db status   # Valid: true, exit 0
docker run --rm --network=none ak-backend:grype-fix \    sh -c 'mkdir /tmp/t && echo "{}" > /tmp/t/package.json && grype dir:/tmp/t -o json | head -c 80'
# {"matches":...
```

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (covered by release-gate `scan-completion-gate` on next dispatch)
- [x] Manually tested locally — `SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --lib` clean
- [x] No regressions in existing tests

## API Changes
- [x] N/A - subprocess invocation + Dockerfile ENV changes only